### PR TITLE
CI: rename the workflows to something less generic

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Build tests
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,4 +1,4 @@
-name: distribution builds
+name: Distribution package test builds
 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch


### PR DESCRIPTION
Our "build.yml" workflow isn't CI, it's just a set of build tests. And the "distribution builds" can be mistaken for official ones, so let's rename that too.

Related to #1522

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
