### PR TITLE
Remove GH Pages config, we don't use it

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate


### PR DESCRIPTION
Seeing as we don't use this file in the project, this commit removes it
to tidy up a bit.

I think we should definitely have a website, but maybe use a separate
repo, with a hook to build with a SSG (GH Actions?), and then publish
the generated files.

At this point of transition though, we should focus on a new release,
and updating all Barrier references to the new project name.

I am not including a newsfragment here, as a website has not been
generated from this file.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
