### PR TITLE
Drop support for --no-xinitthreads

### DIFF
--- a/doc/barrierc.1
+++ b/doc/barrierc.1
@@ -4,7 +4,7 @@
 barrierc \- Barrier Keyboard/Mouse Client
 .SH SYNOPSIS
 .B barrierc
-[\fI\,--yscroll <delta>\/\fR] [\fI\,--display <display>\/\fR] [\fI\,--no-xinitthreads\/\fR] [\fI\,--daemon|--no-daemon\/\fR] [\fI\,--name <screen-name>\/\fR] [\fI\,--restart|--no-restart\/\fR] [\fI\,--debug <level>\/\fR] \fI\,<server-address>\/\fR
+[\fI\,--yscroll <delta>\/\fR] [\fI\,--display <display>\/\fR] [\fI\,--daemon|--no-daemon\/\fR] [\fI\,--name <screen-name>\/\fR] [\fI\,--restart|--no-restart\/\fR] [\fI\,--debug <level>\/\fR] \fI\,<server-address>\/\fR
 .SH DESCRIPTION
 Start the barrier client and connect to a remote server component.
 .SH OPTIONS
@@ -37,9 +37,6 @@ enable the crypto (ssl) plugin.
 .TP
 \fB\-\-display\fR <display>
 connect to the X server at <display>
-.TP
-\fB\-\-no\-xinitthreads\fR
-do not call XInitThreads()
 .TP
 \fB\-f\fR, \fB\-\-no\-daemon\fR
 run in the foreground.

--- a/doc/barriers.1
+++ b/doc/barriers.1
@@ -4,7 +4,7 @@
 barriers \- Barrier Keyboard/Mouse Server
 .SH SYNOPSIS
 .B barriers
-[\fI\,--address <address>\/\fR] [\fI\,--config <pathname>\/\fR] [\fI\,--display <display>\/\fR] [\fI\,--no-xinitthreads\/\fR] [\fI\,--daemon|--no-daemon\/\fR] [\fI\,--name <screen-name>\/\fR] [\fI\,--restart|--no-restart\/\fR] [\fI\,--debug <level>\/\fR]
+[\fI\,--address <address>\/\fR] [\fI\,--config <pathname>\/\fR] [\fI\,--display <display>\/\fR] [\fI\,--daemon|--no-daemon\/\fR] [\fI\,--name <screen-name>\/\fR] [\fI\,--restart|--no-restart\/\fR] [\fI\,--debug <level>\/\fR]
 .SH DESCRIPTION
 Start the barrier server component.
 .SH OPTIONS
@@ -43,9 +43,6 @@ enable the crypto (ssl) plugin.
 .TP
 \fB\-\-display\fR <display>
 connect to the X server at <display>
-.TP
-\fB\-\-no\-xinitthreads\fR
-do not call XInitThreads()
 .TP
 \fB\-\-screen\-change\-script\fR <path>
 full path to script to run on screen change

--- a/doc/newsfragments/xinitthreads.removal
+++ b/doc/newsfragments/xinitthreads.removal
@@ -1,0 +1,1 @@
+The --no-xinitthreads commandline option has been deprecated and no longer has any effect.

