### PR TITLE
clean_build: Use cmake --build . --parallel

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -36,5 +36,5 @@ mkdir build || exit 1
 cd build || exit 1
 echo "Starting Barrier $B_BUILD_TYPE build..."
 "$B_CMAKE" "$B_CMAKE_FLAGS" .. || exit 1
-make || exit 1
+"$B_CMAKE" --build . --parallel || exit 1
 echo "Build completed successfully"


### PR DESCRIPTION
This ensures that the all CPU cores are used without introducing any non-portable scripting.