### PR TITLE
Only allows active client grabbing clipboard

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1229,6 +1229,10 @@ Server::handleClipboardGrabbed(const Event& event, void* vclient)
 	if (m_clientSet.count(grabber) == 0) {
 		return;
 	}
+  // ignore grab event from non-active client, which happens if their clipboard is updated in background
+	if (grabber != m_active) {
+		return;
+	}
 	const IScreen::ClipboardInfo* info =
 		static_cast<const IScreen::ClipboardInfo*>(event.getData());
 


### PR DESCRIPTION
Addresses #1433

This PR disallows non-active client grabbing the clipboard ownership, which could erase the clipboard content of the current active client (i.e. the focused screen). 
This occurs when a background process in an non-active client updates system clipboard content (hence, triggering the grab event).


## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory)