### PR TITLE
treewide: drop the whitespace alignment for class member variables

### DIFF
--- a/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.h
+++ b/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.h
@@ -56,11 +56,11 @@ private:
                             UINT msg, WPARAM wParam, LPARAM lParam);
 
 private:
-    HINSTANCE            m_appInstance;
-    HWND                m_window;
-    HMENU                m_menu;
-    HICON                m_icon[kMaxState];
-    const BufferedLogOutputter*    m_logBuffer;
+    HINSTANCE m_appInstance;
+    HWND m_window;
+    HMENU m_menu;
+    HICON m_icon[kMaxState];
+    const BufferedLogOutputter* m_logBuffer;
 
     static const UINT    s_stateToIconID[];
 };

--- a/src/cmd/barriers/MSWindowsServerTaskBarReceiver.h
+++ b/src/cmd/barriers/MSWindowsServerTaskBarReceiver.h
@@ -56,12 +56,12 @@ private:
                             UINT msg, WPARAM wParam, LPARAM lParam);
 
 private:
-    HINSTANCE            m_appInstance;
-    HWND                m_window;
-    HMENU                m_menu;
-    HICON                m_icon[kMaxState];
-    const BufferedLogOutputter*    m_logBuffer;
-    IEventQueue*        m_events;
+    HINSTANCE m_appInstance;
+    HWND m_window;
+    HMENU m_menu;
+    HICON m_icon[kMaxState];
+    const BufferedLogOutputter* m_logBuffer;
+    IEventQueue* m_events;
 
     static const UINT    s_stateToIconID[];
 };

--- a/src/lib/arch/Arch.h
+++ b/src/lib/arch/Arch.h
@@ -109,5 +109,5 @@ public:
 
 private:
     static Arch*        s_instance;
-    ARCH_INTERNET        m_internet;
+    ARCH_INTERNET m_internet;
 };

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -90,17 +90,17 @@ public:
     class PollEntry {
     public:
         //! The socket to query
-        ArchSocket        m_socket;
+        ArchSocket m_socket;
 
         //! The events to query for
         /*!
         The events to query for can be any combination of kPOLLIN and
         kPOLLOUT.
         */
-        unsigned short    m_events;
+        unsigned short m_events;
 
         //! The result events
-        unsigned short    m_revents;
+        unsigned short m_revents;
     };
 
     //! @name manipulators

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -85,14 +85,14 @@ private:
 
     static ArchMultithreadPosix*    s_instance;
 
-    bool                m_newThreadCalled;
+    bool m_newThreadCalled;
 
     std::mutex m_threadMutex;
-    ArchThread            m_mainThread;
-    ThreadList            m_threadList;
-    ThreadID            m_nextID;
+    ArchThread m_mainThread;
+    ThreadList m_threadList;
+    ThreadID m_nextID;
 
-    pthread_t            m_signalThread;
-    SignalFunc            m_signalFunc[kNUM_SIGNALS];
-    void*                m_signalUserData[kNUM_SIGNALS];
+    pthread_t m_signalThread;
+    SignalFunc m_signalFunc[kNUM_SIGNALS];
+    void* m_signalUserData[kNUM_SIGNALS];
 };

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -42,8 +42,8 @@ typedef char optval_t;
 
 class ArchSocketImpl {
 public:
-    int                    m_fd;
-    int                    m_refCount;
+    int m_fd;
+    int m_refCount;
 };
 
 class ArchNetAddressImpl {
@@ -51,8 +51,8 @@ public:
     ArchNetAddressImpl() : m_len(sizeof(m_addr)) { }
 
 public:
-    struct sockaddr_storage        m_addr;
-    socklen_t                      m_len;
+    struct sockaddr_storage m_addr;
+    socklen_t m_len;
 };
 
 //! Berkeley (BSD) sockets implementation of IArchNetwork

--- a/src/lib/arch/unix/XArchUnix.h
+++ b/src/lib/arch/unix/XArchUnix.h
@@ -29,5 +29,5 @@ public:
     std::string eval() const override;
 
 private:
-    int                    m_error;
+    int m_error;
 };

--- a/src/lib/arch/win32/ArchDaemonWindows.h
+++ b/src/lib/arch/win32/ArchDaemonWindows.h
@@ -118,7 +118,7 @@ private:
         XArchDaemonRunFailed(int result) : m_result(result) { }
 
     public:
-        int                m_result;
+        int m_result;
     };
 
 private:
@@ -126,19 +126,19 @@ private:
 
     std::mutex service_mutex_;
     std::condition_variable service_cv_;
-    DWORD                m_serviceState;
-    bool                m_serviceHandlerWaiting;
-    bool                m_serviceRunning;
+    DWORD m_serviceState;
+    bool m_serviceHandlerWaiting;
+    bool m_serviceRunning;
 
-    DWORD                m_daemonThreadID;
-    DaemonFunc            m_daemonFunc;
-    int                    m_daemonResult;
+    DWORD m_daemonThreadID;
+    DaemonFunc m_daemonFunc;
+    int m_daemonResult;
 
     SERVICE_STATUS_HANDLE m_statusHandle;
 
-    UINT                m_quitMessage;
+    UINT m_quitMessage;
 
-    std::string            m_commandLine;
+    std::string m_commandLine;
 };
 
 #define DEFAULT_DAEMON_NAME _T("Barrier")

--- a/src/lib/arch/win32/ArchLogWindows.h
+++ b/src/lib/arch/win32/ArchLogWindows.h
@@ -38,5 +38,5 @@ public:
     virtual void        writeLog(ELevel, const char*);
 
 private:
-    HANDLE                m_eventLog;
+    HANDLE m_eventLog;
 };

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -85,9 +85,9 @@ private:
 
     std::mutex thread_mutex_;
 
-    ThreadList            m_threadList;
-    ArchThread            m_mainThread;
+    ThreadList m_threadList;
+    ArchThread m_mainThread;
 
-    SignalFunc            m_signalFunc[kNUM_SIGNALS];
-    void*                m_signalUserData[kNUM_SIGNALS];
+    SignalFunc m_signalFunc[kNUM_SIGNALS];
+    void* m_signalUserData[kNUM_SIGNALS];
 };

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -41,10 +41,10 @@
 
 class ArchSocketImpl {
 public:
-    SOCKET                m_socket;
-    int                    m_refCount;
-    WSAEVENT            m_event;
-    bool                m_pollWrite;
+    SOCKET m_socket;
+    int m_refCount;
+    WSAEVENT m_event;
+    bool m_pollWrite;
 };
 
 class ArchNetAddressImpl {
@@ -52,8 +52,8 @@ public:
     static ArchNetAddressImpl* alloc(size_t);
 
 public:
-    int                            m_len;
-    struct sockaddr_storage        m_addr;
+    int m_len;
+    struct sockaddr_storage m_addr;
 };
 #define ADDR_HDR_SIZE    offsetof(ArchNetAddressImpl, m_addr)
 #define TYPED_ADDR(type_, addr_) (reinterpret_cast<type_*>(&addr_->m_addr))
@@ -109,5 +109,5 @@ private:
     typedef std::list<WSAEVENT> EventList;
 
     std::mutex mutex_;
-    EventList            m_unblockEvents;
+    EventList m_unblockEvents;
 };

--- a/src/lib/arch/win32/ArchTaskBarWindows.h
+++ b/src/lib/arch/win32/ArchTaskBarWindows.h
@@ -60,7 +60,7 @@ public:
 private:
     class ReceiverInfo {
     public:
-        UINT            m_id;
+        UINT m_id;
     };
 
     typedef std::map<IArchTaskBarReceiver*, ReceiverInfo> ReceiverToInfoMap;
@@ -95,21 +95,21 @@ private:
     // multithread data
     std::mutex mutex_;
     std::condition_variable cond_var_;
-    bool                m_ready;
-    int                    m_result;
-    ArchThread            m_thread;
+    bool m_ready;
+    int m_result;
+    ArchThread m_thread;
 
     // child thread data
-    HWND                m_hwnd;
-    UINT                m_taskBarRestart;
+    HWND m_hwnd;
+    UINT m_taskBarRestart;
 
     // shared data
-    ReceiverToInfoMap    m_receivers;
-    CIDToReceiverMap    m_idTable;
-    CIDStack            m_oldIDs;
-    UINT                m_nextID;
+    ReceiverToInfoMap m_receivers;
+    CIDToReceiverMap m_idTable;
+    CIDStack m_oldIDs;
+    UINT m_nextID;
 
     // dialogs
-    Dialogs            m_dialogs;
-    Dialogs            m_addedDialogs;
+    Dialogs m_dialogs;
+    Dialogs m_addedDialogs;
 };

--- a/src/lib/arch/win32/XArchWindows.h
+++ b/src/lib/arch/win32/XArchWindows.h
@@ -33,7 +33,7 @@ public:
     virtual std::string    eval() const noexcept;
 
 private:
-    DWORD                m_error;
+    DWORD m_error;
 };
 
 //! Lazy error message string evaluation for winsock
@@ -45,5 +45,5 @@ public:
     virtual std::string    eval() const noexcept;
 
 private:
-    int                    m_error;
+    int m_error;
 };

--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -119,9 +119,9 @@ public:
     //@}
 
 private:
-    Type            m_type;
-    void*           m_target;
-    void*           m_data;
-    Flags           m_flags;
-    EventData*      m_dataObject;
+    Type m_type;
+    void* m_target;
+    void* m_data;
+    Flags m_flags;
+    EventData* m_dataObject;
 };

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -91,10 +91,10 @@ private:
 
     private:
         EventQueueTimer* m_timer;
-        double           m_timeout;
-        void*            m_target;
-        bool             m_oneShot;
-        double           m_time;
+        double m_timeout;
+        void* m_target;
+        bool m_oneShot;
+        double m_time;
     };
 
     typedef std::set<EventQueueTimer*> Timers;
@@ -106,29 +106,29 @@ private:
     typedef std::map<Event::Type, IEventJob*> TypeHandlerTable;
     typedef std::map<void*, TypeHandlerTable> HandlerTable;
 
-    int                    m_systemTarget;
+    int m_systemTarget;
     mutable std::mutex mutex_;
 
     // registered events
-    Event::Type        m_nextType;
-    TypeMap            m_typeMap;
-    NameMap            m_nameMap;
+    Event::Type m_nextType;
+    TypeMap m_typeMap;
+    NameMap m_nameMap;
 
     // buffer of events
     IEventQueueBuffer* m_buffer;
 
     // saved events
-    EventTable         m_events;
-    EventIDList        m_oldEventIDs;
+    EventTable m_events;
+    EventIDList m_oldEventIDs;
 
     // timers
-    Stopwatch          m_time;
-    Timers             m_timers;
-    TimerQueue         m_timerQueue;
-    TimerEvent         m_timerEvent;
+    Stopwatch m_time;
+    Timers m_timers;
+    TimerQueue m_timerQueue;
+    TimerEvent m_timerEvent;
 
     // event handlers
-    HandlerTable       m_handlers;
+    HandlerTable m_handlers;
 
 public:
     //
@@ -156,31 +156,31 @@ public:
     FileEvents& forFile() override;
 
 private:
-    ClientEvents*               m_typesForClient;
-    IStreamEvents*              m_typesForIStream;
-    IpcClientEvents*            m_typesForIpcClient;
-    IpcClientProxyEvents*       m_typesForIpcClientProxy;
-    IpcServerEvents*            m_typesForIpcServer;
-    IpcServerProxyEvents*       m_typesForIpcServerProxy;
-    IDataSocketEvents*          m_typesForIDataSocket;
-    IListenSocketEvents*        m_typesForIListenSocket;
-    ISocketEvents*              m_typesForISocket;
-    OSXScreenEvents*            m_typesForOSXScreen;
-    ClientListenerEvents*       m_typesForClientListener;
-    ClientProxyEvents*          m_typesForClientProxy;
-    ClientProxyUnknownEvents*   m_typesForClientProxyUnknown;
-    ServerEvents*               m_typesForServer;
-    ServerAppEvents*            m_typesForServerApp;
-    IKeyStateEvents*            m_typesForIKeyState;
-    IPrimaryScreenEvents*       m_typesForIPrimaryScreen;
-    IScreenEvents*              m_typesForIScreen;
-    ClipboardEvents*            m_typesForClipboard;
-    FileEvents*                 m_typesForFile;
+    ClientEvents* m_typesForClient;
+    IStreamEvents* m_typesForIStream;
+    IpcClientEvents* m_typesForIpcClient;
+    IpcClientProxyEvents* m_typesForIpcClientProxy;
+    IpcServerEvents* m_typesForIpcServer;
+    IpcServerProxyEvents* m_typesForIpcServerProxy;
+    IDataSocketEvents* m_typesForIDataSocket;
+    IListenSocketEvents* m_typesForIListenSocket;
+    ISocketEvents* m_typesForISocket;
+    OSXScreenEvents* m_typesForOSXScreen;
+    ClientListenerEvents* m_typesForClientListener;
+    ClientProxyEvents* m_typesForClientProxy;
+    ClientProxyUnknownEvents* m_typesForClientProxyUnknown;
+    ServerEvents* m_typesForServer;
+    ServerAppEvents* m_typesForServerApp;
+    IKeyStateEvents* m_typesForIKeyState;
+    IPrimaryScreenEvents* m_typesForIPrimaryScreen;
+    IScreenEvents* m_typesForIScreen;
+    ClipboardEvents* m_typesForClipboard;
+    FileEvents* m_typesForFile;
     mutable std::mutex          ready_mutex_;
     mutable std::condition_variable ready_cv_;
     bool                        is_ready_ = false;
-    std::queue<Event>           m_pending;
-    NonBlockingStream           m_parentStream;
+    std::queue<Event> m_pending;
+    NonBlockingStream m_parentStream;
 };
 
 #define EVENT_TYPE_ACCESSOR(type_)                                            \

