### PR TITLE
Revert "Quote `$B_CMAKE_FLAGS` variable in build sh script"

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -42,5 +42,7 @@ mkdir build || exit 1
 cd build || exit 1
 echo "Starting Input Leap $B_BUILD_TYPE build..."
 "$B_CMAKE" "$B_CMAKE_FLAGS" .. || exit 1
+echo "Starting Barrier $B_BUILD_TYPE build..."
+"$B_CMAKE" $B_CMAKE_FLAGS .. || exit 1
 "$B_CMAKE" --build . --parallel || exit 1
 echo "Build completed successfully"


### PR DESCRIPTION
B_CMAKE_FLAGS may contain multiple options which we want to pass to CMake as separate flags.

Fixes #1450.

This reverts commit f5b4f2ba588dba0ca03467c1fc7f75f133527ecf.

## Contributor Checklist:

No newsfragment needed.