### PR TITLE
azure-pipelines: Disable macOS mojave build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,10 +91,6 @@ jobs:
           imageName: "macOS-10.15"
           B_BUILD_TYPE: Release
           BARRIER_VERSION_STAGE: Release
-      mojave-Release:
-          imageName: "macOS-10.14"
-          B_BUILD_TYPE: Release
-          BARRIER_VERSION_STAGE: Release
   pool:
     vmImage: $(imageName)
   variables:


### PR DESCRIPTION
Azure will drop support for Mojave builds soon and builds are failing due to agent provisioning issues already.