--- a/src/lib/base/EventTypes.h
+++ b/src/lib/base/EventTypes.h
@@ -30,7 +30,7 @@ protected:
     IEventQueue*        getEvents() const;
 
 private:
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };
 
 #define REGISTER_EVENT(type_, name_)                                    \
@@ -75,9 +75,9 @@ public:
     //@}
 
 private:
-    Event::Type        m_connected;
-    Event::Type        m_connectionFailed;
-    Event::Type        m_disconnected;
+    Event::Type m_connected;
+    Event::Type m_connectionFailed;
+    Event::Type m_disconnected;
 };
 
 class IStreamEvents : public EventTypes {
@@ -141,11 +141,11 @@ public:
     //@}
 
 private:
-    Event::Type        m_inputReady;
-    Event::Type        m_outputFlushed;
-    Event::Type        m_outputError;
-    Event::Type        m_inputShutdown;
-    Event::Type        m_outputShutdown;
+    Event::Type m_inputReady;
+    Event::Type m_outputFlushed;
+    Event::Type m_outputError;
+    Event::Type m_inputShutdown;
+    Event::Type m_outputShutdown;
     Event::Type m_inputFormatError;
 };
 
@@ -167,8 +167,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_connected;
-    Event::Type        m_messageReceived;
+    Event::Type m_connected;
+    Event::Type m_messageReceived;
 };
 
 class IpcClientProxyEvents : public EventTypes {
@@ -189,8 +189,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_messageReceived;
-    Event::Type        m_disconnected;
+    Event::Type m_messageReceived;
+    Event::Type m_disconnected;
 };
 
 class IpcServerEvents : public EventTypes {
@@ -211,8 +211,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_clientConnected;
-    Event::Type        m_messageReceived;
+    Event::Type m_clientConnected;
+    Event::Type m_messageReceived;
 };
 
 class IpcServerProxyEvents : public EventTypes {
@@ -229,7 +229,7 @@ public:
     //@}
 
 private:
-    Event::Type        m_messageReceived;
+    Event::Type m_messageReceived;
 };
 
 class IDataSocketEvents : public EventTypes {
@@ -267,9 +267,9 @@ public:
     //@}
 
 private:
-    Event::Type        m_connected;
-    Event::Type        m_secureConnected;
-    Event::Type        m_connectionFailed;
+    Event::Type m_connected;
+    Event::Type m_secureConnected;
+    Event::Type m_connectionFailed;
 };
 
 class IListenSocketEvents : public EventTypes {
@@ -290,7 +290,7 @@ public:
     //@}
 
 private:
-    Event::Type        m_connecting;
+    Event::Type m_connecting;
 };
 
 class ISocketEvents : public EventTypes {
@@ -320,8 +320,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_disconnected;
-    Event::Type        m_stopRetry;
+    Event::Type m_disconnected;
+    Event::Type m_stopRetry;
 };
 
 class OSXScreenEvents : public EventTypes {
@@ -337,7 +337,7 @@ public:
     //@}
 
 private:
-    Event::Type        m_confirmSleep;
+    Event::Type m_confirmSleep;
 };
 
 class ClientListenerEvents : public EventTypes {
@@ -366,8 +366,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_accepted;
-    Event::Type        m_connected;
+    Event::Type m_accepted;
+    Event::Type m_connected;
 };
 
 class ClientProxyEvents : public EventTypes {
@@ -397,8 +397,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_ready;
-    Event::Type        m_disconnected;
+    Event::Type m_ready;
+    Event::Type m_disconnected;
 };
 
 class ClientProxyUnknownEvents : public EventTypes {
@@ -427,8 +427,8 @@ public:
     //@}
 
 private:
-    Event::Type        m_success;
-    Event::Type        m_failure;
+    Event::Type m_success;
+    Event::Type m_failure;
 };
 
 class ServerEvents : public EventTypes {
@@ -518,15 +518,15 @@ public:
     //@}
 
 private:
-    Event::Type        m_error;
-    Event::Type        m_connected;
-    Event::Type        m_disconnected;
-    Event::Type        m_switchToScreen;
-    Event::Type        m_toggleScreen;
-    Event::Type        m_switchInDirection;
-    Event::Type        m_keyboardBroadcast;
-    Event::Type        m_lockCursorToScreen;
-    Event::Type        m_screenSwitched;
+    Event::Type m_error;
+    Event::Type m_connected;
+    Event::Type m_disconnected;
+    Event::Type m_switchToScreen;
+    Event::Type m_toggleScreen;
+    Event::Type m_switchInDirection;
+    Event::Type m_keyboardBroadcast;
+    Event::Type m_lockCursorToScreen;
+    Event::Type m_screenSwitched;
 };
 
 class ServerAppEvents : public EventTypes {
@@ -546,9 +546,9 @@ public:
     //@}
 
 private:
-    Event::Type        m_reloadConfig;
-    Event::Type        m_forceReconnect;
-    Event::Type        m_resetServer;
+    Event::Type m_reloadConfig;
+    Event::Type m_forceReconnect;
+    Event::Type m_resetServer;
 };
 
 class IKeyStateEvents : public EventTypes {
@@ -573,9 +573,9 @@ public:
     //@}
 
 private:
-    Event::Type        m_keyDown;
-    Event::Type        m_keyUp;
-    Event::Type        m_keyRepeat;
+    Event::Type m_keyDown;
+    Event::Type m_keyUp;
+    Event::Type m_keyRepeat;
 };
 
 class IPrimaryScreenEvents : public EventTypes {
@@ -639,17 +639,17 @@ public:
     //@}
 
 private:
-    Event::Type        m_buttonDown;
-    Event::Type        m_buttonUp;
-    Event::Type        m_motionOnPrimary;
-    Event::Type        m_motionOnSecondary;
-    Event::Type        m_wheel;
-    Event::Type        m_screensaverActivated;
-    Event::Type        m_screensaverDeactivated;
-    Event::Type        m_hotKeyDown;
-    Event::Type        m_hotKeyUp;
-    Event::Type        m_fakeInputBegin;
-    Event::Type        m_fakeInputEnd;
+    Event::Type m_buttonDown;
+    Event::Type m_buttonUp;
+    Event::Type m_motionOnPrimary;
+    Event::Type m_motionOnSecondary;
+    Event::Type m_wheel;
+    Event::Type m_screensaverActivated;
+    Event::Type m_screensaverDeactivated;
+    Event::Type m_hotKeyDown;
+    Event::Type m_hotKeyUp;
+    Event::Type m_fakeInputBegin;
+    Event::Type m_fakeInputEnd;
 };
 
 class IScreenEvents : public EventTypes {
@@ -694,10 +694,10 @@ public:
     //@}
 
 private:
-    Event::Type        m_error;
-    Event::Type        m_shapeChanged;
-    Event::Type        m_suspend;
-    Event::Type        m_resume;
+    Event::Type m_error;
+    Event::Type m_shapeChanged;
+    Event::Type m_suspend;
+    Event::Type m_resume;
 };
 
 class ClipboardEvents : public EventTypes {
@@ -736,9 +736,9 @@ public:
     //@}
 
 private:
-    Event::Type        m_clipboardGrabbed;
-    Event::Type        m_clipboardChanged;
-    Event::Type        m_clipboardSending;
+    Event::Type m_clipboardGrabbed;
+    Event::Type m_clipboardChanged;
+    Event::Type m_clipboardSending;
 };
 
 class FileEvents : public EventTypes {
@@ -763,7 +763,7 @@ public:
     //@}
 
 private:
-    Event::Type        m_fileChunkSending;
-    Event::Type        m_fileReceiveCompleted;
-    Event::Type        m_keepAlive;
+    Event::Type m_fileChunkSending;
+    Event::Type m_fileReceiveCompleted;
+    Event::Type m_keepAlive;
 };

--- a/src/lib/base/FunctionEventJob.h
+++ b/src/lib/base/FunctionEventJob.h
@@ -35,6 +35,6 @@ public:
     void run(const Event&) override;
 
 private:
-    void                (*m_func)(const Event&, void*);
-    void*                m_arg;
+    void  (*m_func)(const Event&, void*);
+    void* m_arg;
 };

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -62,8 +62,8 @@ public:
     virtual ~IEventQueue() { }
     class TimerEvent {
     public:
-        EventQueueTimer*    m_timer;    //!< The timer
-        std::uint32_t       m_count;    //!< Number of repeats
+        EventQueueTimer* m_timer; //!< The timer
+        std::uint32_t m_count; //!< Number of repeats
     };
 
     //! @name manipulators

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -134,10 +134,10 @@ private:
     static Log*        s_log;
 
     mutable std::mutex m_mutex;
-    OutputterList        m_outputters;
-    OutputterList        m_alwaysOutputters;
-    int                    m_maxNewlineLength;
-    int                    m_maxPriority;
+    OutputterList m_outputters;
+    OutputterList m_alwaysOutputters;
+    int m_maxNewlineLength;
+    int m_maxPriority;
 };
 
 /*!

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -46,7 +46,7 @@ private:
 
     mutable std::mutex queue_mutex_;
     std::condition_variable queue_ready_cv_;
-    bool                m_queueReady;
-    EventDeque            m_queue;
+    bool m_queueReady;
+    EventDeque m_queue;
 };
 

--- a/src/lib/base/Stopwatch.h
+++ b/src/lib/base/Stopwatch.h
@@ -103,7 +103,7 @@ private:
     double                getClock() const;
 
 private:
-    double                m_mark;
-    bool                m_triggered;
-    bool                m_stopped;
+    double m_mark;
+    bool m_triggered;
+    bool m_stopped;
 };

--- a/src/lib/base/TMethodEventJob.h
+++ b/src/lib/base/TMethodEventJob.h
@@ -35,9 +35,9 @@ public:
     void run(const Event&)  override;
 
 private:
-    T*                    m_object;
-    void                (T::*m_method)(const Event&, void*);
-    void*                m_arg;
+    T* m_object;
+    void (T::*m_method)(const Event&, void*);
+    void* m_arg;
 };
 
 template <class T>

--- a/src/lib/base/XBase.h
+++ b/src/lib/base/XBase.h
@@ -48,7 +48,7 @@ protected:
     */
     virtual std::string format(const char* id, const char* defaultFormat, ...) const noexcept;
 private:
