### PR TITLE
inputleap: add Argv.contains() to search for an argument

### DIFF
--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -47,7 +47,7 @@ Argv::Argv(int argc, const char* const* argv) :
     m_exename(inputleap::fs::u8path(argv[0]).filename().u8string())
 {
     for (int i = 1; i < argc; i++)
-        m_argv.push(argv[i]);
+        m_argv.push_back(argv[i]);
 }
 
 const char*
@@ -57,7 +57,7 @@ Argv::shift()
         return nullptr;
 
     auto a = m_argv.front();
-    m_argv.pop();
+    m_argv.pop_front();
     return a;
 }
 
@@ -73,15 +73,26 @@ Argv::shift(const char *name1, const char* name2, const char **optarg)
         if (optarg != nullptr && m_argv.size() <= 1) {
             throw XArgvParserError("missing argument for `%s'", a);
         }
-        m_argv.pop();
+        m_argv.pop_front();
         if (optarg != nullptr) {
             *optarg = m_argv.front();
-            m_argv.pop();
+            m_argv.pop_front();
         }
         return a;
     }
     return nullptr;
 }
+
+bool
+Argv::contains(const char *name)
+{
+    for (auto it = m_argv.begin(); it != m_argv.end(); it++) {
+        if (strcmp(*it, name) == 0)
+            return true;
+    }
+    return false;
+}
+
 
 ArgsBase* ArgParser::m_argsBase = nullptr;
 

--- a/src/lib/inputleap/ArgParser.h
+++ b/src/lib/inputleap/ArgParser.h
@@ -20,7 +20,7 @@
 #include "common/stdvector.h"
 
 #include <string>
-#include <queue>
+#include <deque>
 
 class ServerArgs;
 class ClientArgs;
@@ -52,6 +52,9 @@ public:
     // Return the next argument (excluding argv[0]) but do not remove it from the list
     const char* peek() { return m_argv.front(); }
 
+    // Return true if the given name is in the argument list
+    bool contains(const char *name);
+
     // True if no more arguments are available
     bool empty() { return m_argv.empty(); }
 
@@ -61,7 +64,7 @@ public:
     const std::string& exename() { return m_exename; };
 
 private:
-    std::queue<const char*> m_argv;
+    std::deque<const char*> m_argv;
     std::string m_exename;
 };
 


### PR DESCRIPTION
his PR cherry-picks a commit by @whot from https://github.com/input-leap/input-leap/pull/1524.

-----

This requires us switching from a std::queue to the std::deque (which was used in std::queue as backend container anyway).