### PR TITLE
ipc: Fix race condition in IpcServer shutdown

### DIFF
--- a/doc/newsfragments/ipc-shutdown-crash.bugfix
+++ b/doc/newsfragments/ipc-shutdown-crash.bugfix
@@ -1,0 +1,1 @@
+Fixed potential crash during app shutdown.

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -70,6 +70,8 @@ IpcServer::~IpcServer()
         return;
     }
 
+    m_events->removeHandler(m_events->forIListenSocket().connecting(), m_socket);
+
     if (m_socket != nullptr) {
         delete m_socket;
     }
@@ -82,8 +84,6 @@ IpcServer::~IpcServer()
         }
         m_clients.clear();
     }
-
-    m_events->removeHandler(m_events->forIListenSocket().connecting(), m_socket);
 }
 
 void


### PR DESCRIPTION
m_socket is first deleted and then removed from the handler list. It should be the other way round.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
