### PR TITLE
Fix `Fix Preserve Focus` option not working on Linux servers

### DIFF
--- a/doc/newsfragments/linux-server-preserve-focus.bugfix
+++ b/doc/newsfragments/linux-server-preserve-focus.bugfix
@@ -1,0 +1,1 @@
+Fixed "Fix preserve Focus" option on Linux servers (https://github.com/input-leap/input-leap/issues/1066).

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -316,7 +316,7 @@ XWindowsScreen::leave()
     m_impl->XGetInputFocus(m_display, &m_lastFocus, &m_lastFocusRevert);
 
 	// take focus
-	if (m_isPrimary || !m_preserveFocus) {
+	if (!m_preserveFocus) {
         m_impl->XSetInputFocus(m_display, m_window, RevertToPointerRoot, CurrentTime);
 	}
 


### PR DESCRIPTION
> This PR has been migrated from old Barrier Github repository https://github.com/debauchee/barrier/pull/1067
> 
> PR created on: 2021-02-16 by @cryzed
> PR last updated on: 2021-02-16

Fixes #1066.

I'm not sure why this check was here in the first place, but the preserve focus setting should take effect whether the code runs on the server (primary) or the client. This change and a subsequent local build shows that the issue is fixed for me.
