### PR TITLE
Fixed missing free of SSL certificate

### DIFF
--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -66,7 +66,6 @@ private:
     void createSSL(); // may only be called with ssl_mutex_ acquired.
     int                    secureAccept(int s);
     int                    secureConnect(int s);
-    bool ensure_peer_certificate(); // may only be called with ssl_mutex_ acquired
 
     void checkResult(int n, int& retry); // may only be called with m_ssl_mutex_ acquired.
 
@@ -75,7 +74,7 @@ private:
     void                disconnect();
 
     // may only be called with ssl_mutex_ acquired
-    bool verify_cert_fingerprint(const barrier::fs::path& fingerprint_db_path);
+    bool verify_peer_certificate(const barrier::fs::path& fingerprint_db_path);
 
     MultiplexerJobStatus serviceConnect(ISocketMultiplexerJob*, bool, bool, bool);
     MultiplexerJobStatus serviceAccept(ISocketMultiplexerJob*, bool, bool, bool);


### PR DESCRIPTION
Fixed missing free of SSL certificate and combining two similar certifcation check functions into one.

I noticed the existing function `verify_cert_fingerprint` called `SSL_get_peer_certificate` without a following `X509_free`. That surely must lead to a resource leak? Also the existing code called helper function `verify_cert_fingerprint` before `ensure_peer_certificate`, but if the peer has no cert (cert is NULL) then `verify_cert_fingerprint` would return false and the `ensure_peer_certificate` not be called. So the only remaining use of `ensure_peer_certificate` was only when there actually was a certificate, to write a log line with the certificate's subject. Therefore I combined these two into one common function, then only one call to `SSL_get_peer_certificate`, followed by a call to `X509_free`, is needed to do both things.

## Contributor Checklist:

* [X] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
