### PR TITLE
Adjust builds to run on systems without specific runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if (UNIX)
     endif()
 
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /D _BIND_TO_CURRENT_VCLIBS_VERSION=1")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /Zi")
     set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD /O2 /Ob2")
 
     list (APPEND libs Wtsapi32 Userenv Wininet comsuppw Shlwapi)


### PR DESCRIPTION
In #1517, I was pointed to a bug on Windows-based systems, where the `vcruntime140_1d.dll` is missing on systems without Visual Studio C++ debug runtimes installed. This means an DLL dependency exception occurs, and users of Input Leap without this DLL, cannot run the program.

This commit makes CMake build Input Leap on Windows using different flags to ensure that IL can build without the debug runtime, but still being debuggable.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
