### PR TITLE
gui: Make build reproducible by removing use of __DATE__

### DIFF
--- a/doc/newsfragments/reproducible-build.bugfix
+++ b/doc/newsfragments/reproducible-build.bugfix
@@ -1,0 +1,1 @@
+Fixed InputLeap code to produce reproducible build artifacts.

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -36,10 +36,6 @@ AboutDialog::AboutDialog(QWidget* parent, const QString& barrierApp) :
 #endif
 	m_pLabelBarrierVersion->setText(version);
 
-	QString buildDateString = QString::fromLocal8Bit(__DATE__).simplified();
-	QDate buildDate = QLocale("en_US").toDate(buildDateString, "MMM d yyyy");
-	m_pLabelBuildDate->setText(buildDate.toString(Qt::SystemLocaleLongDate));
-
 	// change default size based on os
 #if defined(Q_OS_MAC)
 	QSize size(600, 380);

--- a/src/gui/src/AboutDialogBase.ui
+++ b/src/gui/src/AboutDialogBase.ui
@@ -162,20 +162,6 @@ The Barrier GUI is based on QSynergy by Volker Lanz.
    <item row="6" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Build Date: </string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="m_pLabelBuildDate">
-       <property name="text">
-        <string>Unknown</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Build date is a thing that does not useful. It is enough to know the revision which is already supplied via INPUTLEAP_REVISION.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
