### PR TITLE
Drop forced parallel job count in clean_build.sh

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -76,7 +76,7 @@ jobs:
           brew update
           brew install qt5
       - name: Run the build
-        run: ./clean_build.sh
+        run: sh -x ./clean_build.sh
       - uses: actions/upload-artifact@v3
         with:
           name: Publish the DMG for ${{ matrix.os }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           brew update
           brew install qt5
+          brew install ninja
       - name: Run the build
         run: sh -x ./clean_build.sh
       - uses: actions/upload-artifact@v3

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -11,20 +11,6 @@ if [ -z "$B_CMAKE" ]; then
     exit 1
 fi
 
-if [ "$(uname)" = "Darwin" ]; then
-    nproc=$(sysctl -n hw.ncpu)
-else
-    nproc=$(nproc)
-fi
-if [ -z "$nproc" ]; then
-    nproc=8
-fi
-if [ $nproc -gt 32 ]; then
-    nproc=32
-fi
-
-export CMAKE_BUILD_PARALLEL_LEVEL=${nproc}
-
 B_BUILD_DIR="${B_BUILD_DIR:-build}"
 B_BUILD_TYPE="${B_BUILD_TYPE:-Debug}"
 B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"


### PR DESCRIPTION
Let's rely on cmake just using the native tool's job count