-    mutable std::string        m_what;
+    mutable std::string m_what;
 };
 
 /*!
@@ -119,6 +119,6 @@ protected:                                                                \
     std::string getWhat() const noexcept override;                        \
                                                                         \
 private:                                                                \
-    mutable EState                m_state;                                \
-    mutable std::string            m_formatted;                            \
+    mutable EState m_state;                                \
+    mutable std::string m_formatted;                            \
 }

--- a/src/lib/base/log_outputters.h
+++ b/src/lib/base/log_outputters.h
@@ -83,7 +83,7 @@ public:
     void                setLogFilename(const char* title);
 
 private:
-    std::string            m_fileName;
+    std::string m_fileName;
 };
 
 //! Write log to system log
@@ -116,8 +116,8 @@ public:
     ~SystemLogger();
 
 private:
-    ILogOutputter*        m_syslog;
-    ILogOutputter*        m_stop;
+    ILogOutputter* m_syslog;
+    ILogOutputter* m_stop;
 };
 
 //! Save log history
@@ -152,7 +152,7 @@ public:
     bool write(ELevel level, const char* message) override;
 private:
     std::uint32_t m_maxBufferSize;
-    Buffer                m_buffer;
+    Buffer m_buffer;
 };
 
 //! Write log to message box

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -46,7 +46,7 @@ public:
     class FailInfo {
     public:
         FailInfo(const char* what) : m_retry(false), m_what(what) { }
-        bool            m_retry;
+        bool m_retry;
         std::string m_what;
     };
 
@@ -192,33 +192,33 @@ private:
     void                sendClipboardThread(void*);
 
 public:
-    bool                m_mock;
+    bool m_mock;
 
 private:
-    std::string                m_name;
-    NetworkAddress        m_serverAddress;
-    ISocketFactory*        m_socketFactory;
+    std::string m_name;
+    NetworkAddress m_serverAddress;
+    ISocketFactory* m_socketFactory;
     inputleap::Screen* m_screen;
     inputleap::IStream* m_stream;
-    EventQueueTimer*    m_timer;
-    ServerProxy*        m_server;
-    bool                m_ready;
-    bool                m_active;
-    bool                m_suspended;
-    bool                m_connectOnResume;
-    bool                m_ownClipboard[kClipboardEnd];
-    bool                m_sentClipboard[kClipboardEnd];
-    IClipboard::Time    m_timeClipboard[kClipboardEnd];
+    EventQueueTimer* m_timer;
+    ServerProxy* m_server;
+    bool m_ready;
+    bool m_active;
+    bool m_suspended;
+    bool m_connectOnResume;
+    bool m_ownClipboard[kClipboardEnd];
+    bool m_sentClipboard[kClipboardEnd];
+    IClipboard::Time m_timeClipboard[kClipboardEnd];
     std::string m_dataClipboard[kClipboardEnd];
-    IEventQueue*        m_events;
-    std::size_t            m_expectedFileSize;
+    IEventQueue* m_events;
+    std::size_t m_expectedFileSize;
     std::string m_receivedFileData;
-    DragFileList        m_dragFileList;
+    DragFileList m_dragFileList;
     std::string m_dragFileExt;
-    Thread*                m_sendFileThread;
-    Thread*                m_writeToDropDirThread;
-    TCPSocket*            m_socket;
-    bool                m_useSecureNetwork;
-    ClientArgs            m_args;
-    bool                m_enableClipboard;
+    Thread* m_sendFileThread;
+    Thread* m_writeToDropDirThread;
+    TCPSocket* m_socket;
+    bool m_useSecureNetwork;
+    ClientArgs m_args;
+    bool m_enableClipboard;
 };

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -109,23 +109,23 @@ private:
 private:
     typedef EResult (ServerProxy::*MessageParser)(const std::uint8_t*);
 
-    Client*            m_client;
+    Client* m_client;
     inputleap::IStream* m_stream;
 
     std::uint32_t m_seqNum;
 
-    bool                m_compressMouse;
-    bool                m_compressMouseRelative;
+    bool m_compressMouse;
+    bool m_compressMouseRelative;
     std::int32_t m_xMouse, m_yMouse;
     std::int32_t m_dxMouse, m_dyMouse;
 
-    bool                m_ignoreMouse;
+    bool m_ignoreMouse;
 
-    KeyModifierID        m_modifierTranslationTable[kKeyModifierIDLast];
+    KeyModifierID m_modifierTranslationTable[kKeyModifierIDLast];
 
-    double                m_keepAliveAlarm;
-    EventQueueTimer*    m_keepAliveAlarmTimer;
+    double m_keepAliveAlarm;
+    EventQueueTimer* m_keepAliveAlarmTimer;
 
-    MessageParser        m_parser;
-    IEventQueue*        m_events;
+    MessageParser m_parser;
+    IEventQueue* m_events;
 };

--- a/src/lib/inputleap/App.h
+++ b/src/lib/inputleap/App.h
@@ -111,7 +111,7 @@ protected:
 
     IArchTaskBarReceiver* m_taskBarReceiver;
     bool m_suspended;
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 
 private:
     ArgsBase* m_args;
@@ -119,7 +119,7 @@ private:
     FileLogOutputter* m_fileLog;
     CreateTaskBarReceiverFunc m_createTaskBarReceiver;
     ARCH_APP_UTIL m_appUtil;
-    IpcClient*            m_ipcClient;
+    IpcClient* m_ipcClient;
     std::unique_ptr<SocketMultiplexer> m_socketMultiplexer;
 };
 
@@ -142,9 +142,9 @@ public:
     void parseArgs(int argc, const char* const* argv) override;
 
 private:
-    Arch                m_arch;
-    Log                    m_log;
-    EventQueue            m_events;
+    Arch m_arch;
+    Log m_log;
+    EventQueue m_events;
 };
 
 #if WINAPI_MSWINDOWS

--- a/src/lib/inputleap/ArgParser.h
+++ b/src/lib/inputleap/ArgParser.h
@@ -62,7 +62,7 @@ private:
     bool                parseXWindowsArg(ArgsBase& argsBase, const int& argc, const char* const* argv, int& i);
 
 private:
-    App*                m_app;
+    App* m_app;
 
-    static ArgsBase*    m_argsBase;
+    static ArgsBase* m_argsBase;
 };

--- a/src/lib/inputleap/ArgsBase.h
+++ b/src/lib/inputleap/ArgsBase.h
@@ -26,30 +26,30 @@ public:
     virtual ~ArgsBase();
 
 public:
-    bool                m_daemon;
-    bool                m_backend;
-    bool                m_restartable;
-    bool                m_noHooks;
-    std::string         m_exename;
-    const char*         m_logFilter;
-    const char*         m_logFile;
-    const char*         m_display;
-    std::string         m_name;
-    bool                m_disableTray;
-    bool                m_enableIpc;
-    bool                m_enableDragDrop;
+    bool m_daemon;
+    bool m_backend;
+    bool m_restartable;
+    bool m_noHooks;
+    std::string m_exename;
+    const char* m_logFilter;
+    const char* m_logFile;
+    const char* m_display;
+    std::string m_name;
+    bool m_disableTray;
+    bool m_enableIpc;
+    bool m_enableDragDrop;
     std::string m_dropTarget;
 #if SYSAPI_WIN32
-    bool                m_debugServiceWait;
-    bool                m_pauseOnExit;
-    bool                m_stopOnDeskSwitch;
+    bool m_debugServiceWait;
+    bool m_pauseOnExit;
+    bool m_stopOnDeskSwitch;
 #endif
 #if WINAPI_XWINDOWS
-    bool                m_disableXInitThreads;
+    bool m_disableXInitThreads;
 #endif
-    bool                m_shouldExit;
-    std::string         m_barrierAddress;
-    bool                m_enableCrypto;
+    bool m_shouldExit;
+    std::string m_barrierAddress;
+    bool m_enableCrypto;
     inputleap::fs::path m_profileDirectory;
     inputleap::fs::path m_pluginDirectory;
 };

--- a/src/lib/inputleap/Chunk.h
+++ b/src/lib/inputleap/Chunk.h
@@ -25,6 +25,6 @@ public:
     ~Chunk();
 
 public:
-    size_t                m_dataSize;
-    char*                m_chunk;
+    size_t m_dataSize;
+    char* m_chunk;
 };

--- a/src/lib/inputleap/ClientApp.h
+++ b/src/lib/inputleap/ClientApp.h
@@ -77,7 +77,7 @@ public:
     Client* getClientPtr() { return m_client; }
 
 private:
-    Client*            m_client;
-    inputleap::Screen*m_clientScreen;
-    NetworkAddress*    m_serverAddress;
+    Client* m_client;
+    inputleap::Screen* m_clientScreen;
+    NetworkAddress* m_serverAddress;
 };

--- a/src/lib/inputleap/ClientArgs.h
+++ b/src/lib/inputleap/ClientArgs.h
@@ -26,5 +26,5 @@ public:
     ClientArgs();
 
 public:
-    int                    m_yscroll;
+    int m_yscroll;
 };

--- a/src/lib/inputleap/ClientTaskBarReceiver.h
+++ b/src/lib/inputleap/ClientTaskBarReceiver.h
@@ -80,10 +80,10 @@ protected:
     virtual void        onStatusChanged(Client* client);
 
 private:
-    EState                m_state;
+    EState m_state;
     std::string m_errorMessage;
     std::string m_server;
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };
 
 IArchTaskBarReceiver* createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events);

--- a/src/lib/inputleap/Clipboard.h
+++ b/src/lib/inputleap/Clipboard.h
@@ -62,10 +62,10 @@ public:
     std::string get(EFormat) const override;
 
 private:
-    mutable bool        m_open;
-    mutable Time        m_time;
-    bool                m_owner;
-    Time                m_timeOwned;
-    bool                m_added[kNumFormats];
+    mutable bool m_open;
+    mutable Time m_time;
+    bool m_owner;
+    Time m_timeOwned;
+    bool m_added[kNumFormats];
     std::string m_data[kNumFormats];
 };

--- a/src/lib/inputleap/DragInformation.h
+++ b/src/lib/inputleap/DragInformation.h
@@ -49,5 +49,5 @@ private:
 
 private:
     std::string m_filename;
-    size_t                m_filesize;
+    size_t m_filesize;
 };

--- a/src/lib/inputleap/IKeyState.h
+++ b/src/lib/inputleap/IKeyState.h
@@ -54,12 +54,12 @@ public:
         static void split(const char* screens, std::set<std::string>&);
 
     public:
-        KeyID            m_key;
-        KeyModifierMask    m_mask;
-        KeyButton        m_button;
+        KeyID m_key;
+        KeyModifierMask m_mask;
+        KeyButton m_button;
         std::int32_t m_count;
-        char*            m_screens;
-        char            m_screensBuffer[1];
+        char* m_screens;
+        char m_screensBuffer[1];
     };
 
     typedef std::set<KeyButton> KeyButtonSet;

--- a/src/lib/inputleap/IPrimaryScreen.h
+++ b/src/lib/inputleap/IPrimaryScreen.h
@@ -41,8 +41,8 @@ public:
         static bool            equal(const ButtonInfo*, const ButtonInfo*);
 
     public:
-        ButtonID        m_button;
-        KeyModifierMask    m_mask;
+        ButtonID m_button;
+        KeyModifierMask m_mask;
     };
     //! Motion event data
     class MotionInfo {

--- a/src/lib/inputleap/IScreen.h
+++ b/src/lib/inputleap/IScreen.h
@@ -34,7 +34,7 @@ public:
 
     struct ClipboardInfo {
     public:
-        ClipboardID        m_id;
+        ClipboardID m_id;
         std::uint32_t m_sequenceNumber;
     };
 

--- a/src/lib/inputleap/KeyMap.h
+++ b/src/lib/inputleap/KeyMap.h
@@ -50,14 +50,14 @@ public:
     */
     struct KeyItem {
     public:
-        KeyID            m_id;            //!< KeyID
+        KeyID m_id; //!< KeyID
         std::int32_t m_group;        //!< Group for key
-        KeyButton        m_button;        //!< Button to generate KeyID
-        KeyModifierMask    m_required;        //!< Modifiers required for KeyID
-        KeyModifierMask    m_sensitive;    //!< Modifiers key is sensitive to
-        KeyModifierMask    m_generates;    //!< Modifiers key is mapped to
-        bool            m_dead;            //!< \c true if this is a dead KeyID
-        bool            m_lock;            //!< \c true if this locks a modifier
+        KeyButton m_button; //!< Button to generate KeyID
+        KeyModifierMask m_required; //!< Modifiers required for KeyID
+        KeyModifierMask m_sensitive; //!< Modifiers key is sensitive to
+        KeyModifierMask m_generates; //!< Modifiers key is mapped to
+        bool m_dead; //!< \c true if this is a dead KeyID
+        bool m_lock; //!< \c true if this locks a modifier
         std::uint32_t m_client;        //!< Client data
 
     public:
@@ -90,25 +90,25 @@ public:
     public:
         struct Button {
         public:
-            KeyButton    m_button;        //!< Button to synthesize
-            bool        m_press;        //!< \c true iff press
-            bool        m_repeat;        //!< \c true iff for an autorepeat
+            KeyButton m_button; //!< Button to synthesize
+            bool m_press; //!< \c true iff press
+            bool m_repeat; //!< \c true iff for an autorepeat
             std::uint32_t m_client;        //!< Client data
         };
         struct Group {
         public:
             std::int32_t m_group;        //!< Group/offset to change to/by
-            bool        m_absolute;        //!< \c true iff change to, else by
-            bool        m_restore;        //!< \c true iff for restoring state
+            bool m_absolute; //!< \c true iff change to, else by
+            bool m_restore; //!< \c true iff for restoring state
         };
         union Data {
         public:
-            Button        m_button;
-            Group        m_group;
+            Button m_button;
+            Group m_group;
         };
 
-        EType            m_type;
-        Data            m_data;
+        EType m_type;
+        Data m_data;
     };
 
     //! A sequence of keystrokes
@@ -470,25 +470,25 @@ private:
     typedef std::map<KeyModifierMask, std::string> ModifierToNameMap;
 
     // KeyID info
-    KeyIDMap            m_keyIDMap;
+    KeyIDMap m_keyIDMap;
     std::int32_t m_numGroups;
-    ModifierToKeyTable    m_modifierKeys;
+    ModifierToKeyTable m_modifierKeys;
 
     // composition info
-    bool                m_composeAcrossGroups;
+    bool m_composeAcrossGroups;
 
     // half-duplex info
-    KeyButtonSet        m_halfDuplex;            // half-duplex set by barrier
-    KeySet                m_halfDuplexMods;        // half-duplex set by user
+    KeyButtonSet m_halfDuplex; // half-duplex set by barrier
+    KeySet m_halfDuplexMods; // half-duplex set by user
 
     // dummy KeyItem for changing modifiers
-    KeyItem                m_modifierKeyItem;
+    KeyItem m_modifierKeyItem;
 
     // parsing/formatting tables
-    static NameToKeyMap*        s_nameToKeyMap;
-    static NameToModifierMap*    s_nameToModifierMap;
-    static KeyToNameMap*        s_keyToNameMap;
-    static ModifierToNameMap*    s_modifierToNameMap;
+    static NameToKeyMap* s_nameToKeyMap;
+    static NameToModifierMap* s_nameToModifierMap;
+    static KeyToNameMap* s_keyToNameMap;
+    static ModifierToNameMap* s_modifierToNameMap;
 };
 
 }

--- a/src/lib/inputleap/KeyState.h
+++ b/src/lib/inputleap/KeyState.h
@@ -139,8 +139,8 @@ public:
 
     public:
         std::int32_t m_activeGroup;
-        KeyModifierMask    m_mask;
-        ModifierToKeys&    m_activeModifiers;
+        KeyModifierMask m_mask;
+        ModifierToKeys& m_activeModifiers;
 
     private:
         // not implemented
@@ -196,10 +196,10 @@ private:
     inputleap::KeyMap& m_keyMap;
 
     // current modifier state
-    KeyModifierMask        m_mask;
+    KeyModifierMask m_mask;
 
     // the active modifiers and the buttons activating them
-    ModifierToKeys        m_activeModifiers;
+    ModifierToKeys m_activeModifiers;
 
     // current keyboard state (> 0 if pressed, 0 otherwise).  this is
     // initialized to the keyboard state according to the system then
@@ -217,7 +217,7 @@ private:
 
     // server keyboard state.  an entry is 0 if not the key isn't pressed
     // otherwise it's the local KeyButton synthesized for the server key.
-    KeyButton            m_serverKeys[kNumButtons];
+    KeyButton m_serverKeys[kNumButtons];
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };

--- a/src/lib/inputleap/PacketStreamFilter.h
+++ b/src/lib/inputleap/PacketStreamFilter.h
@@ -56,7 +56,7 @@ private:
 private:
     mutable std::mutex mutex_;
     std::uint32_t m_size;
-    StreamBuffer        m_buffer;
-    bool                m_inputShutdown;
-    IEventQueue*        m_events;
+    StreamBuffer m_buffer;
+    bool m_inputShutdown;
+    IEventQueue* m_events;
 };

--- a/src/lib/inputleap/PlatformScreen.h
+++ b/src/lib/inputleap/PlatformScreen.h
@@ -80,7 +80,7 @@ protected:
     virtual IKeyState*    getKeyState() const = 0;
 
 protected:
-    std::string                m_draggingFilename;
-    bool                m_draggingStarted;
-    bool                m_fakeDraggingStarted;
+    std::string m_draggingFilename;
+    bool m_draggingStarted;
+    bool m_fakeDraggingStarted;
 };

