### PR TITLE
Make dist workflow only build on Input Leap tag

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   fedora:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     container: fedora:36
 


### PR DESCRIPTION
This modification reduces confusion for users with GH Actions, and I will be looking to make generic amd64/arm64 artifacts for debug builds on Linux/Mac, but for now, this fix makes it so the `dist.yml` workflow only builds Fedora RPMs on a tag release. That way, we have only one CI workflow actually running when it comes to new commits, and publishing generic amd64/arm64 Mac, Linux, and amd64 Windows executable artifacts.

Thoughts?

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
