### PR TITLE
lib/base: Fix setting original status flags in NonBlockingStream class

### DIFF
--- a/src/lib/base/NonBlockingStream.cpp
+++ b/src/lib/base/NonBlockingStream.cpp
@@ -37,7 +37,7 @@ NonBlockingStream::NonBlockingStream(int fd) :
     tcsetattr(fd, TCSANOW, &ta);
 
     // prevent IO from blocking so we can poll (read())
-    int _cntl_previous = fcntl(fd, F_GETFL);
+    _cntl_previous = fcntl(fd, F_GETFL);
     fcntl(fd, F_SETFL, _cntl_previous | O_NONBLOCK);
 }
 


### PR DESCRIPTION
The changed line was supposed to be an assignment to _cntl_previous private member of the class NonBlockingStream. Without this fix, _cntl_previous member never gets any value to be later used in class NonBlockingStream desructor.

* [not needed] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
