### PR TITLE
Use ninja in clean_build.sh, if available

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -25,6 +25,12 @@ if [ "$(uname)" = "Darwin" ]; then
     . ./macos_environment.sh
     B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
 fi
+
+# Prefer ninja if available
+if command -v ninja 2>/dev/null; then
+    B_CMAKE_FLAGS="-GNinja ${B_CMAKE_FLAGS}"
+fi
+
 # allow local customizations to build environment
 [ -r ./build_env.sh ] && . ./build_env.sh
 

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -35,6 +35,6 @@ rm -rf build
 mkdir build || exit 1
 cd build || exit 1
 echo "Starting Barrier $B_BUILD_TYPE build..."
-"$B_CMAKE" "$B_CMAKE_FLAGS" .. || exit 1
+"$B_CMAKE" $B_CMAKE_FLAGS .. || exit 1
 "$B_CMAKE" --build . --parallel || exit 1
 echo "Build completed successfully"


### PR DESCRIPTION
Unlike make, ninja has sane dependency resolution and this speeds up builds, especially when ccache is used and there are cache matches.