--- a/src/lib/inputleap/PortableTaskBarReceiver.h
+++ b/src/lib/inputleap/PortableTaskBarReceiver.h
@@ -79,13 +79,13 @@ protected:
     virtual void        onStatusChanged(INode* node);
 
 private:
-    EState                m_state;
+    EState m_state;
     std::string m_errorMessage;
 
     std::string m_server;
-    Clients            m_clients;
+    Clients m_clients;
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };
 
 IArchTaskBarReceiver* createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events);

--- a/src/lib/inputleap/Screen.h
+++ b/src/lib/inputleap/Screen.h
@@ -315,31 +315,31 @@ protected:
 
 private:
     // our platform dependent screen
-    IPlatformScreen*    m_screen;
+    IPlatformScreen* m_screen;
 
     // true if screen is being used as a primary screen, false otherwise
-    bool                m_isPrimary;
+    bool m_isPrimary;
 
     // true if screen is enabled
-    bool                m_enabled;
+    bool m_enabled;
 
     // true if the cursor is on this screen
-    bool                m_entered;
+    bool m_entered;
 
     // true if screen saver should be synchronized to server
-    bool                m_screenSaverSync;
+    bool m_screenSaverSync;
 
     // note toggle keys that toggles on up/down (false) or on
     // transition (true)
-    KeyModifierMask        m_halfDuplex;
+    KeyModifierMask m_halfDuplex;
 
     // true if we're faking input on a primary screen
-    bool                m_fakeInput;
+    bool m_fakeInput;
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 
-    bool                m_mock;
-    bool                m_enableDragDrop;
+    bool m_mock;
+    bool m_enableDragDrop;
 };
 
 }

--- a/src/lib/inputleap/ServerApp.h
+++ b/src/lib/inputleap/ServerApp.h
@@ -104,13 +104,13 @@ public:
 
     Server* getServerPtr() { return m_server; }
 
-    Server*                m_server;
-    EServerState        m_serverState;
+    Server* m_server;
+    EServerState m_serverState;
     inputleap::Screen* m_serverScreen;
-    PrimaryClient*        m_primaryClient;
-    ClientListener*        m_listener;
-    EventQueueTimer*    m_timer;
-    NetworkAddress*        m_barrierAddress;
+    PrimaryClient* m_primaryClient;
+    ClientListener* m_listener;
+    EventQueueTimer* m_timer;
+    NetworkAddress* m_barrierAddress;
 
 private:
     void handleScreenSwitched(const Event&, void*  data);

--- a/src/lib/inputleap/ServerArgs.h
+++ b/src/lib/inputleap/ServerArgs.h
@@ -28,7 +28,7 @@ public:
 
 public:
     std::string m_configFile;
-    Config*                m_config;
+    Config* m_config;
     std::string m_screenChangeScript;
     bool check_client_certificates = true;
 };

--- a/src/lib/inputleap/ServerTaskBarReceiver.h
+++ b/src/lib/inputleap/ServerTaskBarReceiver.h
@@ -86,10 +86,10 @@ protected:
     virtual void        onStatusChanged(Server* server);
 
 private:
-    EState                m_state;
+    EState m_state;
     std::string m_errorMessage;
-    Clients            m_clients;
-    IEventQueue*        m_events;
+    Clients m_clients;
+    IEventQueue* m_events;
 };
 
 IArchTaskBarReceiver* createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events);

--- a/src/lib/inputleap/XBarrier.h
+++ b/src/lib/inputleap/XBarrier.h
@@ -57,8 +57,8 @@ protected:
     std::string getWhat() const noexcept override;
 
 private:
-    int                    m_major;
-    int                    m_minor;
+    int m_major;
+    int m_minor;
 };
 
 //! Client already connected exception
@@ -108,7 +108,7 @@ protected:
     std::string getWhat() const noexcept override;
 
 private:
-    std::string                m_name;
+    std::string m_name;
 };
 
 //! Generic exit eception
@@ -129,5 +129,5 @@ protected:
     std::string getWhat() const noexcept override;
 
 private:
-    int    m_code;
+    int m_code;
 };

--- a/src/lib/inputleap/XScreen.h
+++ b/src/lib/inputleap/XScreen.h
@@ -64,5 +64,5 @@ protected:
     std::string getWhat() const noexcept override;
 
 private:
-    double                m_timeUntilRetry;
+    double m_timeUntilRetry;
 };

--- a/src/lib/inputleap/win32/AppUtilWindows.h
+++ b/src/lib/inputleap/win32/AppUtilWindows.h
@@ -54,8 +54,8 @@ public:
     void startNode();
 
 private:
-    AppExitMode            m_exitMode;
-    IEventQueue*        m_events;
+    AppExitMode m_exitMode;
+    IEventQueue* m_events;
 
     static BOOL WINAPI consoleHandler(DWORD Event);
 };

--- a/src/lib/inputleap/win32/DaemonApp.h
+++ b/src/lib/inputleap/win32/DaemonApp.h
@@ -46,13 +46,13 @@ private:
 public:
     static DaemonApp* s_instance;
 
-    MSWindowsWatchdog*    m_watchdog;
+    MSWindowsWatchdog* m_watchdog;
 
 private:
-    IpcServer*            m_ipcServer;
-    IpcLogOutputter*    m_ipcLogOutputter;
-    IEventQueue*        m_events;
-    FileLogOutputter*    m_fileLogOutputter;
+    IpcServer* m_ipcServer;
+    IpcLogOutputter* m_ipcLogOutputter;
+    IEventQueue* m_events;
+    FileLogOutputter* m_fileLogOutputter;
 };
 
 #define LOG_FILENAME "barrierd.log"

--- a/src/lib/io/StreamBuffer.h
+++ b/src/lib/io/StreamBuffer.h
@@ -73,7 +73,7 @@ private:
     typedef std::vector<std::uint8_t> Chunk;
     typedef std::list<Chunk> ChunkList;
 
-    ChunkList            m_chunks;
+    ChunkList m_chunks;
     std::uint32_t m_size;
     std::uint32_t m_headUsed;
 };

--- a/src/lib/io/StreamFilter.h
+++ b/src/lib/io/StreamFilter.h
@@ -68,6 +68,6 @@ private:
 
 private:
     inputleap::IStream* m_stream;
-    bool                m_adopted;
-    IEventQueue*        m_events;
+    bool m_adopted;
+    IEventQueue* m_events;
 };

--- a/src/lib/ipc/IpcClient.h
+++ b/src/lib/ipc/IpcClient.h
@@ -57,8 +57,8 @@ private:
     void                handleMessageReceived(const Event&, void*);
 
 private:
-    NetworkAddress        m_serverAddress;
-    TCPSocket            m_socket;
-    IpcServerProxy*    m_server;
-    IEventQueue*        m_events;
+    NetworkAddress m_serverAddress;
+    TCPSocket m_socket;
+    IpcServerProxy* m_server;
+    IEventQueue* m_events;
 };

--- a/src/lib/ipc/IpcClientProxy.h
+++ b/src/lib/ipc/IpcClientProxy.h
@@ -49,9 +49,9 @@ private:
 
 private:
     inputleap::IStream& m_stream;
-    EIpcClientType        m_clientType;
-    bool                m_disconnecting;
+    EIpcClientType m_clientType;
+    bool m_disconnecting;
     std::mutex m_readMutex;
     std::mutex m_writeMutex;
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -100,22 +100,22 @@ private:
 private:
     typedef std::deque<std::string> Buffer;
 
-    IpcServer&            m_ipcServer;
-    Buffer                m_buffer;
+    IpcServer& m_ipcServer;
+    Buffer m_buffer;
     std::mutex m_bufferMutex;
-    bool                m_sending;
-    Thread*                m_bufferThread;
-    bool                m_running;
+    bool m_sending;
+    Thread* m_bufferThread;
+    bool m_running;
     std::condition_variable notify_cv_;
     std::mutex notify_mutex_;
-    bool                m_bufferWaiting;
+    bool m_bufferWaiting;
     IArchMultithread::ThreadID
-                        m_bufferThreadId;
+ m_bufferThreadId;
     std::uint16_t m_bufferMaxSize;
     std::uint16_t m_bufferRateWriteLimit;
-    double                m_bufferRateTimeLimit;
+    double m_bufferRateTimeLimit;
     std::uint16_t m_bufferWriteCount;
-    double                m_bufferRateStart;
-    EIpcClientType        m_clientType;
+    double m_bufferRateStart;
+    EIpcClientType m_clientType;
     std::mutex m_runningMutex;
 };

--- a/src/lib/ipc/IpcMessage.h
+++ b/src/lib/ipc/IpcMessage.h
@@ -46,7 +46,7 @@ public:
     EIpcClientType            clientType() const { return m_clientType; }
 
 private:
-    EIpcClientType            m_clientType;
+    EIpcClientType m_clientType;
 };
 
 class IpcShutdownMessage : public IpcMessage {
@@ -81,5 +81,5 @@ public:
 
 private:
     std::string m_command;
-    bool                m_elevate;
+    bool m_elevate;
 };

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -74,12 +74,12 @@ private:
 private:
     typedef std::list<IpcClientProxy*> ClientList;
 
-    bool                m_mock;
-    IEventQueue*        m_events;
-    SocketMultiplexer*    m_socketMultiplexer;
-    TCPListenSocket*    m_socket;
-    NetworkAddress        m_address;
-    ClientList            m_clients;
+    bool m_mock;
+    IEventQueue* m_events;
+    SocketMultiplexer* m_socketMultiplexer;
+    TCPListenSocket* m_socket;
+    NetworkAddress m_address;
+    ClientList m_clients;
     mutable std::mutex m_clientsMutex;
 
 #ifdef INPUTLEAP_TEST_ENV

--- a/src/lib/ipc/IpcServerProxy.h
+++ b/src/lib/ipc/IpcServerProxy.h
@@ -42,5 +42,5 @@ private:
 
 private:
     inputleap::IStream& m_stream;
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -193,5 +193,5 @@ private:
     static void threadFunc(const std::function<void()>& func);
 
 private:
-    ArchThread            m_thread;
+    ArchThread m_thread;
 };

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -116,7 +116,7 @@ private:
     void                checkPort();
 
 private:
-    ArchNetAddress        m_address;
+    ArchNetAddress m_address;
     std::string m_hostname;
-    int                    m_port;
+    int m_port;
 };

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -93,9 +93,9 @@ private:
     // by it.
     std::mutex ssl_mutex_;
 
-    Ssl*                m_ssl;
-    bool                m_secureReady;
-    bool                m_fatal;
+    Ssl* m_ssl;
+    bool m_secureReady;
+    bool m_fatal;
     ConnectionSecurityLevel security_level_ = ConnectionSecurityLevel::ENCRYPTED;
 
     int secure_accept_retry_ = 0; // used only in secureAccept()

--- a/src/lib/net/SocketMultiplexer.h
+++ b/src/lib/net/SocketMultiplexer.h
@@ -96,8 +96,8 @@ private:
 
 private:
     std::mutex mutex_;
-    Thread*                m_thread;
-    bool                m_update;
+    Thread* m_thread;
+    bool m_update;
     std::condition_variable cv_jobs_ready_;
     bool jobs_are_ready_ = false;
 
@@ -107,9 +107,9 @@ private:
     std::condition_variable cv_job_list_lock_locked_;
     bool job_list_lock_lock_is_locked_ = false;
 
-    Thread*                m_jobListLocker;
-    Thread*                m_jobListLockLocker;
+    Thread* m_jobListLocker;
+    Thread* m_jobListLockLocker;
 
-    SocketJobs            m_socketJobs;
-    SocketJobMap        m_socketJobMap;
+    SocketJobs m_socketJobs;
+    SocketJobMap m_socketJobMap;
 };

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -51,8 +51,8 @@ public:
     MultiplexerJobStatus serviceListening(ISocketMultiplexerJob*, bool, bool, bool);
 
 protected:
-    ArchSocket            m_socket;
+    ArchSocket m_socket;
     std::mutex mutex_;
-    IEventQueue*        m_events;
-    SocketMultiplexer*    m_socketMultiplexer;
+    IEventQueue* m_events;
+    SocketMultiplexer* m_socketMultiplexer;
 };

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -96,17 +96,17 @@ private:
     MultiplexerJobStatus serviceConnected(ISocketMultiplexerJob*, bool, bool, bool);
 
 protected:
-    bool                m_readable;
-    bool                m_writable;
-    bool                m_connected;
-    IEventQueue*        m_events;
-    StreamBuffer        m_inputBuffer;
-    StreamBuffer        m_outputBuffer;
+    bool m_readable;
+    bool m_writable;
+    bool m_connected;
+    IEventQueue* m_events;
+    StreamBuffer m_inputBuffer;
+    StreamBuffer m_outputBuffer;
 
     mutable std::mutex tcp_mutex_;
 private:
-    ArchSocket            m_socket;
+    ArchSocket m_socket;
     std::condition_variable flushed_cv_;
     bool is_flushed_ = true;
-    SocketMultiplexer*    m_socketMultiplexer;
+    SocketMultiplexer* m_socketMultiplexer;
 };

--- a/src/lib/net/TCPSocketFactory.h
+++ b/src/lib/net/TCPSocketFactory.h
@@ -38,6 +38,6 @@ public:
                                         ConnectionSecurityLevel security_level) const override;
 
 private:
-    IEventQueue*        m_events;
-    SocketMultiplexer*    m_socketMultiplexer;
+    IEventQueue* m_events;
+    SocketMultiplexer* m_socketMultiplexer;
 };

--- a/src/lib/net/TSocketMultiplexerMethodJob.h
+++ b/src/lib/net/TSocketMultiplexerMethodJob.h
@@ -59,9 +59,9 @@ public:
 
 private:
     RunFunction func_;
-    ArchSocket            m_socket;
-    bool                m_readable;
-    bool                m_writable;
+    ArchSocket m_socket;
+    bool m_readable;
+    bool m_writable;
 };
 
 

