### PR TITLE
Update LICENSE file, add Input Leap org to authors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2021-2022 The Input Leap Developers
 Copyright (C) 2018 Debauchee Open Source Group
 Copyright (C) 2012-2016 Symless Ltd.
 Copyright (C) 2008-2014 Nick Bolton

--- a/doc/newsfragments/license-update.doc
+++ b/doc/newsfragments/license-update.doc
@@ -1,0 +1,1 @@
+Update LICENSE file in repository to reflect fork from Barrier organisation.


### PR DESCRIPTION
This PR updates the `/LICENSE` file in the repository, and this should be discussed openly before merging.

I also am wondering if we should do a separate PR for the license header changes in the GUI, or incorporate it into this one...

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
