### PR TITLE
A little bit of CMake cleanup

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -41,7 +41,7 @@ jobs:
           add-apt-repository ppa:git-core/ppa
           apt-get update -y
           apt-get dist-upgrade -y
-          apt-get install -y git g++ libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev libssl-dev cmake ninja-build
+          apt-get install -y git g++ libxtst-dev libxinerama-dev libxrandr-dev libice-dev libsm-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev libssl-dev cmake ninja-build
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Run the build
         run: ./clean_build.sh
+        env:
+            VERBOSE: 1
 
   mac-build:
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ if (UNIX)
         )
 
     else() # not-apple
+        if (NOT ${PKG_CONFIG_FOUND})
+            message (FATAL_ERROR "pkg-config not found, required for dependencies")
+        endif ()
+
         # FreeBSD uses /usr/local for anything not part of base
         # Also package avahi-libdns puts dns_sd.h a bit deeper
         if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
@@ -179,83 +183,26 @@ if (UNIX)
             set (CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES};${AVAHI_COMPAT_INCLUDE_DIRS}")
         endif ()
 
-        set (XKBlib "X11/Xlib.h;X11/XKBlib.h")
-        set (CMAKE_EXTRA_INCLUDE_FILES "${XKBlib};X11/extensions/Xrandr.h")
-        check_type_size ("XRRNotifyEvent" X11_EXTENSIONS_XRANDR_H)
-        set (HAVE_X11_EXTENSIONS_XRANDR_H "${X11_EXTENSIONS_XRANDR_H}")
-        set (CMAKE_EXTRA_INCLUDE_FILES)
+        pkg_check_modules (XLIB REQUIRED x11 xext xrandr xinerama xtst xi)
+        pkg_check_modules (ICE REQUIRED ice sm)
+        include_directories (${XLIB_INCLUDE_DIRS} ${ICE_INCLUDE_DIRS})
 
-        check_include_files ("${XKBlib};X11/extensions/dpms.h" HAVE_X11_EXTENSIONS_DPMS_H)
-        check_include_files ("X11/extensions/Xinerama.h" HAVE_X11_EXTENSIONS_XINERAMA_H)
-        check_include_files ("${XKBlib};X11/extensions/XKBstr.h" HAVE_X11_EXTENSIONS_XKBSTR_H)
-        check_include_files ("X11/extensions/XKB.h" HAVE_XKB_EXTENSION)
-        check_include_files ("X11/extensions/XTest.h" HAVE_X11_EXTENSIONS_XTEST_H)
-        check_include_files ("${XKBlib}" HAVE_X11_XKBLIB_H)
-        check_include_files ("X11/extensions/XInput2.h" HAVE_XI2)
+        # Old cmake doesn't populate LINK_LIBRARIES.
+        # Use the "normal" libraries but this won't pick up non-standard
+        # library directories paths.
+        # Fixed in cmake 3.12, released July 2018 (commit 92ac721a44)
+        if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+            list (APPEND libs ${XLIB_LIBRARIES} ${ICE_LIBRARIES})
+        else()
+            list (APPEND libs ${XLIB_LINK_LIBRARIES} ${ICE_LINK_LIBRARIES})
+        endif()
+
+        set (HAVE_X11 1)
+
         check_include_files ("dns_sd.h" HAVE_DNSSD)
-
-        if (NOT HAVE_X11_EXTENSIONS_XTEST_H)
-            message (FATAL_ERROR "Missing header: X11/extensions/XTest.h")
-        endif()
-
-        if (NOT HAVE_X11_XKBLIB_H)
-            message (FATAL_ERROR "Missing header: " ${XKBlib})
-        endif()
-
         if(INPUTLEAP_BUILD_GUI AND NOT HAVE_DNSSD)
             message (FATAL_ERROR "Missing header: dns_sd.h")
         endif()