--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -176,7 +176,7 @@ ArgParser::parseXWindowsArg(ArgsBase& argsBase, const int& argc, const char* con
         argsBase.m_display = argv[++i];
     }
     else if (isArg(i, argc, argv, nullptr, "--no-xinitthreads")) {
-        argsBase.m_disableXInitThreads = true;
+        LOG((CLOG_NOTE "--no-xinitthreads is deprecated"));
     } else {
         // option not supported here
         return false;

--- a/src/lib/inputleap/ArgsBase.cpp
+++ b/src/lib/inputleap/ArgsBase.cpp
@@ -37,9 +37,6 @@ m_disableTray(false),
 m_enableIpc(false),
 m_enableDragDrop(false),
 m_dropTarget(""),
-#if WINAPI_XWINDOWS
-m_disableXInitThreads(false),
-#endif
 m_shouldExit(false),
 m_barrierAddress(),
     m_enableCrypto(true),

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -108,10 +108,9 @@ ClientApp::help()
 {
 #if WINAPI_XWINDOWS
 #  define WINAPI_ARG \
-    " [--display <display>] [--no-xinitthreads]"
+    " [--display <display>]"
 #  define WINAPI_INFO \
-    "      --display <display>  connect to the X server at <display>\n" \
-    "      --no-xinitthreads    do not call XInitThreads()\n"
+    "      --display <display>  connect to the X server at <display>\n"
 #else
 #  define WINAPI_ARG ""
 #  define WINAPI_INFO ""
@@ -169,7 +168,7 @@ ClientApp::createScreen()
 #if WINAPI_XWINDOWS
     return new inputleap::Screen(new XWindowsScreen(
         new XWindowsImpl(),
-        args().m_display, false, args().m_disableXInitThreads,
+        args().m_display, false,
         args().m_yscroll, m_events), m_events);
 #endif
 #if WINAPI_CARBON

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -116,10 +116,9 @@ ServerApp::help()
     // window api args (windows/x-windows/carbon)
 #if WINAPI_XWINDOWS
 #  define WINAPI_ARGS \
-    " [--display <display>] [--no-xinitthreads]"
+    " [--display <display>]"
 #  define WINAPI_INFO \
     "      --display <display>  connect to the X server at <display>\n" \
-    "      --no-xinitthreads    do not call XInitThreads()\n" \
     "      --screen-change-script <path>\n" \
     "                           full path to script to run on screen change\n" \
     "                           first argument is the new screen name\n"
@@ -619,7 +618,7 @@ ServerApp::createScreen()
 #if WINAPI_XWINDOWS
     return new inputleap::Screen(new XWindowsScreen(
         new XWindowsImpl(),
-        args().m_display, true, args().m_disableXInitThreads, 0, m_events), m_events);
+        args().m_display, true, 0, m_events), m_events);
 #endif
 #if WINAPI_CARBON
     return new inputleap::Screen(new OSXScreen(m_events, true), m_events);

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -61,7 +61,6 @@ XWindowsScreen::XWindowsScreen(
         IXWindowsImpl* impl,
 		const char* displayName,
 		bool isPrimary,
-		bool disableXInitThreads,
 		int mouseScrollDelta,
 		IEventQueue* events) :
     PlatformScreen(events),
@@ -99,13 +98,9 @@ XWindowsScreen::XWindowsScreen(
 	if (mouseScrollDelta==0) m_mouseScrollDelta=120;
 	s_screen = this;
 
-	if (!disableXInitThreads) {
-	  // initializes Xlib support for concurrent threads.
-      if (m_impl->XInitThreads() == 0)
-	    throw XArch("XInitThreads() returned zero");
-	} else {
-		LOG((CLOG_DEBUG "skipping XInitThreads()"));
-	}
+    // initializes Xlib support for concurrent threads.
+    if (m_impl->XInitThreads() == 0)
+        throw XArch("XInitThreads() returned zero");
 
 	// set the X I/O error handler so we catch the display disconnecting
     m_impl->XSetIOErrorHandler(&XWindowsScreen::ioErrorHandler);

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -36,7 +36,7 @@ class XWindowsScreenSaver;
 class XWindowsScreen : public PlatformScreen {
 public:
     XWindowsScreen(IXWindowsImpl* impl, const char* displayName, bool isPrimary,
-        bool disableXInitThreads, int mouseScrollDelta,
+        int mouseScrollDelta,
         IEventQueue* events);
     ~XWindowsScreen() override;
 

--- a/src/test/integtests/platform/XWindowsScreenTests.cpp
+++ b/src/test/integtests/platform/XWindowsScreenTests.cpp
@@ -35,7 +35,7 @@ TEST(CXWindowsScreenTests, fakeMouseMove_nonPrimary_getCursorPosValuesCorrect)
     EXPECT_CALL(eventQueue, adoptHandler(_, _, _)).Times(2);
     EXPECT_CALL(eventQueue, adoptBuffer(_)).Times(2);
     EXPECT_CALL(eventQueue, removeHandler(_, _)).Times(2);
-    XWindowsScreen screen(new XWindowsImpl(), displayName, false, false, 0, &eventQueue);
+    XWindowsScreen screen(new XWindowsImpl(), displayName, false, 0, &eventQueue);
 
     screen.fakeMouseMove(10, 20);
 


### PR DESCRIPTION
This was added 11 years ago but without information in the commit as to
why it was added. Likely there was a bug in some Xlib version that
required this.

This bug was probably fixed a long time ago and as of libX11 1.8
libX11 now always calls XInitThreads anyway. So let's
drop this code.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
