### PR TITLE
Use std::unique_ptr where possible instead of manual pointer handling

### DIFF
--- a/src/gui/src/QBarrierApplication.cpp
+++ b/src/gui/src/QBarrierApplication.cpp
@@ -25,16 +25,12 @@
 QBarrierApplication* QBarrierApplication::s_Instance = nullptr;
 
 QBarrierApplication::QBarrierApplication(int& argc, char** argv) :
-    QApplication(argc, argv),
-    m_Translator(nullptr)
+    QApplication(argc, argv)
 {
     s_Instance = this;
 }
 
-QBarrierApplication::~QBarrierApplication()
-{
-    delete m_Translator;
-}
+QBarrierApplication::~QBarrierApplication() = default;
 
 void QBarrierApplication::commitData(QSessionManager&)
 {
@@ -52,20 +48,19 @@ QBarrierApplication* QBarrierApplication::getInstance()
 
 void QBarrierApplication::switchTranslator(QString lang)
 {
-    if (m_Translator != nullptr)
-    {
-        removeTranslator(m_Translator);
-        delete m_Translator;
+    if (translator_) {
+        removeTranslator(translator_.get());
+        translator_.reset();
     }
 
     QResource locale(":/res/lang/gui_" + lang + ".qm");
-    m_Translator = new QTranslator();
-    m_Translator->load(locale.data(), locale.size());
-    installTranslator(m_Translator);
+    translator_ = std::make_unique<QTranslator>();
+    translator_->load(locale.data(), locale.size());
+    installTranslator(translator_.get());
 }
 
 void QBarrierApplication::setTranslator(QTranslator* translator)
 {
-    m_Translator = translator;
-    installTranslator(m_Translator);
+    translator_.reset(translator);
+    installTranslator(translator_.get());
 }

--- a/src/gui/src/QBarrierApplication.h
+++ b/src/gui/src/QBarrierApplication.h
@@ -21,6 +21,7 @@
 #define QBARRIERAPPLICATION__H
 
 #include <QApplication>
+#include <memory>
 
 class QSessionManager;
 
@@ -33,12 +34,13 @@ class QBarrierApplication : public QApplication
     public:
         void commitData(QSessionManager& manager);
         void switchTranslator(QString lang);
+        // takes ownership
         void setTranslator(QTranslator* translator);
 
         static QBarrierApplication* getInstance();
 
     private:
-        QTranslator* m_Translator;
+        std::unique_ptr<QTranslator> translator_;
 
         static QBarrierApplication* s_Instance;
 };

--- a/src/gui/src/ZeroconfBrowser.cpp
+++ b/src/gui/src/ZeroconfBrowser.cpp
@@ -21,17 +21,12 @@
 
 ZeroconfBrowser::ZeroconfBrowser(QObject* parent) :
     QObject(parent),
-    m_DnsServiceRef(nullptr),
-    m_pSocket(nullptr)
+    m_DnsServiceRef(nullptr)
 {
 }
 
 ZeroconfBrowser::~ZeroconfBrowser()
 {
-    if (m_pSocket) {
-        delete m_pSocket;
-    }
-
     if (m_DnsServiceRef) {
         DNSServiceRefDeallocate(m_DnsServiceRef);
         m_DnsServiceRef = nullptr;
@@ -52,8 +47,8 @@ void ZeroconfBrowser::browseForType(const QString& type)
             emit error(kDNSServiceErr_Invalid);
         }
         else {
-            m_pSocket = new QSocketNotifier(sockFD, QSocketNotifier::Read, this);
-            connect(m_pSocket, SIGNAL(activated(int)), this,
+            socket_ = std::make_unique<QSocketNotifier>(sockFD, QSocketNotifier::Read, this);
+            connect(socket_.get(), SIGNAL(activated(int)), this,
                 SLOT(socketReadyRead()));
         }
     }

--- a/src/gui/src/ZeroconfBrowser.h
+++ b/src/gui/src/ZeroconfBrowser.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <dns_sd.h>
 
+#include <memory>
+
 class QSocketNotifier;
 
 class ZeroconfBrowser : public QObject
@@ -51,7 +53,7 @@ private:
 
 private:
     DNSServiceRef m_DnsServiceRef;
-    QSocketNotifier* m_pSocket;
+    std::unique_ptr<QSocketNotifier> socket_;
     QList<ZeroconfRecord> m_Records;
     QString m_BrowsingType;
 };

--- a/src/gui/src/ZeroconfRegister.cpp
+++ b/src/gui/src/ZeroconfRegister.cpp
@@ -21,17 +21,12 @@
 
 ZeroconfRegister::ZeroconfRegister(QObject* parent) :
     QObject(parent),
-    m_DnsServiceRef(nullptr),
-    m_pSocket(nullptr)
+    m_DnsServiceRef(nullptr)
 {
 }
 
 ZeroconfRegister::~ZeroconfRegister()
 {
-    if (m_pSocket) {
-        delete m_pSocket;
-    }
-
     if (m_DnsServiceRef) {
         DNSServiceRefDeallocate(m_DnsServiceRef);
         m_DnsServiceRef = nullptr;
@@ -69,8 +64,8 @@ void ZeroconfRegister::registerService(const ZeroconfRecord& record,
             emit error(kDNSServiceErr_Invalid);
         }
         else {
-            m_pSocket = new QSocketNotifier(sockfd, QSocketNotifier::Read, this);
-            connect(m_pSocket, SIGNAL(activated(int)), this, SLOT(socketReadyRead()));
+            socket_ = std::make_unique<QSocketNotifier>(sockfd, QSocketNotifier::Read, this);
+            connect(socket_.get(), SIGNAL(activated(int)), this, SLOT(socketReadyRead()));
         }
     }
 }

--- a/src/gui/src/ZeroconfRegister.h
+++ b/src/gui/src/ZeroconfRegister.h
@@ -30,6 +30,7 @@ class QSocketNotifier;
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <dns_sd.h>
+#include <memory>
 
 class ZeroconfRegister : public QObject
 {
@@ -56,6 +57,6 @@ private:
 
 private:
     DNSServiceRef m_DnsServiceRef;
-    QSocketNotifier* m_pSocket;
+    std::unique_ptr<QSocketNotifier> socket_;
     ZeroconfRecord finalRecord;
 };

--- a/src/gui/src/ZeroconfService.h
+++ b/src/gui/src/ZeroconfService.h
@@ -22,6 +22,8 @@
 
 #include <QtCore/QObject>
 
+#include <memory>
+
 typedef int32_t  DNSServiceErrorType;
 
 class ZeroconfRegister;
@@ -47,8 +49,8 @@ private:
 private:
     MainWindow* m_pMainWindow;
     ZeroconfServer m_zeroconfServer;
-    ZeroconfBrowser* m_pZeroconfBrowser;
-    ZeroconfRegister* m_pZeroconfRegister;
+    std::unique_ptr<ZeroconfBrowser> zeroconf_browser_;
+    std::unique_ptr<ZeroconfRegister> zeroconf_register_;
     bool m_ServiceRegistered;
 
     static const char* m_ServerServiceName;

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -85,7 +85,7 @@ EventQueue::EventQueue() :
     m_typesForIScreen(nullptr),
     m_typesForClipboard(nullptr),
     m_typesForFile(nullptr),
-    m_parentStream(NonBlockingStream(0)) // STDIN_FILENO
+    m_parentStream{0} // STDIN_FILENO
 {
     ARCH->setSignalHandler(Arch::kINTERRUPT, &interrupt, this);
     ARCH->setSignalHandler(Arch::kTERMINATE, &interrupt, this);

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -102,7 +102,7 @@ private:
     typedef std::vector<std::uint32_t> EventIDList;
     typedef std::map<Event::Type, const char*> TypeMap;
     typedef std::map<std::string, Event::Type> NameMap;
-    typedef std::map<Event::Type, IEventJob*> TypeHandlerTable;
+    using TypeHandlerTable = std::map<Event::Type, std::unique_ptr<IEventJob>>;
     typedef std::map<void*, TypeHandlerTable> HandlerTable;
 
     int m_systemTarget;

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -27,6 +27,7 @@
 
 #include <condition_variable>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <set>
@@ -113,7 +114,7 @@ private:
     NameMap m_nameMap;
 
     // buffer of events
-    IEventQueueBuffer* m_buffer;
+    std::unique_ptr<IEventQueueBuffer> buffer_;
 
     // saved events
     EventTable m_events;

--- a/src/lib/base/NonBlockingStream.cpp
+++ b/src/lib/base/NonBlockingStream.cpp
@@ -32,7 +32,7 @@ NonBlockingStream::NonBlockingStream(int fd) :
     // before we get data (and to keep it from being echoed back out)
     termios ta;
     tcgetattr(fd, &ta);
-    _p_ta_previous = new termios(ta);
+    _p_ta_previous = std::make_unique<termios>(ta);
     ta.c_lflag &= ~(ICANON | ECHO);
     tcsetattr(fd, TCSANOW, &ta);
 
@@ -43,9 +43,8 @@ NonBlockingStream::NonBlockingStream(int fd) :
 
 NonBlockingStream::~NonBlockingStream()
 {
-    tcsetattr(_fd, TCSANOW, _p_ta_previous);
+    tcsetattr(_fd, TCSANOW, _p_ta_previous.get());
     fcntl(_fd, F_SETFL, _cntl_previous);
-    delete _p_ta_previous;
 }
 
 bool NonBlockingStream::try_read_char(char &ch) const

--- a/src/lib/base/NonBlockingStream.h
+++ b/src/lib/base/NonBlockingStream.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <memory>
+
 // windows doesn't have a unistd.h so this class won't work as-written.
 // at the moment barrier doesn't need this functionality on windows so
 // it's left as a stub to be optimized out
@@ -43,7 +45,7 @@ public:
 
 private:
     int _fd;
-    termios * _p_ta_previous;
+    std::unique_ptr<termios> _p_ta_previous;
     int _cntl_previous;
 };
 

--- a/src/lib/base/UniquePtrContainer.h
+++ b/src/lib/base/UniquePtrContainer.h
@@ -1,0 +1,59 @@
+/*
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2002 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INPUTLEAP_LIB_BASE_UNIQUE_PTR_CONTAINER
+#define INPUTLEAP_LIB_BASE_UNIQUE_PTR_CONTAINER
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+template<class T>
+class UniquePtrContainer {
+public:
+    using Container = std::vector<std::unique_ptr<T>>;
+
+    void clear()
+    {
+        data_.clear();
+    }
+
+    void insert(std::unique_ptr<T>&& d)
+    {
+        data_.push_back(std::move(d));
+    }
+
+    void erase(T* p)
+    {
+        data_.erase(std::remove_if(data_.begin(), data_.end(),
+                                   [p](const auto& d) { return d.get() == p; }),
+                    data_.end());
+    }
+
+    typename Container::iterator begin() { return data_.begin(); }
+    typename Container::const_iterator begin() const { return data_.begin(); }
+    typename Container::const_iterator cbegin() const { return data_.cbegin(); }
+
+    typename Container::iterator end() { return data_.end(); }
+    typename Container::const_iterator end() const { return data_.end(); }
+    typename Container::const_iterator cend() const { return data_.cend(); }
+private:
+    std::vector<std::unique_ptr<T>> data_;
+};
+
+#endif // INPUTLEAP_LIB_BASE_UNIQUE_PTR_CONTAINER

--- a/src/lib/ipc/IpcClient.h
+++ b/src/lib/ipc/IpcClient.h
@@ -21,6 +21,7 @@
 #include "net/NetworkAddress.h"
 #include "net/TCPSocket.h"
 #include "base/EventTypes.h"
+#include <memory>
 
 class IpcServerProxy;
 class IpcMessage;
@@ -59,6 +60,6 @@ private:
 private:
     NetworkAddress m_serverAddress;
     TCPSocket m_socket;
-    IpcServerProxy* m_server;
+    std::unique_ptr<IpcServerProxy> server_;
     IEventQueue* m_events;
 };

--- a/src/lib/ipc/IpcClientProxy.h
+++ b/src/lib/ipc/IpcClientProxy.h
@@ -35,7 +35,7 @@ class IpcClientProxy {
     friend class IpcServer;
 
 public:
-    IpcClientProxy(inputleap::IStream& stream, IEventQueue* events);
+    IpcClientProxy(std::unique_ptr<inputleap::IStream>&& stream, IEventQueue* events);
     virtual ~IpcClientProxy();
 
 private:
@@ -48,7 +48,7 @@ private:
     void disconnect();
 
 private:
-    inputleap::IStream& m_stream;
+    std::unique_ptr<inputleap::IStream> stream_;
     EIpcClientType m_clientType;
     bool m_disconnecting;
     std::mutex m_readMutex;

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -36,7 +36,6 @@ IpcServer::IpcServer(IEventQueue* events, SocketMultiplexer* socketMultiplexer) 
     m_mock(false),
     m_events(events),
     m_socketMultiplexer(socketMultiplexer),
-    m_socket(nullptr),
     m_address(NetworkAddress(IPC_HOST, IPC_PORT))
 {
     init();
@@ -54,12 +53,12 @@ IpcServer::IpcServer(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
 void
 IpcServer::init()
 {
-    m_socket = new TCPListenSocket(m_events, m_socketMultiplexer, IArchNetwork::kINET);
+    socket_ = std::make_unique<TCPListenSocket>(m_events, m_socketMultiplexer, IArchNetwork::kINET);
 
     m_address.resolve();
 
     m_events->adoptHandler(
-        m_events->forIListenSocket().connecting(), m_socket,
+        m_events->forIListenSocket().connecting(), socket_.get(),
         new TMethodEventJob<IpcServer>(
         this, &IpcServer::handleClientConnecting));
 }
@@ -70,11 +69,8 @@ IpcServer::~IpcServer()
         return;
     }
 
-    m_events->removeHandler(m_events->forIListenSocket().connecting(), m_socket);
-
-    if (m_socket != nullptr) {
-        delete m_socket;
-    }
+    m_events->removeHandler(m_events->forIListenSocket().connecting(), socket_.get());
+    socket_.reset();
 
     {
         std::lock_guard<std::mutex> lock(m_clientsMutex);
@@ -89,13 +85,13 @@ IpcServer::~IpcServer()
 void
 IpcServer::listen()
 {
-    m_socket->bind(m_address);
+    socket_->bind(m_address);
 }
 
 void
 IpcServer::handleClientConnecting(const Event&, void*)
 {
-    inputleap::IStream* stream = m_socket->accept();
+    inputleap::IStream* stream = socket_->accept();
     if (stream == nullptr) {
         return;
     }

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -91,8 +91,8 @@ IpcServer::listen()
 void
 IpcServer::handleClientConnecting(const Event&, void*)
 {
-    inputleap::IStream* stream = socket_->accept();
-    if (stream == nullptr) {
+    auto stream = socket_->accept();
+    if (!stream) {
         return;
     }
 
@@ -101,7 +101,7 @@ IpcServer::handleClientConnecting(const Event&, void*)
     IpcClientProxy* proxy = nullptr;
     {
         std::lock_guard<std::mutex> lock(m_clientsMutex);
-        proxy = new IpcClientProxy(*stream, m_events);
+        proxy = new IpcClientProxy(std::move(stream), m_events);
         m_clients.push_back(proxy);
     }
 

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -77,7 +77,7 @@ private:
     bool m_mock;
     IEventQueue* m_events;
     SocketMultiplexer* m_socketMultiplexer;
-    TCPListenSocket* m_socket;
+    std::unique_ptr<TCPListenSocket> socket_;
     NetworkAddress m_address;
     ClientList m_clients;
     mutable std::mutex m_clientsMutex;
@@ -87,7 +87,6 @@ public:
     IpcServer() :
         m_mock(true),
         m_events(nullptr),
-        m_socketMultiplexer(nullptr),
-        m_socket(nullptr) { }
+        m_socketMultiplexer(nullptr) { }
 #endif
 };

--- a/src/lib/net/IListenSocket.h
+++ b/src/lib/net/IListenSocket.h
@@ -20,6 +20,7 @@
 
 #include "net/ISocket.h"
 #include "base/EventTypes.h"
+#include <memory>
 
 class IDataSocket;
 
@@ -30,17 +31,11 @@ listen for incoming connections.
 */
 class IListenSocket : public ISocket {
 public:
-    //! @name manipulators
-    //@{
-
     //! Accept connection
     /*!
     Accept a connection, returning a socket representing the full-duplex
     data stream.  Returns nullptr if no socket is waiting to be accepted.
     This is only valid after a call to \c bind().
     */
-    virtual IDataSocket*
-                        accept() = 0;
-
-    //@}
+    virtual std::unique_ptr<IDataSocket> accept() = 0;
 };

--- a/src/lib/net/SecureListenSocket.h
+++ b/src/lib/net/SecureListenSocket.h
@@ -31,7 +31,7 @@ public:
                        ConnectionSecurityLevel security_level);
 
     // IListenSocket overrides