--- a/src/lib/net/XSocket.h
+++ b/src/lib/net/XSocket.h
@@ -61,9 +61,9 @@ protected:
     std::string getWhat() const noexcept override;
 
 private:
-    EError                m_error;
+    EError m_error;
     std::string m_hostname;
-    int                    m_port;
+    int m_port;
 };
 
 //! I/O closing exception

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -76,9 +76,9 @@ private:
 private:
     typedef std::vector<IMSWindowsClipboardConverter*> ConverterList;
 
-    HWND                m_window;
-    mutable Time        m_time;
-    ConverterList        m_converters;
+    HWND m_window;
+    mutable Time m_time;
+    ConverterList m_converters;
     static UINT            s_ownershipFormat;
     IMSWindowsClipboardFacade* m_facade;
     bool m_deleteFacade;

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.h
@@ -41,5 +41,5 @@ private:
     std::string findArg(const std::string& data, const std::string& name) const;
 
 private:
-    UINT                m_format;
+    UINT m_format;
 };

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -195,13 +195,13 @@ private:
     class Desk {
     public:
         std::string m_name;
-        Thread*        m_thread;
-        DWORD            m_threadID;
-        DWORD            m_targetID;
-        HDESK            m_desk;
-        HWND            m_window;
-        HWND            m_foregroundWindow;
-        bool            m_lowLevel;
+        Thread* m_thread;
+        DWORD m_threadID;
+        DWORD m_targetID;
+        HDESK m_desk;
+        HWND m_window;
+        HWND m_foregroundWindow;
+        bool m_lowLevel;
     };
     typedef std::map<std::string, Desk*> Desks;
 
@@ -245,17 +245,17 @@ private:
 
 private:
     // true if screen is being used as a primary screen, false otherwise
-    bool                m_isPrimary;
+    bool m_isPrimary;
 
     // true if hooks are not to be installed (useful for debugging)
-    bool                m_noHooks;
+    bool m_noHooks;
 
     // true if mouse has entered the screen
-    bool                m_isOnScreen;
+    bool m_isOnScreen;
 
     // our resources
-    ATOM                m_deskClass;
-    HCURSOR                m_cursor;
+    ATOM m_deskClass;
+    HCURSOR m_cursor;
 
     // screen shape stuff
     std::int32_t m_x, m_y;
@@ -263,35 +263,35 @@ private:
     std::int32_t m_xCenter, m_yCenter;
 
     // true if system appears to have multiple monitors
-    bool                m_multimon;
+    bool m_multimon;
 
     // the timer used to check for desktop switching
-    EventQueueTimer*    m_timer;
+    EventQueueTimer* m_timer;
 
     // screen saver stuff
-    DWORD                m_threadID;
-    const IScreenSaver*    m_screensaver;
-    bool                m_screensaverNotify;
+    DWORD m_threadID;
+    const IScreenSaver* m_screensaver;
+    bool m_screensaverNotify;
 
     // the current desk and it's name
-    Desk*                m_activeDesk;
+    Desk* m_activeDesk;
     std::string m_activeDeskName;
 
     // one desk per desktop and a cond var to communicate with it
     mutable std::mutex mutex_;
     mutable std::condition_variable desks_ready_cv_;
     bool is_desks_ready_ = false;
-    Desks                m_desks;
+    Desks m_desks;
 
     // keyboard stuff
     std::function<void()> m_updateKeys;
-    HKL                    m_keyLayout;
+    HKL m_keyLayout;
 
     // options
-    bool                m_leaveForegroundOption;
+    bool m_leaveForegroundOption;
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 
     // true if program should stop on desk switch.
-    bool                m_stopOnDeskSwitch;
+    bool m_stopOnDeskSwitch;
 };

--- a/src/lib/platform/MSWindowsDropTarget.h
+++ b/src/lib/platform/MSWindowsDropTarget.h
@@ -50,9 +50,9 @@ public:
 private:
     bool                queryDataObject(IDataObject* dataObject);
 
-    long                m_refCount;
-    bool                m_allowDrop;
-    std::string            m_dragFilename;
+    long m_refCount;
+    bool m_allowDrop;
+    std::string m_dragFilename;
 
     static MSWindowsDropTarget*
                         s_instance;

--- a/src/lib/platform/MSWindowsEventQueueBuffer.h
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.h
@@ -42,10 +42,10 @@ public:
     virtual void        deleteTimer(EventQueueTimer*) const;
 
 private:
-    DWORD                m_thread;
-    UINT                m_userEvent;
-    MSG                    m_event;
-    UINT                m_daemonQuit;
-    IEventQueue*        m_events;
-    UINT                m_os_supported_message_types;
+    DWORD m_thread;
+    UINT m_userEvent;
+    MSG m_event;
+    UINT m_daemonQuit;
+    IEventQueue* m_events;
+    UINT m_os_supported_message_types;
 };

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -232,8 +232,8 @@ private:
         bool            operator<(const HotKeyItem&) const;
 
     private:
-        UINT            m_keycode;
-        UINT            m_mask;
+        UINT m_keycode;
+        UINT m_mask;
     };
     typedef std::map<std::uint32_t, HotKeyItem> HotKeyMap;
     typedef std::vector<std::uint32_t> HotKeyIDList;
@@ -243,16 +243,16 @@ private:
     static HINSTANCE    s_windowInstance;
 
     // true if screen is being used as a primary screen, false otherwise
-    bool                m_isPrimary;
+    bool m_isPrimary;
 
     // true if hooks are not to be installed (useful for debugging)
-    bool                m_noHooks;
+    bool m_noHooks;
 
     // true if mouse has entered the screen
-    bool                m_isOnScreen;
+    bool m_isOnScreen;
 
     // our resources
-    ATOM                m_class;
+    ATOM m_class;
 
     // screen shape stuff
     std::int32_t m_x, m_y;
@@ -260,7 +260,7 @@ private:
     std::int32_t m_xCenter, m_yCenter;
 
     // true if system appears to have multiple monitors
-    bool                m_multimon;
+    bool m_multimon;
 
     // last mouse position
     std::int32_t m_xCursor, m_yCursor;
@@ -273,39 +273,38 @@ private:
     std::uint32_t m_markReceived;
 
     // the main loop's thread id
-    DWORD                m_threadID;
+    DWORD m_threadID;
 
     // timer for periodically checking stuff that requires polling
-    EventQueueTimer*    m_fixTimer;
+    EventQueueTimer* m_fixTimer;
 
     // the keyboard layout to use when off primary screen
-    HKL                    m_keyLayout;
+    HKL m_keyLayout;
 
     // screen saver stuff
-    MSWindowsScreenSaver*
-                        m_screensaver;
-    bool                m_screensaverNotify;
-    bool                m_screensaverActive;
+    MSWindowsScreenSaver* m_screensaver;
+    bool m_screensaverNotify;
+    bool m_screensaverActive;
 
     // clipboard stuff.  our window is used mainly as a clipboard
     // owner and as a link in the clipboard viewer chain.
-    HWND                m_window;
-    HWND                m_nextClipboardWindow;
-    bool                m_ownClipboard;
+    HWND m_window;
+    HWND m_nextClipboardWindow;
+    bool m_ownClipboard;
 
     // one desk per desktop and a cond var to communicate with it
-    MSWindowsDesks*    m_desks;
+    MSWindowsDesks* m_desks;
 
     // keyboard stuff
-    MSWindowsKeyState*    m_keyState;
+    MSWindowsKeyState* m_keyState;
 
     // hot key stuff
-    HotKeyMap            m_hotKeys;
-    HotKeyIDList        m_oldHotKeyIDs;
-    HotKeyToIDMap        m_hotKeyToIDMap;
+    HotKeyMap m_hotKeys;
+    HotKeyIDList m_oldHotKeyIDs;
+    HotKeyToIDMap m_hotKeyToIDMap;
 
     // map of button state
-    bool                m_buttons[NumButtonIDs];
+    bool m_buttons[NumButtonIDs];
 
     // the system shows the mouse cursor when an internal display count
     // is >= 0.  this count is maintained per application but there's
@@ -318,27 +317,26 @@ private:
     // MouseKeys is simulating one.  we track this so we can force the
     // cursor to be displayed when the user has entered this screen.
     // m_showingMouse is true when we're doing that.
-    bool                m_hasMouse;
-    bool                m_showingMouse;
-    bool                m_gotOldMouseKeys;
-    MOUSEKEYS            m_mouseKeys;
-    MOUSEKEYS            m_oldMouseKeys;
+    bool m_hasMouse;
+    bool m_showingMouse;
+    bool m_gotOldMouseKeys;
+    MOUSEKEYS m_mouseKeys;
+    MOUSEKEYS m_oldMouseKeys;
 
-    MSWindowsHook        m_hook;
+    MSWindowsHook m_hook;
 
     static MSWindowsScreen*
                         s_screen;
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 
     mutable std::string m_dropTargetPath;
 
-    MSWindowsDropTarget*
-                        m_dropTarget;
-    HWND                m_dropWindow;
-    const int            m_dropWindowSize;
+    MSWindowsDropTarget* m_dropTarget;
+    HWND m_dropWindow;
+    const int m_dropWindowSize;
 
-    Thread*            m_sendDragThread;
+    Thread* m_sendDragThread;
 
-    PrimaryKeyDownList    m_primaryKeyDownList;
+    PrimaryKeyDownList m_primaryKeyDownList;
 };

--- a/src/lib/platform/MSWindowsScreenSaver.h
+++ b/src/lib/platform/MSWindowsScreenSaver.h
@@ -55,8 +55,8 @@ public:
 private:
     class FindScreenSaverInfo {
     public:
-        HDESK            m_desktop;
-        HWND            m_window;
+        HDESK m_desktop;
+        HWND m_window;
     };
 
     static BOOL CALLBACK    killScreenSaverFunc(HWND hwnd, LPARAM lParam);
@@ -71,18 +71,18 @@ private:
     bool                isSecure(bool* wasSecureAnInt) const;
 
 private:
-    BOOL                m_wasEnabled;
-    bool                m_wasSecure;
-    bool                m_wasSecureAnInt;
+    BOOL m_wasEnabled;
+    bool m_wasSecure;
+    bool m_wasSecureAnInt;
 
-    HANDLE                m_process;
-    Thread*            m_watch;
-    DWORD                m_threadID;
-    UINT                m_msg;
-    WPARAM                m_wParam;
-    LPARAM                m_lParam;
+    HANDLE m_process;
+    Thread* m_watch;
+    DWORD m_threadID;
+    UINT m_msg;
+    WPARAM m_wParam;
+    LPARAM m_lParam;
 
     // checkActive state.  true if the screen saver is being watched
     // for deactivation (and is therefore active).
-    bool                m_active;
+    bool m_active;
 };

--- a/src/lib/platform/MSWindowsSession.h
+++ b/src/lib/platform/MSWindowsSession.h
@@ -48,5 +48,5 @@ private:
     BOOL                nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry);
 
 private:
-    DWORD                m_activeSessionId;
+    DWORD m_activeSessionId;
 };

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -59,24 +59,24 @@ private:
     BOOL doStartProcessAsSelf(std::string& command);
 
 private:
-    Thread*                m_thread;
-    bool                m_autoDetectCommand;
-    std::string            m_command;
-    bool                m_monitoring;
-    bool                m_commandChanged;
-    HANDLE                m_stdOutWrite;
-    HANDLE                m_stdOutRead;
-    Thread*                m_outputThread;
-    IpcServer&            m_ipcServer;
-    IpcLogOutputter&    m_ipcLogOutputter;
-    bool                m_elevateProcess;
-    MSWindowsSession    m_session;
+    Thread* m_thread;
+    bool m_autoDetectCommand;
+    std::string m_command;
+    bool m_monitoring;
+    bool m_commandChanged;
+    HANDLE m_stdOutWrite;
+    HANDLE m_stdOutRead;
+    Thread* m_outputThread;
+    IpcServer& m_ipcServer;
+    IpcLogOutputter& m_ipcLogOutputter;
+    bool m_elevateProcess;
+    MSWindowsSession m_session;
     PROCESS_INFORMATION m_processInfo;
-    int                    m_processFailures;
-    bool                m_processRunning;
-    FileLogOutputter*    m_fileLogOutputter;
-    bool                m_autoElevated;
-    bool                m_daemonized;
+    int m_processFailures;
+    bool m_processRunning;
+    FileLogOutputter* m_fileLogOutputter;
+    bool m_autoElevated;
+    bool m_daemonized;
 };
 
 //! Relauncher error

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -51,9 +51,9 @@ private:
 private:
     typedef std::vector<IOSXClipboardConverter*> ConverterList;
 
-    mutable Time        m_time;
-    ConverterList        m_converters;
-    PasteboardRef        m_pboard;
+    mutable Time m_time;
+    ConverterList m_converters;
+    PasteboardRef m_pboard;
 };
 
 //! Clipboard format converter interface

--- a/src/lib/platform/OSXDragView.h
+++ b/src/lib/platform/OSXDragView.h
@@ -21,8 +21,8 @@
 
 @interface OSXDragView : NSView<NSDraggingSource,NSDraggingInfo>
 {
-    NSMutableString*    m_dropTarget;
-    NSString*    m_dragFileExt;
+    NSMutableString* m_dropTarget;
+    NSString* m_dragFileExt;
 }
 
 - (CFStringRef)getDropTarget;

--- a/src/lib/platform/OSXEventQueueBuffer.h
+++ b/src/lib/platform/OSXEventQueueBuffer.h
@@ -41,7 +41,7 @@ public:
     virtual void        deleteTimer(EventQueueTimer*) const;
 
 private:
-    EventRef            m_event;
-    IEventQueue*        m_eventQueue;
-    EventQueueRef        m_carbonEventQueue;
+    EventRef m_event;
+    IEventQueue* m_eventQueue;
+    EventQueueRef m_carbonEventQueue;
 };

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -163,13 +163,13 @@ private:
     typedef std::map<CFDataRef, std::int32_t> GroupMap;
     typedef std::map<std::uint32_t, KeyID> VirtualKeyMap;
 