-
-        check_library_exists ("SM;ICE" IceConnectionNumber "" HAVE_ICE)
-        check_library_exists ("Xext;X11" DPMSQueryExtension "" HAVE_Xext)
-        check_library_exists ("Xtst;Xext;X11" XTestQueryExtension "" HAVE_Xtst)
-        check_library_exists ("Xinerama" XineramaQueryExtension "" HAVE_Xinerama)
-        check_library_exists ("Xi" XISelectEvents "" HAVE_Xi)
-        check_library_exists ("Xrandr" XRRQueryExtension "" HAVE_Xrandr)
-
-        if (HAVE_ICE)
-
-            # Assume we have SM if we have ICE.
-            set (HAVE_SM 1)
-            list (APPEND libs SM ICE)
-
-        endif()
-
-        if (HAVE_Xtst)
-
-            # Xtxt depends on X11.
-            set (HAVE_X11 1)
-            list (APPEND libs Xtst X11)
-
-        else()
-
-            message (FATAL_ERROR "Missing library: Xtst")
-
-        endif()
-
-        if (HAVE_Xext)
-            list (APPEND libs Xext)
-        endif()
-
-        if (HAVE_Xinerama)
-            list (APPEND libs Xinerama)
-        else (HAVE_Xinerama)
-            if (HAVE_X11_EXTENSIONS_XINERAMA_H)
-                set (HAVE_X11_EXTENSIONS_XINERAMA_H 0)
-                message (WARNING "Old Xinerama implementation detected, disabled")
-            endif()
-        endif()
-
-        if (HAVE_Xrandr)
-            list (APPEND libs Xrandr)
-        endif()
-
-        # this was outside of the linux scope,
-        # not sure why, moving it back inside.
-        if (HAVE_Xi)
-            list (APPEND libs Xi)
-        endif()
-
     endif()
 
     # For config.h, set some static values; it may be a good idea to make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ if (UNIX)
     set (TIME_WITH_SYS_TIME 1)
     set (HAVE_SOCKLEN_T 1)
 