-    IDataSocket* accept() override;
+    std::unique_ptr<IDataSocket> accept() override;
 private:
     ConnectionSecurityLevel security_level_;
 };

--- a/src/lib/net/TCPListenSocket.cpp
+++ b/src/lib/net/TCPListenSocket.cpp
@@ -104,27 +104,23 @@ TCPListenSocket::getEventTarget() const
     return const_cast<void*>(static_cast<const void*>(this));
 }
 
-IDataSocket*
-TCPListenSocket::accept()
+std::unique_ptr<IDataSocket> TCPListenSocket::accept()
 {
-    IDataSocket* socket = nullptr;
+    std::unique_ptr<IDataSocket> socket;
     try {
-        socket = new TCPSocket(m_events, m_socketMultiplexer, ARCH->acceptSocket(m_socket, nullptr));
-        if (socket != nullptr) {
-            setListeningJob();
-        }
+        socket = std::make_unique<TCPSocket>(m_events, m_socketMultiplexer,
+                                             ARCH->acceptSocket(m_socket, nullptr));
+        setListeningJob();
         return socket;
     }
     catch (XArchNetwork&) {
-        if (socket != nullptr) {
-            delete socket;
+        if (socket) {
             setListeningJob();
         }
         return nullptr;
     }
     catch (std::exception &ex) {
-        if (socket != nullptr) {
-            delete socket;
+        if (socket) {
             setListeningJob();
         }
         throw ex;

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -42,7 +42,7 @@ public:
     void* getEventTarget() const override;
 
     // IListenSocket overrides
-    IDataSocket* accept() override;
+    std::unique_ptr<IDataSocket> accept() override;
 
 protected:
     void setListeningJob();

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -130,8 +130,8 @@ ClientListener::handleClientConnecting(const Event&, void*)
         return;
     }
 
-    auto socket_ptr = socket.release();
-    m_clientSockets.insert(socket_ptr);
+    auto socket_ptr = socket.get();
+    client_sockets_.insert(std::move(socket));
 
     m_events->adoptHandler(m_events->forClientListener().accepted(),
                 socket_ptr->getEventTarget(),
@@ -227,8 +227,7 @@ ClientListener::handleClientDisconnected(const Event&, void* vclient)
             // we know which socket we no longer need
             IDataSocket* socket = static_cast<IDataSocket*>(client->getStream());
             delete client;
-            m_clientSockets.erase(socket);
-            delete socket;
+            client_sockets_.erase(socket);
 
             break;
         }
@@ -244,9 +243,5 @@ ClientListener::cleanupListenSocket()
 void
 ClientListener::cleanupClientSockets()
 {
-    ClientSockets::iterator it;
-    for (it = m_clientSockets.begin(); it != m_clientSockets.end(); it++) {
-        delete *it;
-    }
-    m_clientSockets.clear();
+    client_sockets_.clear();
 }

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -21,8 +21,10 @@
 #include "server/Config.h"
 #include "base/EventTypes.h"
 #include "base/Event.h"
+#include "base/UniquePtrContainer.h"
 #include "net/ConnectionSecurityLevel.h"
 #include <deque>
+#include <memory>
 #include <set>
 
 class ClientProxy;
@@ -77,7 +79,6 @@ private:
 private:
     typedef std::set<ClientProxyUnknown*> NewClients;
     typedef std::deque<ClientProxy*> WaitingClients;
-    typedef std::set<IDataSocket*> ClientSockets;
 
     IListenSocket* m_listen;
     ISocketFactory* m_socketFactory;
@@ -86,5 +87,5 @@ private:
     Server* m_server;
     IEventQueue* m_events;
     ConnectionSecurityLevel security_level_;
-    ClientSockets m_clientSockets;
+    UniquePtrContainer<IDataSocket> client_sockets_;
 };


### PR DESCRIPTION
This PR is partial cleanup of new/delete pairs where std::unique_ptr can be used to ensure that the stored pointer is deleted.