-    VirtualKeyMap        m_virtualKeyMap;
+    VirtualKeyMap m_virtualKeyMap;
     mutable std::uint32_t m_deadKeyState;
-    GroupList            m_groups;
-    GroupMap            m_groupMap;
-    bool                m_shiftPressed;
-    bool                m_controlPressed;
-    bool                m_altPressed;
-    bool                m_superPressed;
-    bool                m_capsPressed;
+    GroupList m_groups;
+    GroupMap m_groupMap;
+    bool m_shiftPressed;
+    bool m_controlPressed;
+    bool m_altPressed;
+    bool m_superPressed;
+    bool m_capsPressed;
 };

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -212,7 +212,7 @@ private:
         bool            operator<(const HotKeyItem&) const;
 
     private:
-        EventHotKeyRef    m_ref;
+        EventHotKeyRef m_ref;
         std::uint32_t m_keycode;
         std::uint32_t m_mask;
     };
@@ -235,7 +235,7 @@ private:
         bool test(std::uint32_t button) const;
         std::int8_t getFirstButtonDown() const;
     private:
-        std::bitset<NumButtonIDs>      m_buttons;
+        std::bitset<NumButtonIDs> m_buttons;
     };
 
     typedef std::map<std::uint32_t, HotKeyItem> HotKeyMap;
@@ -244,13 +244,13 @@ private:
     typedef std::map<HotKeyItem, std::uint32_t> HotKeyToIDMap;
 
     // true if screen is being used as a primary screen, false otherwise
-    bool                m_isPrimary;
+    bool m_isPrimary;
 
     // true if mouse has entered the screen
-    bool                m_isOnScreen;
+    bool m_isOnScreen;
 
     // the display
-    CGDirectDisplayID    m_displayID;
+    CGDirectDisplayID m_displayID;
 
     // screen shape stuff
     std::int32_t m_x, m_y;
@@ -259,7 +259,7 @@ private:
 
     // mouse state
     mutable std::int32_t m_xCursor, m_yCursor;
