### PR TITLE
gui: change an error message to something easier to google for

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
     // QApplication's constructor will call a fscking abort() if
     // DISPLAY is bad. Let's check it first and handle it gracefully
     if (!display_is_valid()) {
-        fprintf(stderr, "The Barrier GUI requires a display. Quitting...\n");
+        fprintf(stderr, "The Barrier GUI requires the DISPLAY environment variable to be set. Quitting...\n");
         return 1;
     }
 #endif


### PR DESCRIPTION
99% of the time this fails it's because DISPLAY is unset. Some cases
have it set but not point to the X server but that's niche enough we
probably don't need to worry about.

Fixes barrier issue 1735
