### PR TITLE
github: Switch to containers for CI on Ubuntu

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -24,21 +24,28 @@ jobs:
   # This workflow contains a single job called "build"
   linux-build:
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: ["ubuntu:18.04", "ubuntu:20.04"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
 
-      # Runs a set of commands using the runners shell
       - name: Update image and install pre-reqs
         run: |
-          sudo apt-get update -y
-          sudo apt-get dist-upgrade -y
-          sudo apt-get install -y libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev cmake ninja-build
+          apt-get update -y
+          # needed for add-apt-repository
+          apt-get install -y software-properties-common
+          # actions/checkout@v3 wants newer git than what's in default repositories
+          add-apt-repository ppa:git-core/ppa
+          apt-get update -y
+          apt-get dist-upgrade -y
+          apt-get install -y git g++ libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev libssl-dev cmake ninja-build
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Run the build
         run: ./clean_build.sh

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -17,6 +17,13 @@ else
     fi
 fi
 
+CMAKE_VERSION="$("$B_CMAKE" --version)"
+if [ "$(printf '%s\n' "3.12.0" "$currentver" | sort -V | head -n1)" = "3.12.0" ]; then
+    CMAKE_HAS_PARALLEL=1
+else
+    CMAKE_HAS_PARALLEL=0
+fi
+
 B_BUILD_TYPE="${B_BUILD_TYPE:-Debug}"
 B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"
 
@@ -42,5 +49,15 @@ mkdir build || exit 1
 cd build || exit 1
 echo "Starting Input Leap $B_BUILD_TYPE build..."
 "$B_CMAKE" $B_CMAKE_FLAGS .. || exit 1
-"$B_CMAKE" --build . --parallel || exit 1
+
+if [ "$CMAKE_HAS_PARALLEL" -eq "1" ]; then
+    "$B_CMAKE" --build . --parallel || exit 1
+else
+    if command -v ninja 2>/dev/null; then
+        ninja || exit 1
+    else
+        make || exit 1
+    fi
+fi
+
 echo "Build completed successfully"


### PR DESCRIPTION
The OS images provided by Github contain additional package repositories by default. Unfortunately sometimes contacting these repositories fails, so we switch to vanilla Ubuntu containers.

## Contributor Checklist:

* [not needed] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
