### PR TITLE
Fix out-of-bounds access in XWindowsScreen::updateButtons

### DIFF
--- a/doc/newsfragments/fix-crash-when-switching-screens.bugfix
+++ b/doc/newsfragments/fix-crash-when-switching-screens.bugfix
@@ -1,0 +1,1 @@
+Fixed out of bounds write which sometimes causes crash when switching screens.

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1908,15 +1908,14 @@ XWindowsScreen::updateButtons()
 	}
 
 	// allocate button array
-	m_buttons.resize(maxButton);
+	m_buttons.resize(maxButton + 1);
 
-	// fill in button array values.  m_buttons[i] is the physical
-	// button number for logical button i+1.
+    // fill in button array values.  m_buttons[i] is the physical
+    // button number for logical button i.
+    std::fill(m_buttons.begin(), m_buttons.end(), 0);
+
     for (std::uint32_t i = 0; i < numButtons; ++i) {
-		m_buttons[i] = 0;
-	}
-    for (std::uint32_t i = 0; i < numButtons; ++i) {
-		m_buttons[tmpButtons[i] - 1] = i + 1;
+        m_buttons[tmpButtons[i]] = i;
 	}
 
 	// clean up

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -227,7 +227,7 @@ private:
     bool m_screensaverNotify;
 
     // logical to physical button mapping.  m_buttons[i] gives the
-    // physical button for logical button i+1.
+    // physical button for logical button i.
     std::vector<unsigned char> m_buttons;
 
     // true if global auto-repeat was enabled before we turned it off


### PR DESCRIPTION
This code triggers an assertion in gcc's std_vector.h on my system due to a logical button 0 causing a write to m_buttons[-1], and a SIGABRT.

I've tried to make this code do what it seems to be intended to do, but m_buttons isn't actually read from anywhere anyway.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

(Maintainer's note (@shymega): PR from debauchee/barrier#1827) (cherry picked from commit 4cc700c363f083c87992ba318d97d74ecbf1e711)

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
