### PR TITLE
Quote `$B_CMAKE_FLAGS` variable in build sh script

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -41,6 +41,6 @@ rm -rf build
 mkdir build || exit 1
 cd build || exit 1
 echo "Starting Barrier $B_BUILD_TYPE build..."
-"$B_CMAKE" $B_CMAKE_FLAGS .. || exit 1
+"$B_CMAKE" "$B_CMAKE_FLAGS" .. || exit 1
 "$B_CMAKE" --build . --parallel || exit 1
 echo "Build completed successfully"


### PR DESCRIPTION
This quotes the variable `$B_CMAKE_FLAGS` used in the build
initialisation command (CMake). Because we source arbitrary environment
variables earlier on in the script, they could contain whitespace, or
other problematic characters, which might cause some build wonkiness.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