-    add_definitions (-DSYSAPI_UNIX=1 -DHAVE_CONFIG_H)
+    add_definitions (-DSYSAPI_UNIX=1)
 
     if (APPLE)
         add_definitions (-DWINAPI_CARBON=1 -D_THREAD_SAFE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
     vmImage: $(imageName)
   steps:
     - script: sudo apt-get update -y
-    - script: sudo apt-get install -y libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev
+    - script: sudo apt-get install -y libxtst-dev libxinerama-dev libxrandr-dev libice-dev libsm-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev
       displayName: Install Dependencies
     - script: sh -x ./clean_build.sh
       displayName: Clean Build

--- a/dist/rpm/barrier.spec.in
+++ b/dist/rpm/barrier.spec.in
@@ -21,7 +21,8 @@ BuildRequires: gmock-devel
 BuildRequires: gtest-devel
 BuildRequires: gulrak-filesystem-devel
 BuildRequires: libX11-devel
-BuildRequires: libXtst-devel
+BuildRequires: libXtst-devel libXinerama-devel libXrandr-devel
+BuildRequires: libICE-devel libSM-devel
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 BuildRequires: qt5-qtbase-devel

--- a/res/config.h.in
+++ b/res/config.h.in
@@ -97,27 +97,6 @@
 /* Define to 1 if you have the <wchar.h> header file. */
 #cmakedefine HAVE_WCHAR_H ${HAVE_WCHAR_H}
 
-/* Define to 1 if you have the <X11/extensions/Xrandr.h> header file. */
-#cmakedefine HAVE_X11_EXTENSIONS_XRANDR_H ${HAVE_X11_EXTENSIONS_XRANDR_H}
-
-/* Define to 1 if you have the <X11/extensions/dpms.h> header file. */
-#cmakedefine HAVE_X11_EXTENSIONS_DPMS_H ${HAVE_X11_EXTENSIONS_DPMS_H}
-
-/* Define to 1 if you have the <X11/extensions/Xinerama.h> header file. */
-#cmakedefine HAVE_X11_EXTENSIONS_XINERAMA_H ${HAVE_X11_EXTENSIONS_XINERAMA_H}
-
-/* Define to 1 if you have the <X11/extensions/XKBstr.h> header file. */
-#cmakedefine HAVE_X11_EXTENSIONS_XKBSTR_H ${HAVE_X11_EXTENSIONS_XKBSTR_H}
-
-/* Define to 1 if you have the <X11/XKBlib.h> header file. */
-#cmakedefine HAVE_X11_XKBLIB_H ${HAVE_X11_XKBLIB_H}
-
-/* Define to 1 if you have the <X11/extensions/XInput2.h> header file. */
-#cmakedefine HAVE_XI2 ${HAVE_XI2}
-
-/* Define this if the XKB extension is available. */
-#cmakedefine HAVE_XKB_EXTENSION ${HAVE_XKB_EXTENSION}
-
 /* Define to necessary symbol if this constant uses a non-standard name on your system. */
 #cmakedefine PTHREAD_CREATE_JOINABLE ${PTHREAD_CREATE_JOINABLE}
 

--- a/src/lib/platform/IXWindowsImpl.h
+++ b/src/lib/platform/IXWindowsImpl.h
@@ -8,27 +8,17 @@
 #define XK_MISCELLANY
 #define XK_XKB_KEYS
 #include <X11/keysymdef.h>
-#if HAVE_X11_EXTENSIONS_DPMS_H
      extern "C" {
 #	include <X11/extensions/dpms.h>
      }
-#endif
 #include <X11/extensions/XTest.h>
-#if HAVE_X11_EXTENSIONS_XINERAMA_H
      // Xinerama.h may lack extern "C" for inclusion by C++
      extern "C" {
-#	include <X11/extensions/Xinerama.h>
+#include <X11/extensions/Xinerama.h>
      }
-#endif
-#if HAVE_X11_EXTENSIONS_XRANDR_H
-#	include <X11/extensions/Xrandr.h>
-#endif
-#if HAVE_XKB_EXTENSION
-#	include <X11/XKBlib.h>
-#endif
-#ifdef HAVE_XI2
-#	include <X11/extensions/XInput2.h>
-#endif
+#include <X11/extensions/Xrandr.h>
+#include <X11/XKBlib.h>
+#include <X11/extensions/XInput2.h>
 
 class IXWindowsImpl {
 public:

--- a/src/lib/platform/IXWindowsImpl.h
+++ b/src/lib/platform/IXWindowsImpl.h
@@ -8,14 +8,9 @@
 #define XK_MISCELLANY
 #define XK_XKB_KEYS
 #include <X11/keysymdef.h>
-     extern "C" {
-#	include <X11/extensions/dpms.h>
-     }
+#include <X11/extensions/dpms.h>
 #include <X11/extensions/XTest.h>
-     // Xinerama.h may lack extern "C" for inclusion by C++
-     extern "C" {
 #include <X11/extensions/Xinerama.h>
-     }
 #include <X11/extensions/Xrandr.h>
 #include <X11/XKBlib.h>
 #include <X11/extensions/XInput2.h>

--- a/src/lib/platform/XWindowsImpl.cpp
+++ b/src/lib/platform/XWindowsImpl.cpp
@@ -242,57 +242,28 @@ Bool XWindowsImpl::XRRQueryExtension(Display* display, int* event_base_return,
     (void) event_base_return;
     (void) error_base_return;
 
-#if HAVE_X11_EXTENSIONS_XRANDR_H
     return ::XRRQueryExtension(display, event_base_return, error_base_return);
-#else
-    return false;
-#endif
 }
 
 void XWindowsImpl::XRRSelectInput(Display *display, Window window, int mask)
 {
-#if HAVE_X11_EXTENSIONS_XRANDR_H
     ::XRRSelectInput(display, window, mask);
-#else
-    (void) display; (void) window; (void) mask;
-#endif
 }
 
 Bool XWindowsImpl::XineramaQueryExtension(Display* display, int* event_base,
                                           int* error_base)
 {
-#if HAVE_X11_EXTENSIONS_XINERAMA_H
     return ::XineramaQueryExtension(display, event_base, error_base);
-#else
-    (void) display;
-    (void) event_base;
-    (void) error_base;
-
-    return false;
-#endif
 }
 
 Bool XWindowsImpl::XineramaIsActive(Display* display)
 {
-#if HAVE_X11_EXTENSIONS_XINERAMA_H
     return ::XineramaIsActive(display);
-#else
-    (void) display;
-
-    return false;
-#endif
 }
 
 void* XWindowsImpl::XineramaQueryScreens(Display* display, int* number)
 {
-#if HAVE_X11_EXTENSIONS_XINERAMA_H
     return ::XineramaQueryScreens(display, number);
-#else
-    (void) display;
-    (void) number;
-
-    return nullptr;
-#endif
 }
 
 Window XWindowsImpl::XCreateWindow(Display* display, Window parent,

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -27,9 +27,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/extensions/XTest.h>
-#if HAVE_XKB_EXTENSION
 #    include <X11/extensions/XKBstr.h>
-#endif
 
 class IEventQueue;
 
@@ -142,9 +140,7 @@ private:
     IXWindowsImpl* m_impl;
 
     Display*            m_display;
-#if HAVE_XKB_EXTENSION
     XkbDescPtr            m_xkb;
-#endif
     std::int32_t m_group;
     XKBModifierMap        m_lastGoodXKBModifiers;
     NonXKBModifierMap    m_lastGoodNonXKBModifiers;

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -140,9 +140,7 @@ private:
     int y_accumulateMouseScroll(std::int32_t yDelta) const;
 
     bool                detectXI2();
-#ifdef HAVE_XI2
     void                selectXIRawMotion();
-#endif
     void                selectEvents(Window) const;
     void                doSelectEvents(Window) const;
 

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -27,12 +27,10 @@
 
 #include <X11/Xatom.h>
 #include <X11/extensions/XTest.h>
-#if HAVE_X11_EXTENSIONS_DPMS_H
 extern "C" {
 #    include <X11/Xmd.h>
 #    include <X11/extensions/dpms.h>
 }
-#endif
 
 //
 // XWindowsScreenSaver
@@ -66,7 +64,6 @@ XWindowsScreenSaver::XWindowsScreenSaver(IXWindowsImpl* impl, Display* display,
 
     // check for DPMS extension.  this is an alternative screen saver
     // that powers down the display.
-#if HAVE_X11_EXTENSIONS_DPMS_H
     int eventBase, errorBase;
     if (m_impl->DPMSQueryExtension(m_display, &eventBase, &errorBase)) {
         if (m_impl->DPMSCapable(m_display)) {
@@ -74,7 +71,6 @@ XWindowsScreenSaver::XWindowsScreenSaver(IXWindowsImpl* impl, Display* display,
             m_dpms  = true;
         }
     }
-#endif
 
     // watch top-level windows for changes
     bool error = false;
@@ -530,20 +526,17 @@ XWindowsScreenSaver::handleDisableTimer(const Event&, void*)
 void
 XWindowsScreenSaver::activateDPMS(bool activate)
 {
-#if HAVE_X11_EXTENSIONS_DPMS_H
     if (m_dpms) {
         // DPMSForceLevel will generate a BadMatch if DPMS is disabled
         XWindowsUtil::ErrorLock lock(m_display);
         m_impl->DPMSForceLevel(m_display,
                                activate ? DPMSModeStandby : DPMSModeOn);
     }
-#endif
 }
 
 void
 XWindowsScreenSaver::enableDPMS(bool enable)
 {
-#if HAVE_X11_EXTENSIONS_DPMS_H
     if (m_dpms) {
         if (enable) {
             m_impl->DPMSEnable(m_display);
@@ -552,13 +545,11 @@ XWindowsScreenSaver::enableDPMS(bool enable)
             m_impl->DPMSDisable(m_display);
         }
     }
-#endif
 }
 
 bool
 XWindowsScreenSaver::isDPMSEnabled() const
 {
-#if HAVE_X11_EXTENSIONS_DPMS_H
     if (m_dpms) {
         CARD16 level;
         BOOL state;
@@ -568,15 +559,11 @@ XWindowsScreenSaver::isDPMSEnabled() const
     else {
         return false;
     }
-#else
-    return false;
-#endif
 }
 
 bool
 XWindowsScreenSaver::isDPMSActivated() const
 {
-#if HAVE_X11_EXTENSIONS_DPMS_H
     if (m_dpms) {
         CARD16 level;
         BOOL state;
@@ -586,7 +573,4 @@ XWindowsScreenSaver::isDPMSActivated() const
     else {
         return false;
     }
-#else
-    return false;
-#endif
 }

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -27,10 +27,8 @@
 
 #include <X11/Xatom.h>
 #include <X11/extensions/XTest.h>
-extern "C" {
-#    include <X11/Xmd.h>
-#    include <X11/extensions/dpms.h>
-}
+#include <X11/Xmd.h>
+#include <X11/extensions/dpms.h>
 
 //
 // XWindowsScreenSaver

--- a/src/test/integtests/platform/XWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/XWindowsKeyStateTests.cpp
@@ -29,9 +29,7 @@
 #define XK_MISCELLANY
 #include <X11/keysymdef.h>
 
-#if HAVE_XKB_EXTENSION
-#    include <X11/XKBlib.h>
-#endif
+#include <X11/XKBlib.h>
 
 #include "test/global/gtest.h"
 #include "test/global/gmock.h"
@@ -209,7 +207,6 @@ TEST_F(XWindowsKeyStateTests, pollActiveGroup_positiveGroup_returnsGroup)
 
 TEST_F(XWindowsKeyStateTests, pollActiveGroup_xkb_areEqual)
 {
-#if HAVE_XKB_EXTENSION
     MockKeyMap keyMap;
     MockEventQueue eventQueue;
     XWindowsKeyState keyState(new XWindowsImpl(), m_display, true, &eventQueue, keyMap);
@@ -228,8 +225,5 @@ TEST_F(XWindowsKeyStateTests, pollActiveGroup_xkb_areEqual)
     else {
         FAIL() << "XkbGetState() returned error " << errno;
     }
-#else
-    SUCCEED() << "Xkb extension not installed";
-#endif
 }
 


### PR DESCRIPTION
Not sure this counts as "user-visible change" since most users definitely won't see this and most builders either :smile: 

This cleanup vastly simplifies the X11 package checks by using pkgconfig instead. I think at this point we can expect this to exist and work on every system from the last decade. automake and meson are exclusively requiring it, so not using it just makes our life harder.

Plus, most of the checks here were borderline pointless a decade ago, they certainly are now. There are no X servers anymore that don't support XKB/XI2/Xrandr for example, and virtually all desktop systems have all libX* installed anyway.