### PR TITLE
Windows build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.h
 /bin
 /lib
 /build
+/out
 /CMakeFiles
 /ext/cryptopp562
 /ext/openssl
@@ -24,6 +25,8 @@ Makefile
 *.cmake
 **/CMakeFiles/
 CMakeCache.txt
+CMakePresets.json
+CMakeUserPresets.json
 /rpm
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.h
+++ b/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.h
@@ -19,9 +19,7 @@
 #pragma once
 
 #include "barrier/ClientTaskBarReceiver.h"
-
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include "common/win32/winapi.h"
 
 class BufferedLogOutputter;
 class IEventQueue;

--- a/src/cmd/barrierd/barrierd.cpp
+++ b/src/cmd/barrierd/barrierd.cpp
@@ -31,8 +31,7 @@ main(int argc, char** argv)
 
 #elif SYSAPI_WIN32
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include "common/win32/winapi.h"
 
 int WINAPI
 WinMain(HINSTANCE, HINSTANCE, LPSTR, int)

--- a/src/cmd/barriers/MSWindowsServerTaskBarReceiver.h
+++ b/src/cmd/barriers/MSWindowsServerTaskBarReceiver.h
@@ -19,9 +19,7 @@
 #pragma once
 
 #include "barrier/ServerTaskBarReceiver.h"
-
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include "common/win32/winapi.h"
 
 class BufferedLogOutputter;
 class IEventQueue;

--- a/src/lib/common/win32/encoding_utilities.cpp
+++ b/src/lib/common/win32/encoding_utilities.cpp
@@ -17,6 +17,7 @@
 
 #include "encoding_utilities.h"
 #include <stringapiset.h>
+#include <limits>
 
 std::string win_wchar_to_utf8(const WCHAR* utfStr)
 {
@@ -29,9 +30,12 @@ std::string win_wchar_to_utf8(const WCHAR* utfStr)
 
 std::vector<WCHAR> utf8_to_win_char(const std::string& str)
 {
-    int result_len = MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), NULL, 0);
+    if (str.size() > std::numeric_limits<int>::max())
+        return {};
+    int input_len = static_cast<int>(str.size());
+    int result_len = MultiByteToWideChar(CP_UTF8, 0, str.data(), input_len, NULL, 0);
     std::vector<WCHAR> result;
     result.resize(result_len + 1, 0);
-    MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), result.data(), result_len);
+    MultiByteToWideChar(CP_UTF8, 0, str.data(), input_len, result.data(), result_len);
     return result;
 }

--- a/src/lib/common/win32/winapi.h
+++ b/src/lib/common/win32/winapi.h
@@ -15,14 +15,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef BARRIER_LIB_COMMON_WIN32_ENCODING_UTILITIES_H
-#define BARRIER_LIB_COMMON_WIN32_ENCODING_UTILITIES_H
+#ifndef BARRIER_LIB_COMMON_WIN32_WINAPI_H
+#define BARRIER_LIB_COMMON_WIN32_WINAPI_H
 
-#include "winapi.h"
-#include <string>
-#include <vector>
-
-std::string win_wchar_to_utf8(const WCHAR* utfStr);
-std::vector<WCHAR> utf8_to_win_char(const std::string& str);
-
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #endif
+
+#ifndef STRICT
+#define STRICT
+#endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <Windows.h>
+
+#endif // BARRIER_LIB_COMMON_WIN32_WINAPI_H

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -245,7 +245,9 @@ std::string create_fingerprint_randomart(const std::vector<std::uint8_t>& dgst_r
     std::size_t i;
     std::uint32_t b;
     int	 x, y;
-    std::size_t len = strlen(augmentation_string) - 1;
+
+    // avoid compiler warning when comparing len to items in field array
+    std::uint8_t len = static_cast<uint8_t>(strlen(augmentation_string) - 1);
 
     std::vector<char> retval;
     retval.reserve((FLDSIZE_X + 3) * (FLDSIZE_Y + 2));

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -241,7 +241,6 @@ std::string create_fingerprint_randomart(const std::vector<std::uint8_t>& dgst_r
      * intersects with itself.  Matter of taste.
      */
     const char* augmentation_string = " .o+=*BOX@%&#/^SE";
-    char *p;
     std::uint8_t field[FLDSIZE_X][FLDSIZE_Y];
     std::size_t i;
     std::uint32_t b;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -52,6 +52,7 @@
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4706) // assignment within conditional
+#pragma warning(disable: 4996) // GetVersionExA was declared deprecated
 #define COMPILE_MULTIMON_STUBS
 #include <multimon.h>
 #pragma warning(pop)

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -2070,7 +2070,7 @@ ConfigReadContext::parseInterval(const ArgList& args) const
 		throw XConfigRead(*this, "invalid interval \"%{1}\"", concatArgs(args));
 	}
 
-	return Config::Interval(startValue / 100.0f, endValue / 100.0f);
+	return Config::Interval(static_cast<float>(startValue / 100.0), static_cast<float>(endValue / 100.0));
 }
 
 void ConfigReadContext::parseNameWithArgs(const std::string& type, const std::string& line,


### PR DESCRIPTION
Fixed all compiler warnings when building only the command line programs with Windows with Visual Studio 2022 (VC 14.30):
```
"BARRIER_BUILD_GUI": false,
"BARRIER_BUILD_INSTALLER": false
```

I'm quite sure the added numeric type casts are safe with regards to overflow.

The most controversial change is probably the added header `src/lib/common/win32/winapi.h` for just including `Windows.h` - but with preprocessor directives: `WIN32_LEAN_AND_MEAN`, `STRICT` and `NOMINMAX`. Don't know if you think this is a good idea? (And if you have a better name for it...) Main reason is I needed the `NOMINMAX` to avoid conflict with legacy max macro when using `numeric_limits<int>::max()`. There was (and still is outside of the command line "world" I am compiling atm) quite a few instances of the following:

```
#define WIN32_LEAN_AND_MEAN
#include <Windows.h>
```

An alternative could be to define them at CMake level with `add_compile_definitions`, but would then have to be done for every target..

PS: Congrats on your new project. Looking forward to follow its development!

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