-    mutable bool        m_cursorPosValid;
+    mutable bool m_cursorPosValid;
 
     /* FIXME: this data structure is explicitly marked mutable due
        to a need to track the state of buttons since the remote
@@ -271,72 +271,72 @@ private:
     typedef std::map<std::uint16_t, CGEventType> MouseButtonEventMapType;
     std::vector<MouseButtonEventMapType> MouseButtonEventMap;
 
-    bool                m_cursorHidden;
+    bool m_cursorHidden;
     std::int32_t m_dragNumButtonsDown;
-    Point                m_dragLastPoint;
-    EventQueueTimer*    m_dragTimer;
+    Point m_dragLastPoint;
+    EventQueueTimer* m_dragTimer;
 
     // keyboard stuff
-    OSXKeyState*        m_keyState;
+    OSXKeyState* m_keyState;
 
     // clipboards
-    OSXClipboard       m_pasteboard;
+    OSXClipboard m_pasteboard;
     std::uint32_t m_sequenceNumber;
 
     // screen saver stuff
-    OSXScreenSaver*    m_screensaver;
-    bool                m_screensaverNotify;
+    OSXScreenSaver* m_screensaver;
+    bool m_screensaverNotify;
 
     // clipboard stuff
-    bool                m_ownClipboard;
-    EventQueueTimer*    m_clipboardTimer;
+    bool m_ownClipboard;
+    EventQueueTimer* m_clipboardTimer;
 
     // window object that gets user input events when the server
     // has focus.
-    WindowRef            m_hiddenWindow;
+    WindowRef m_hiddenWindow;
     // window object that gets user input events when the server
     // does not have focus.
-    WindowRef            m_userInputWindow;
+    WindowRef m_userInputWindow;
 
     // fast user switching
-    EventHandlerRef            m_switchEventHandlerRef;
+    EventHandlerRef m_switchEventHandlerRef;
 
     // sleep / wakeup
     std::mutex pm_mutex_;
-    Thread*                m_pmWatchThread;
+    Thread* m_pmWatchThread;
     std::condition_variable pm_thread_ready_cv_;
     bool is_pm_thread_ready_ = false;
-    CFRunLoopRef            m_pmRunloop;
-    io_connect_t            m_pmRootPort;
+    CFRunLoopRef m_pmRunloop;
+    io_connect_t m_pmRootPort;
 
     // hot key stuff
-    HotKeyMap                m_hotKeys;
-    HotKeyIDList            m_oldHotKeyIDs;
-    ModifierHotKeyMap        m_modifierHotKeys;
+    HotKeyMap m_hotKeys;
+    HotKeyIDList m_oldHotKeyIDs;
+    ModifierHotKeyMap m_modifierHotKeys;
     std::uint32_t m_activeModifierHotKey;
-    KeyModifierMask            m_activeModifierHotKeyMask;
-    HotKeyToIDMap            m_hotKeyToIDMap;
+    KeyModifierMask m_activeModifierHotKeyMask;
+    HotKeyToIDMap m_hotKeyToIDMap;
 
     // global hotkey operating mode
     static bool                s_testedForGHOM;
     static bool                s_hasGHOM;
 
     // Quartz input event support
-    CFMachPortRef            m_eventTapPort;
-    CFRunLoopSourceRef        m_eventTapRLSR;
+    CFMachPortRef m_eventTapPort;
+    CFRunLoopSourceRef m_eventTapRLSR;
 
     // for double click coalescing.
-    double                    m_lastClickTime;
-    int                     m_clickState;
+    double m_lastClickTime;
+    int m_clickState;
     std::int32_t m_lastSingleClickXCursor;
     std::int32_t m_lastSingleClickYCursor;
 
     // cursor will hide and show on enable and disable if true.
-    bool                    m_autoShowHideCursor;
+    bool m_autoShowHideCursor;
 
-    IEventQueue*            m_events;
+    IEventQueue* m_events;
 
-    Thread*                m_getDropTargetThread;
+    Thread* m_getDropTargetThread;
     std::string m_dropTarget;
 
 #if defined(MAC_OS_X_VERSION_10_7)
@@ -345,5 +345,5 @@ private:
     bool is_carbon_loop_ready_ = false;
 #endif
 
-    class OSXScreenImpl*    m_impl;
+    class OSXScreenImpl* m_impl;
 };

--- a/src/lib/platform/OSXScreenSaver.h
+++ b/src/lib/platform/OSXScreenSaver.h
@@ -48,12 +48,12 @@ private:
 
 private:
     // the target for the events we generate
-    void*                m_eventTarget;
+    void* m_eventTarget;
 
-    bool                m_enabled;
-    void*                m_screenSaverController;
-    void*                m_autoReleasePool;
-    EventHandlerRef        m_launchTerminationEventHandlerRef;
-    ProcessSerialNumber    m_screenSaverPSN;
-    IEventQueue*        m_events;
+    bool m_enabled;
+    void* m_screenSaverController;
+    void* m_autoReleasePool;
+    EventHandlerRef m_launchTerminationEventHandlerRef;
+    ProcessSerialNumber m_screenSaverPSN;
+    IEventQueue* m_events;
 };

--- a/src/lib/platform/OSXUchrKeyResource.h
+++ b/src/lib/platform/OSXUchrKeyResource.h
@@ -44,11 +44,11 @@ private:
     bool            addSequence(KeySequence& keys, UCKeyCharSeq c) const;
 
 private:
-    const UCKeyboardLayout*            m_resource;
-    const UCKeyModifiersToTableNum*    m_m;
-    const UCKeyToCharTableIndex*    m_cti;
-    const UCKeySequenceDataIndex*    m_sdi;
-    const UCKeyStateRecordsIndex*    m_sri;
-    const UCKeyStateTerminators*    m_st;
+    const UCKeyboardLayout* m_resource;
+    const UCKeyModifiersToTableNum* m_m;
+    const UCKeyToCharTableIndex* m_cti;
+    const UCKeySequenceDataIndex* m_sdi;
+    const UCKeyStateRecordsIndex* m_sri;
+    const UCKeyStateTerminators* m_st;
     std::uint16_t m_spaceOutput;
 };

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -150,30 +150,30 @@ private:
         bool            processEvent(Display* display, XEvent* event);
 
     private:
-        Window            m_requestor;
-        Time            m_time;
-        Atom            m_property;
-        bool            m_incr;
-        bool            m_failed;
-        bool            m_done;
+        Window m_requestor;
+        Time m_time;
+        Atom m_property;
+        bool m_incr;
+        bool m_failed;
+        bool m_done;
 
         // atoms needed for the protocol
-        Atom            m_atomNone;        // NONE, not None
-        Atom            m_atomIncr;
+        Atom m_atomNone;        // NONE, not None
+        Atom m_atomIncr;
 
         // true iff we've received the selection notify
-        bool            m_reading;
+        bool m_reading;
 
         // the converted selection data
         std::string* m_data;
 
         // the actual type of the data.  if this is None then the
         // selection owner cannot convert to the requested type.
-        Atom*            m_actualTarget;
+        Atom* m_actualTarget;
 
     public:
         // true iff the selection owner didn't follow ICCCM conventions
-        bool            m_error;
+        bool m_error;
     };
 
     // Motif structure IDs
@@ -225,21 +225,21 @@ private:
 
     public:
         // information about the request
-        Window            m_requestor;
-        Atom            m_target;
-        ::Time            m_time;
-        Atom            m_property;
+        Window m_requestor;
+        Atom m_target;
+        ::Time m_time;
+        Atom m_property;
 
         // true iff we've sent the notification for this reply
-        bool            m_replied;
+        bool m_replied;
 
         // true iff the reply has sent its last message
-        bool            m_done;
+        bool m_done;
 
         // the data to send and its type and format
         std::string m_data;
-        Atom            m_type;
-        int                m_format;
+        Atom m_type;
+        int m_format;
 
         // index of next byte in m_data to send
         std::uint32_t m_ptr;
@@ -280,48 +280,48 @@ private:
 
 private:
     typedef std::vector<IXWindowsClipboardConverter*> ConverterList;
-    IXWindowsImpl*       m_impl;
+    IXWindowsImpl* m_impl;
 
-    Display*            m_display;
-    Window                m_window;
-    ClipboardID            m_id;
-    Atom                m_selection;
-    mutable bool        m_open;
-    mutable Time        m_time;
-    bool                m_owner;
-    mutable Time        m_timeOwned;
-    Time                m_timeLost;
+    Display* m_display;
+    Window m_window;
+    ClipboardID m_id;
+    Atom m_selection;
+    mutable bool m_open;
+    mutable Time m_time;
+    bool m_owner;
+    mutable Time m_timeOwned;
+    Time m_timeLost;
 
     // true iff open and clipboard owned by a motif app
-    mutable bool        m_motif;
+    mutable bool m_motif;
 
     // the added/cached clipboard data
-    mutable bool        m_checkCache;
-    bool                m_cached;
-    Time                m_cacheTime;
-    bool                m_added[kNumFormats];
+    mutable bool m_checkCache;
+    bool m_cached;
+    Time m_cacheTime;
+    bool m_added[kNumFormats];
     std::string m_data[kNumFormats];
 
     // conversion request replies
-    ReplyMap            m_replies;
-    ReplyEventMask        m_eventMasks;
+    ReplyMap m_replies;
+    ReplyEventMask m_eventMasks;
 
     // clipboard format converters
-    ConverterList        m_converters;
+    ConverterList m_converters;
 
     // atoms we'll need
-    Atom                m_atomTargets;
-    Atom                m_atomMultiple;
-    Atom                m_atomTimestamp;
-    Atom                m_atomInteger;
-    Atom                m_atomAtom;
-    Atom                m_atomAtomPair;
-    Atom                m_atomData;
-    Atom                m_atomINCR;
-    Atom                m_atomMotifClipLock;
-    Atom                m_atomMotifClipHeader;
-    Atom                m_atomMotifClipAccess;
-    Atom                m_atomGDKSelection;
+    Atom m_atomTargets;
+    Atom m_atomMultiple;
+    Atom m_atomTimestamp;
+    Atom m_atomInteger;
+    Atom m_atomAtom;
+    Atom m_atomAtomPair;
+    Atom m_atomData;
+    Atom m_atomINCR;
+    Atom m_atomMotifClipLock;
+    Atom m_atomMotifClipHeader;
+    Atom m_atomMotifClipAccess;
+    Atom m_atomGDKSelection;
 };
 
 //! Clipboard format converter interface

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -35,5 +35,5 @@ public:
     std::string toIClipboard(const std::string&) const override;
 
 private:
-    Atom                m_atom;
+    Atom m_atom;
 };

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.h
@@ -37,5 +37,5 @@ public:
     std::string toIClipboard(const std::string&) const override;
 
 private:
-    Atom                m_atom;
+    Atom m_atom;
 };

--- a/src/lib/platform/XWindowsClipboardTextConverter.h
+++ b/src/lib/platform/XWindowsClipboardTextConverter.h
@@ -37,5 +37,5 @@ public:
     std::string toIClipboard(const std::string&) const override;
 
 private:
-    Atom                m_atom;
+    Atom m_atom;
 };

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.h
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.h
@@ -37,5 +37,5 @@ public:
     std::string toIClipboard(const std::string&) const override;
 
 private:
-    Atom                m_atom;
+    Atom m_atom;
 };

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -37,5 +37,5 @@ public:
     std::string toIClipboard(const std::string&) const override;
 
 private:
-    Atom                m_atom;
+    Atom m_atom;
 };

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -52,15 +52,15 @@ private:
 
 private:
     typedef std::vector<XEvent> EventList;
-    IXWindowsImpl*      m_impl;
+    IXWindowsImpl* m_impl;
 
     mutable std::mutex  mutex_;
-    Display*            m_display;
-    Window              m_window;
-    Atom                m_userEvent;
-    XEvent              m_event;
-    EventList           m_postedEvents;
-    bool                m_waiting;
-    int                 m_pipefd[2];
-    IEventQueue*        m_events;
+    Display* m_display;
+    Window m_window;
+    Atom m_userEvent;
+    XEvent m_event;
+    EventList m_postedEvents;
+    bool m_waiting;
+    int m_pipefd[2];
+    IEventQueue* m_events;
 };

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -121,9 +121,9 @@ private:
 private:
     struct XKBModifierInfo {
     public:
-        unsigned char    m_level;
+        unsigned char m_level;
         std::uint32_t m_mask;
-        bool            m_lock;
+        bool m_lock;
     };
 
 #ifdef INPUTLEAP_TEST_ENV
@@ -139,23 +139,23 @@ private:
 
     IXWindowsImpl* m_impl;
 
-    Display*            m_display;
-    XkbDescPtr            m_xkb;
+    Display* m_display;
+    XkbDescPtr m_xkb;
     std::int32_t m_group;
-    XKBModifierMap        m_lastGoodXKBModifiers;
-    NonXKBModifierMap    m_lastGoodNonXKBModifiers;
+    XKBModifierMap m_lastGoodXKBModifiers;
+    NonXKBModifierMap m_lastGoodNonXKBModifiers;
 
     // X modifier (bit number) to barrier modifier (mask) mapping
-    KeyModifierMaskList    m_modifierFromX;
+    KeyModifierMaskList m_modifierFromX;
 
     // barrier modifier (mask) to X modifier (mask)
-    KeyModifierToXMask    m_modifierToX;
+    KeyModifierToXMask m_modifierToX;
 
     // map KeyID to all keycodes that can synthesize that KeyID
-    KeyToKeyCodeMap        m_keyCodeFromKey;
+    KeyToKeyCodeMap m_keyCodeFromKey;
 
     // autorepeat state
-    XKeyboardState        m_keyboardState;
+    XKeyboardState m_keyboardState;
 
 #ifdef INPUTLEAP_TEST_ENV
 public:

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -115,10 +115,10 @@ private:
 private:
     class KeyEventFilter {
     public:
-        int             m_event;
-        Window          m_window;
-        Time            m_time;
-        KeyCode         m_keycode;
+        int m_event;
+        Window m_window;
+        Time m_time;
+        KeyCode m_keycode;
     };
 
     Display*            openDisplay(const char* displayName);
@@ -162,8 +162,8 @@ private:
         bool            operator<(const HotKeyItem&) const;
 
     private:
-        int             m_keycode;
-        unsigned int    m_mask;
+        int m_keycode;
+        unsigned int m_mask;
     };
     typedef std::set<bool> FilteredKeycodes;
     typedef std::vector<std::pair<int, unsigned int> > HotKeyList;
@@ -171,91 +171,91 @@ private:
     typedef std::vector<std::uint32_t> HotKeyIDList;
     typedef std::map<HotKeyItem, std::uint32_t> HotKeyToIDMap;
 
-    IXWindowsImpl*      m_impl;
+    IXWindowsImpl* m_impl;
 
     // true if screen is being used as a primary screen, false otherwise
-    bool                m_isPrimary;
+    bool m_isPrimary;
 
     // The size of a smallest supported scroll event, in points
-    int                 m_mouseScrollDelta;
+    int m_mouseScrollDelta;
 
     // Accumulates scrolls of less than m_?_mouseScrollDelta across multiple
     // scroll events. We dispatch a scroll event whenever the accumulated scroll
     // becomes larger than m_?_mouseScrollDelta
-    mutable int         m_x_accumulatedScroll;
-    mutable int         m_y_accumulatedScroll;
+    mutable int m_x_accumulatedScroll;
+    mutable int m_y_accumulatedScroll;
 
-    Display*            m_display;
-    Window              m_root;
-    Window              m_window;
+    Display* m_display;
+    Window m_root;
+    Window m_window;
 
     // true if mouse has entered the screen
-    bool                m_isOnScreen;
+    bool m_isOnScreen;
 
     // screen shape stuff
-    std::int32_t        m_x, m_y;
-    std::int32_t        m_w, m_h;
-    std::int32_t        m_xCenter, m_yCenter;
+    std::int32_t m_x, m_y;
+    std::int32_t m_w, m_h;
+    std::int32_t m_xCenter, m_yCenter;
 
     // last mouse position
     std::int32_t m_xCursor, m_yCursor;
 
     // keyboard stuff
-    XWindowsKeyState*   m_keyState;
+    XWindowsKeyState* m_keyState;
 
     // hot key stuff
-    HotKeyMap           m_hotKeys;
-    HotKeyIDList        m_oldHotKeyIDs;
-    HotKeyToIDMap       m_hotKeyToIDMap;
+    HotKeyMap m_hotKeys;
+    HotKeyIDList m_oldHotKeyIDs;
+    HotKeyToIDMap m_hotKeyToIDMap;
 
     // input focus stuff
-    Window              m_lastFocus;
-    int                 m_lastFocusRevert;
+    Window m_lastFocus;
+    int m_lastFocusRevert;
 
     // input method stuff
-    XIM                 m_im;
-    XIC                 m_ic;
-    KeyCode             m_lastKeycode;
-    FilteredKeycodes    m_filtered;
+    XIM m_im;
+    XIC m_ic;
+    KeyCode m_lastKeycode;
+    FilteredKeycodes m_filtered;
 
     // clipboards
-    XWindowsClipboard*  m_clipboard[kClipboardEnd];
-    std::uint32_t       m_sequenceNumber;
+    XWindowsClipboard* m_clipboard[kClipboardEnd];
+    std::uint32_t m_sequenceNumber;
 
     // screen saver stuff
     XWindowsScreenSaver* m_screensaver;
-    bool                m_screensaverNotify;
+    bool m_screensaverNotify;
 
     // logical to physical button mapping.  m_buttons[i] gives the
     // physical button for logical button i+1.
-    std::vector<unsigned char>    m_buttons;
+    std::vector<unsigned char> m_buttons;
 
     // true if global auto-repeat was enabled before we turned it off
-    bool                m_autoRepeat;
+    bool m_autoRepeat;
 
     // stuff to workaround xtest being xinerama unaware.  attempting
     // to fake a mouse motion under xinerama may behave strangely,
     // especially if screen 0 is not at 0,0 or if faking a motion on
     // a screen other than screen 0.
-    bool                m_xtestIsXineramaUnaware;
-    bool                m_xinerama;
+    bool m_xtestIsXineramaUnaware;
+    bool m_xinerama;
 
     // stuff to work around lost focus issues on certain systems
     // (ie: a MythTV front-end).
-    bool                m_preserveFocus;
+    bool m_preserveFocus;
 
     // XKB extension stuff
-    bool                m_xkb;
-    int                 m_xkbEventBase;
+    bool m_xkb;
+    int m_xkbEventBase;
 
-    bool                m_xi2detected;
+    bool m_xi2detected;
 
     // XRandR extension stuff
-    bool                m_xrandr;
-    int                 m_xrandrEventBase;
+    bool m_xrandr;
+    int m_xrandrEventBase;
 
-    IEventQueue*        m_events;
-    inputleap::KeyMap   m_keyMap;
+    IEventQueue* m_events;
+    inputleap::KeyMap m_keyMap;
 
     // pointer to (singleton) screen.  this is only needed by
     // ioErrorHandler().

--- a/src/lib/platform/XWindowsScreenSaver.h
+++ b/src/lib/platform/XWindowsScreenSaver.h
@@ -112,60 +112,60 @@ private:
 private:
     typedef std::map<Window, long> WatchList;
 
-    IXWindowsImpl*       m_impl;
+    IXWindowsImpl* m_impl;
 
     // the X display
-    Display*            m_display;
+    Display* m_display;
 
     // window to receive xscreensaver responses
-    Window                m_xscreensaverSink;
+    Window m_xscreensaverSink;
 
     // the target for the events we generate
-    void*                m_eventTarget;
+    void* m_eventTarget;
 
     // xscreensaver's window
-    Window                m_xscreensaver;
+    Window m_xscreensaver;
 
     // xscreensaver activation state
-    bool                m_xscreensaverActive;
+    bool m_xscreensaverActive;
 
     // old event mask on root window
-    long                m_rootEventMask;
+    long m_rootEventMask;
 
     // potential xscreensaver windows being watched
-    WatchList            m_watchWindows;
+    WatchList m_watchWindows;
 
     // atoms used to communicate with xscreensaver's window
-    Atom                m_atomScreenSaver;
-    Atom                m_atomScreenSaverVersion;
-    Atom                m_atomScreenSaverActivate;
-    Atom                m_atomScreenSaverDeactivate;
+    Atom m_atomScreenSaver;
+    Atom m_atomScreenSaverVersion;
+    Atom m_atomScreenSaverActivate;
+    Atom m_atomScreenSaverDeactivate;
 
     // built-in screen saver settings
-    int                    m_timeout;
-    int                    m_interval;
-    int                    m_preferBlanking;
-    int                    m_allowExposures;
+    int m_timeout;
+    int m_interval;
+    int m_preferBlanking;
+    int m_allowExposures;
 
     // DPMS screen saver settings
-    bool                m_dpms;
-    bool                m_dpmsEnabled;
+    bool m_dpms;
+    bool m_dpmsEnabled;
 
     // true iff the client wants the screen saver suppressed
-    bool                m_disabled;
+    bool m_disabled;
 
     // true iff we're ignoring m_disabled.  this is true, for example,
     // when the client has called activate() and so presumably wants
     // to activate the screen saver even if disabled.
-    bool                m_suppressDisable;
+    bool m_suppressDisable;
 
     // the disable timer (nullptr if not installed)
-    EventQueueTimer*    m_disableTimer;
+    EventQueueTimer* m_disableTimer;
 
     // fake mouse motion position for suppressing the screen saver.
     // xscreensaver since 2.21 requires the mouse to move more than 10
     // pixels to be considered significant.
     std::int32_t m_disablePos;
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -152,19 +152,19 @@ public:
     private:
         typedef int (*XErrorHandler)(Display*, XErrorEvent*);
 
-        Display*        m_display;
-        ErrorHandler    m_handler;
-        void*            m_userData;
-        XErrorHandler    m_oldXHandler;
-        ErrorLock*        m_next;
+        Display* m_display;
+        ErrorHandler m_handler;
+        void* m_userData;
+        XErrorHandler m_oldXHandler;
+        ErrorLock* m_next;
         static ErrorLock*    s_top;
     };
 
 private:
     class PropertyNotifyPredicateInfo {
     public:
-        Window            m_window;
-        Atom            m_property;
+        Window m_window;
+        Atom m_property;
     };
 
     static Bool            propertyNotifyPredicate(Display*,

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -79,12 +79,12 @@ private:
     typedef std::deque<ClientProxy*> WaitingClients;
     typedef std::set<IDataSocket*> ClientSockets;
 
-    IListenSocket*        m_listen;
-    ISocketFactory*        m_socketFactory;
-    NewClients            m_newClients;
-    WaitingClients        m_waitingClients;
-    Server*                m_server;
-    IEventQueue*        m_events;
+    IListenSocket* m_listen;
+    ISocketFactory* m_socketFactory;
+    NewClients m_newClients;
+    WaitingClients m_waitingClients;
+    Server* m_server;
+    IEventQueue* m_events;
     ConnectionSecurityLevel security_level_;
-    ClientSockets      m_clientSockets;
+    ClientSockets m_clientSockets;
 };

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -87,19 +87,19 @@ protected:
         ClientClipboard();
 
     public:
-        Clipboard        m_clipboard;
+        Clipboard m_clipboard;
         std::uint32_t m_sequenceNumber;
-        bool            m_dirty;
+        bool m_dirty;
     };
 
-    ClientClipboard    m_clipboard[kClipboardEnd];
+    ClientClipboard m_clipboard[kClipboardEnd];
 
 private:
     typedef bool (ClientProxy1_0::*MessageParser)(const std::uint8_t*);
 
-    ClientInfo            m_info;
-    double                m_heartbeatAlarm;
-    EventQueueTimer*    m_heartbeatTimer;
-    MessageParser        m_parser;
-    IEventQueue*        m_events;
+    ClientInfo m_info;
+    double m_heartbeatAlarm;
+    EventQueueTimer* m_heartbeatTimer;
+    MessageParser m_parser;
+    IEventQueue* m_events;
 };

--- a/src/lib/server/ClientProxy1_3.h
+++ b/src/lib/server/ClientProxy1_3.h
@@ -42,7 +42,7 @@ protected:
     virtual void        keepAlive();
 
 private:
-    double                m_keepAliveRate;
-    EventQueueTimer*    m_keepAliveTimer;
-    IEventQueue*        m_events;
+    double m_keepAliveRate;
+    EventQueueTimer* m_keepAliveTimer;
+    IEventQueue* m_events;
 };

--- a/src/lib/server/ClientProxy1_4.h
+++ b/src/lib/server/ClientProxy1_4.h
@@ -43,5 +43,5 @@ public:
     void keyUp(KeyID key, KeyModifierMask mask, KeyButton button) override;
     void keepAlive() override;
 
-    Server*            m_server;
+    Server* m_server;
 };

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -37,5 +37,5 @@ public:
     void                dragInfoReceived();
 
 private:
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -36,5 +36,5 @@ private:
     void                handleClipboardSendingEvent(const Event&, void*);
 
 private:
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 };

--- a/src/lib/server/ClientProxyUnknown.h
+++ b/src/lib/server/ClientProxyUnknown.h
@@ -62,10 +62,10 @@ private:
     void                handleReady(const Event&, void*);
 
 private:
-    inputleap::IStream*    m_stream;
-    EventQueueTimer*    m_timer;
-    ClientProxy*        m_proxy;
-    bool                m_ready;
-    Server*                m_server;
-    IEventQueue*        m_events;
+    inputleap::IStream* m_stream;
+    EventQueueTimer* m_timer;
+    ClientProxy* m_proxy;
+    bool m_ready;
+    Server* m_server;
+    IEventQueue* m_events;
 };

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -92,8 +92,8 @@ public:
 
     private:
         std::string m_name;
-        EDirection        m_side;
-        Interval        m_interval;
+        EDirection m_side;
+        Interval m_interval;
     };
 
 private:
@@ -104,7 +104,7 @@ private:
         bool operator==(const std::string& name) const;
 
     private:
-        Config*            m_config;
+        Config* m_config;
         std::string m_name;
     };
 
@@ -134,10 +134,10 @@ private:
         const_iterator    end() const;
 
     private:
-        EdgeLinks        m_neighbors;
+        EdgeLinks m_neighbors;
 
     public:
-        ScreenOptions    m_options;
+        ScreenOptions m_options;
     };
     typedef std::map<std::string, Cell, inputleap::string::CaselessCmp> CellMap;
     typedef std::map<std::string, std::string, inputleap::string::CaselessCmp> NameMap;
@@ -169,7 +169,7 @@ public:
         }
 
     private:
-        internal_const_iterator    m_i;
+        internal_const_iterator m_i;
     };
 
     Config(IEventQueue* events);
@@ -458,13 +458,13 @@ private:
     static std::string getOptionValue(OptionID, OptionValue);
 
 private:
-    CellMap                m_map;
-    NameMap                m_nameToCanonicalName;
-    NetworkAddress        m_barrierAddress;
-    ScreenOptions        m_globalOptions;
-    InputFilter            m_inputFilter;
-    bool                m_hasLockToScreenAction;
-    IEventQueue*        m_events;
+    CellMap m_map;
+    NameMap m_nameToCanonicalName;
+    NetworkAddress m_barrierAddress;
+    ScreenOptions m_globalOptions;
+    InputFilter m_inputFilter;
+    bool m_hasLockToScreenAction;
+    IEventQueue* m_events;
 };
 
 //! Configuration read context
@@ -510,7 +510,7 @@ private:
     static std::string        concatArgs(const ArgList& args);
 
 private:
-    std::istream&        m_stream;
+    std::istream& m_stream;
     std::int32_t m_line;
 };
 
@@ -529,5 +529,5 @@ protected:
     std::string getWhat() const noexcept override;
 
 private:
-    std::string                m_error;
+    std::string m_error;
 };

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -73,9 +73,9 @@ public:
 
     private:
         std::uint32_t m_id;
-        KeyID                    m_key;
-        KeyModifierMask            m_mask;
-        IEventQueue*            m_events;
+        KeyID m_key;
+        KeyModifierMask m_mask;
+        IEventQueue* m_events;
     };
 
     // MouseButtonCondition
@@ -94,9 +94,9 @@ public:
         EFilterStatus match(const Event&) override;
 
     private:
-        ButtonID                m_button;
-        KeyModifierMask            m_mask;
-        IEventQueue*            m_events;
+        ButtonID m_button;
+        KeyModifierMask m_mask;
+        IEventQueue* m_events;
     };
 
     // ScreenConnectedCondition
@@ -112,7 +112,7 @@ public:
 
     private:
         std::string m_screen;
-        IEventQueue*            m_events;
+        IEventQueue* m_events;
     };
 
     // -------------------------------------------------------------------------
@@ -145,8 +145,8 @@ public:
         void perform(const Event&) override;
 
     private:
-        Mode                    m_mode;
-        IEventQueue*            m_events;
+        Mode m_mode;
+        IEventQueue* m_events;
     };
 
     // SwitchToScreenAction
@@ -162,8 +162,8 @@ public:
         void perform(const Event&) override;
 
     private:
-        std::string                    m_screen;
-        IEventQueue*            m_events;
+        std::string m_screen;
+        IEventQueue* m_events;
     };
 
     // ToggleScreenAction
@@ -193,8 +193,8 @@ public:
         void perform(const Event&) override;
 
     private:
-        EDirection                m_direction;
-        IEventQueue*            m_events;
+        EDirection m_direction;
+        IEventQueue* m_events;
     };
 
     // KeyboardBroadcastAction
@@ -214,9 +214,9 @@ public:
         void perform(const Event&) override;
 
     private:
-        Mode                    m_mode;
-        std::string                    m_screens;
-        IEventQueue*            m_events;
+        Mode m_mode;
+        std::string m_screens;
+        IEventQueue* m_events;
     };
 
     // KeystrokeAction
@@ -239,9 +239,9 @@ public:
         virtual const char*        formatName() const;
 
     private:
-        IPlatformScreen::KeyInfo*    m_keyInfo;
-        bool                    m_press;
-        IEventQueue*            m_events;
+        IPlatformScreen::KeyInfo* m_keyInfo;
+        bool m_press;
+        IEventQueue* m_events;
     };
 
     // MouseButtonAction -- modifier combinations not implemented yet
@@ -265,9 +265,9 @@ public:
         virtual const char*        formatName() const;
 
     private:
-        IPlatformScreen::ButtonInfo*    m_buttonInfo;
-        bool                    m_press;
-        IEventQueue*            m_events;
+        IPlatformScreen::ButtonInfo* m_buttonInfo;
+        bool m_press;
+        IEventQueue* m_events;
     };
 
     class Rule {
@@ -318,9 +318,9 @@ public:
     private:
         typedef std::vector<Action*> ActionList;
 
-        Condition*        m_condition;
-        ActionList        m_activateActions;
-        ActionList        m_deactivateActions;
+        Condition* m_condition;
+        ActionList m_activateActions;
+        ActionList m_deactivateActions;
     };
 
     // -------------------------------------------------------------------------
@@ -367,7 +367,7 @@ private:
     void                handleEvent(const Event&, void*);
 
 private:
-    RuleList            m_ruleList;
-    PrimaryClient*        m_primaryClient;
-    IEventQueue*        m_events;
+    RuleList m_ruleList;
+    PrimaryClient* m_primaryClient;
+    IEventQueue* m_events;
 };

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -149,6 +149,6 @@ public:
     bool isPrimary() const override{ return true; }
 private:
     inputleap::Screen* m_screen;
-    bool                m_clipboardDirty[kClipboardEnd];
+    bool m_clipboardDirty[kClipboardEnd];
     std::int32_t m_fakeInputCount;
 };

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -56,7 +56,7 @@ public:
         static LockCursorToScreenInfo* alloc(State state = kToggle);
 
     public:
-        State            m_state;
+        State m_state;
     };
 
     //! Switch to screen data
@@ -66,7 +66,7 @@ public:
 
     public:
         // this is a C-string;  this type is a variable size structure
-        char            m_screen[1];
+        char m_screen[1];
     };
 
     //! Switch in direction data
@@ -75,7 +75,7 @@ public:
         static SwitchInDirectionInfo* alloc(EDirection direction);
 
     public:
-        EDirection        m_direction;
+        EDirection m_direction;
     };
 
     //! Screen connected data
@@ -97,8 +97,8 @@ public:
                                             const std::string& screens);
 
     public:
-        State            m_state;
-        char            m_screens[1];
+        State m_state;
+        char m_screens[1];
     };
 
     /*!
@@ -112,7 +112,7 @@ public:
 
 #ifdef INPUTLEAP_TEST_ENV
     Server() : m_mock(true), m_config(nullptr) { }
-    void setActive(BaseClientProxy* active) {    m_active = active; }
+    void setActive(BaseClientProxy* active) { m_active = active; }
 #endif
 
     //! @name manipulators
@@ -365,7 +365,7 @@ private:
     void                sendDragInfo(BaseClientProxy* newScreen);
 
 public:
-    bool                m_mock;
+    bool m_mock;
 
 private:
     class ClipboardInfo {
@@ -373,27 +373,27 @@ private:
         ClipboardInfo();
 
     public:
-        Clipboard        m_clipboard;
+        Clipboard m_clipboard;
         std::string m_clipboardData;
         std::string m_clipboardOwner;
         std::uint32_t m_clipboardSeqNum;
     };
 
     // the primary screen client
-    PrimaryClient*        m_primaryClient;
+    PrimaryClient* m_primaryClient;
 
     // all clients (including the primary client) indexed by name
     typedef std::map<std::string, BaseClientProxy*> ClientList;
     typedef std::set<BaseClientProxy*> ClientSet;
-    ClientList            m_clients;
-    ClientSet            m_clientSet;
+    ClientList m_clients;
+    ClientSet m_clientSet;
 
     // all old connections that we're waiting to hangup
     typedef std::map<BaseClientProxy*, EventQueueTimer*> OldClients;
-    OldClients            m_oldClients;
+    OldClients m_oldClients;
 
     // the client with focus
-    BaseClientProxy*    m_active;
+    BaseClientProxy* m_active;
 
     // the sequence number of enter messages
     std::uint32_t m_seqNum;
@@ -410,70 +410,70 @@ private:
     std::int32_t m_xDelta2, m_yDelta2;
 
     // current configuration
-    Config*                m_config;
+    Config* m_config;
 
     // input filter (from m_config);
-    InputFilter*        m_inputFilter;
+    InputFilter* m_inputFilter;
 
     // clipboard cache
-    ClipboardInfo        m_clipboards[kClipboardEnd];
+    ClipboardInfo m_clipboards[kClipboardEnd];
 
     // state saved when screen saver activates
-    BaseClientProxy*    m_activeSaver;
+    BaseClientProxy* m_activeSaver;
     std::int32_t m_xSaver, m_ySaver;
 
     // common state for screen switch tests.  all tests are always
     // trying to reach the same screen in the same direction.
-    EDirection            m_switchDir;
-    BaseClientProxy*    m_switchScreen;
+    EDirection m_switchDir;
+    BaseClientProxy* m_switchScreen;
 
     // state for delayed screen switching
-    double                m_switchWaitDelay;
-    EventQueueTimer*    m_switchWaitTimer;
+    double m_switchWaitDelay;
+    EventQueueTimer* m_switchWaitTimer;
     std::int32_t m_switchWaitX, m_switchWaitY;
 
     // state for double-tap screen switching
-    double                m_switchTwoTapDelay;
-    Stopwatch            m_switchTwoTapTimer;
-    bool                m_switchTwoTapEngaged;
-    bool                m_switchTwoTapArmed;
+    double m_switchTwoTapDelay;
+    Stopwatch m_switchTwoTapTimer;
+    bool m_switchTwoTapEngaged;
+    bool m_switchTwoTapArmed;
     std::int32_t m_switchTwoTapZone;
 
     // modifiers needed before switching
-    bool                m_switchNeedsShift;
-    bool                m_switchNeedsControl;
-    bool                m_switchNeedsAlt;
+    bool m_switchNeedsShift;
+    bool m_switchNeedsControl;
+    bool m_switchNeedsAlt;
 
     // relative mouse move option
-    bool                m_relativeMoves;
+    bool m_relativeMoves;
 
     // flag whether or not we have broadcasting enabled and the screens to
     // which we should send broadcasted keys.
-    bool                m_keyboardBroadcasting;
+    bool m_keyboardBroadcasting;
     std::string m_keyboardBroadcastingScreens;
 
     // screen locking (former scroll lock)
-    bool                m_lockedToScreen;
+    bool m_lockedToScreen;
 
     // server screen
     inputleap::Screen* m_screen;
 
-    IEventQueue*        m_events;
+    IEventQueue* m_events;
 
     // file transfer
-    size_t                m_expectedFileSize;
+    size_t m_expectedFileSize;
     std::string m_receivedFileData;
-    DragFileList        m_dragFileList;
-    DragFileList        m_fakeDragFileList;
-    Thread*                m_sendFileThread;
-    Thread*                m_writeToDropDirThread;
+    DragFileList m_dragFileList;
+    DragFileList m_fakeDragFileList;
+    Thread* m_sendFileThread;
+    Thread* m_writeToDropDirThread;
     std::string m_dragFileExt;
-    bool                m_ignoreFileTransfer;
-    bool                m_enableClipboard;
+    bool m_ignoreFileTransfer;
+    bool m_enableClipboard;
 
-    Thread*                m_sendDragInfoThread;
-    bool                m_waitDragInfoThread;
+    Thread* m_sendDragInfoThread;
+    bool m_waitDragInfoThread;
 
-    ClientListener*        m_clientListener;
-    ServerArgs            m_args;
+    ClientListener* m_clientListener;
+    ServerArgs m_args;
 };

--- a/src/test/global/TestEventQueue.h
+++ b/src/test/global/TestEventQueue.h
@@ -34,5 +34,5 @@ private:
     void                timeoutThread(void*);
 
 private:
-    EventQueueTimer*    m_quitTimeoutTimer;
+    EventQueueTimer* m_quitTimeoutTimer;
 };


### PR DESCRIPTION
Realign all header files to use a single space between the class member
type and its name, i.e. "int foo;" instead of the previous attempted
alignment of all member variables to the same tabstop.

Patch created by running:
```
 sed -i 's/ \+\(m_.*\);/ \1;/' src/**/*.h
```
and then fixing/ignoring the occasional outlier.

This is in response to https://github.com/input-leap/input-leap/pull/1494#issuecomment-1208113958. Best to do this in one go all over the tree to have some sort of consistency (even though this patch probably doesn't catch all occurrences).

## Verification

Only thing `git diff -w` picks up is a manually added line join

```
$ git diff -w HEAD~
diff --git a/src/lib/platform/MSWindowsScreen.h b/src/lib/platform/MSWindowsScreen.h
index be9bbd3d..63864c8a 100644
--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -282,8 +282,7 @@ private:
     HKL m_keyLayout;
 
     // screen saver stuff
-    MSWindowsScreenSaver*
-                        m_screensaver;
+    MSWindowsScreenSaver* m_screensaver;
     bool m_screensaverNotify;
     bool m_screensaverActive;
 
@@ -333,8 +332,7 @@ private:
 
     mutable std::string m_dropTargetPath;
 
-    MSWindowsDropTarget*
-                        m_dropTarget;
+    MSWindowsDropTarget* m_dropTarget;
     HWND m_dropWindow;
     const int m_dropWindowSize;
 


```