### PR TITLE
Revert "Quote `$B_CMAKE_FLAGS` variable in build sh script"

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -41,8 +41,6 @@ rm -rf build
 mkdir build || exit 1
 cd build || exit 1
 echo "Starting Input Leap $B_BUILD_TYPE build..."
-"$B_CMAKE" "$B_CMAKE_FLAGS" .. || exit 1
-echo "Starting Barrier $B_BUILD_TYPE build..."
 "$B_CMAKE" $B_CMAKE_FLAGS .. || exit 1
 "$B_CMAKE" --build . --parallel || exit 1
 echo "Build completed successfully"


### PR DESCRIPTION
This fixes 4fbe60e7ed2f2fa60e1b2415472e6ce7521c94e3 which had incorrect merge conflict resolution.

I should look into `git diff` output more carefully.

No newsfragment needed.