### PR TITLE
lib: handle the --help winapi arguments with inline ifdefs

### DIFF
--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -106,24 +106,22 @@ ClientApp::parseArgs(int argc, const char* const* argv)
 void
 ClientApp::help()
 {
-#if WINAPI_XWINDOWS
-#  define WINAPI_ARG \
-    " [--display <display>]"
-#  define WINAPI_INFO \
-    "      --display <display>  connect to the X server at <display>\n"
-#else
-#  define WINAPI_ARG ""
-#  define WINAPI_INFO ""
-#endif
-
     std::ostringstream buffer;
     buffer << "Start the barrier client and connect to a remote server component.\n"
            << "\n"
-           << "Usage: " << args().m_exename << " [--yscroll <delta>]" <<  WINAPI_ARG << HELP_SYS_ARGS
+           << "Usage: " << args().m_exename << " [--yscroll <delta>]"
+#ifdef WINAPI_XWINDOWS
+           << " [--display <display>]"
+#endif
+           << HELP_SYS_ARGS
            << HELP_COMMON_ARGS << " <server-address>\n"
            << "\n"
            << "Options:\n"
-           << HELP_COMMON_INFO_1 << WINAPI_INFO << HELP_SYS_INFO
+           << HELP_COMMON_INFO_1
+#if WINAPI_XWINDOWS
+           << "      --display <display>  connect to the X server at <display>\n"
+#endif
+           << HELP_SYS_INFO
            << "      --yscroll <delta>    defines the vertical scrolling delta, which is\n"
            << "                           120 by default.\n"
            << HELP_COMMON_INFO_2

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -113,20 +113,6 @@ ServerApp::parseArgs(int argc, const char* const* argv)
 void
 ServerApp::help()
 {
-    // window api args (windows/x-windows/carbon)
-#if WINAPI_XWINDOWS
-#  define WINAPI_ARGS \
-    " [--display <display>]"
-#  define WINAPI_INFO \
-    "      --display <display>  connect to the X server at <display>\n" \
-    "      --screen-change-script <path>\n" \
-    "                           full path to script to run on screen change\n" \
-    "                           first argument is the new screen name\n"
-#else
-#  define WINAPI_ARGS ""
-#  define WINAPI_INFO ""
-#endif
-
     // refer to custom profile directory even if not saved yet
     inputleap::fs::path profile_path = argsBase().m_profileDirectory;
     if (profile_path.empty()) {
@@ -145,7 +131,12 @@ ServerApp::help()
            << "Usage: " << args().m_exename
            << " [--address <address>]"
            << " [--config <pathname>]"
-           << WINAPI_ARGS << HELP_SYS_ARGS << HELP_COMMON_ARGS << "\n"
+#ifdef WINAPI_XWINDOWS
+           << " [--display <display>]"
+#endif
+           << HELP_SYS_ARGS
+           << HELP_COMMON_ARGS
+           << "\n"
            << "\n"
            << "Options:\n"
            << "  -a, --address <address>  listen for clients on the given address.\n"
@@ -153,7 +144,15 @@ ServerApp::help()
            << HELP_COMMON_INFO_1
            << "      --disable-client-cert-checking disable client SSL certificate \n"
               "                                     checking (deprecated)\n"
-           << WINAPI_INFO << HELP_SYS_INFO << HELP_COMMON_INFO_2 << "\n"
+#ifdef WINAPI_XWINDOWS
+           << "      --display <display>  connect to the X server at <display>\n"
+           << "      --screen-change-script <path>\n"
+           << "                           full path to script to run on screen change\n"
+           << "                           first argument is the new screen name\n"
+#endif
+           << HELP_SYS_INFO
+           << HELP_COMMON_INFO_2
+           << "\n"
            << "Default options are marked with a *\n"
            << "\n"
            << "The argument for --address is of the form: [<hostname>][:<port>].  The\n"


### PR DESCRIPTION
A lot easier to read this way, doubly so if we have multiple winapi
targets in the future.
