### PR TITLE
Cleanup error handling

### DIFF
--- a/src/lib/arch/XArch.h
+++ b/src/lib/arch/XArch.h
@@ -46,19 +46,12 @@ cleanup but before leaving or returning from the handler.
 #define RETHROW_XTHREAD \
     try { throw; } catch (XThread&) { throw; } catch (...) { }
 
-//! Generic exception architecture dependent library
-class XArch : public std::runtime_error {
-public:
-    XArch(const std::string& msg) : std::runtime_error(msg) { }
-    virtual ~XArch() noexcept { }
-};
-
 //! Generic network exception
 /*!
 Exceptions derived from this class are used by the networking
 library to indicate various errors.
 */
-class XArchNetwork : public XArch { using XArch::XArch; };
+class XArchNetwork : public std::runtime_error { using std::runtime_error::runtime_error; };
 
 //! Operation was interrupted
 class XArchNetworkInterrupted : public XArchNetwork { using XArchNetwork::XArchNetwork; };
@@ -132,7 +125,7 @@ class XArchNetworkNameUnsupported : public XArchNetworkName {
 Exceptions derived from this class are used by the daemon
 library to indicate various errors.
 */
-class XArchDaemon : public XArch { using XArch::XArch; };
+class XArchDaemon : public std::runtime_error { using std::runtime_error::runtime_error; };
 
 //! Could not daemonize
 class XArchDaemonFailed : public XArchDaemon { using XArchDaemon::XArchDaemon; };

--- a/src/lib/arch/XArch.h
+++ b/src/lib/arch/XArch.h
@@ -28,7 +28,7 @@ Exceptions derived from this class are used by the multithreading
 library to perform stack unwinding when a thread terminates.  These
 exceptions must always be rethrown by clients when caught.
 */
-class XThread { };
+class XThread : public std::exception { };
 
 //! Thread exception to cancel
 /*!

--- a/src/lib/arch/XArch.h
+++ b/src/lib/arch/XArch.h
@@ -46,25 +46,9 @@ cleanup but before leaving or returning from the handler.
 #define RETHROW_XTHREAD \
     try { throw; } catch (XThread&) { throw; } catch (...) { }
 
-//! Lazy error message string evaluation
-/*!
-This class encapsulates platform dependent error string lookup.
-Platforms subclass this type, taking an appropriate error code
-type in the c'tor and overriding eval() to return the error
-string for that error code.
-*/
-class XArchEval {
-public:
-    XArchEval() { }
-    virtual ~XArchEval() noexcept { }
-
-    virtual std::string eval() const = 0;
-};
-
 //! Generic exception architecture dependent library
 class XArch : public std::runtime_error {
 public:
-    XArch(XArchEval* adopted) : std::runtime_error(adopted->eval()) { delete adopted; }
     XArch(const std::string& msg) : std::runtime_error(msg) { }
     virtual ~XArch() noexcept { }
 };
@@ -73,7 +57,6 @@ public:
 #define XARCH_SUBCLASS(name_, super_)                                    \
 class name_ : public super_ {                                            \
 public:                                                                    \
-    name_(XArchEval* adoptedEvaluator) : super_(adoptedEvaluator) { }    \
     name_(const std::string& msg) : super_(msg) { }                        \
 }
 

--- a/src/lib/arch/XArch.h
+++ b/src/lib/arch/XArch.h
@@ -53,92 +53,97 @@ public:
     virtual ~XArch() noexcept { }
 };
 
-// Macro to declare XArch derived types
-#define XARCH_SUBCLASS(name_, super_)                                    \
-class name_ : public super_ {                                            \
-public:                                                                    \
-    name_(const std::string& msg) : super_(msg) { }                        \
-}
-
 //! Generic network exception
 /*!
 Exceptions derived from this class are used by the networking
 library to indicate various errors.
 */
-XARCH_SUBCLASS(XArchNetwork, XArch);
+class XArchNetwork : public XArch { using XArch::XArch; };
 
 //! Operation was interrupted
-XARCH_SUBCLASS(XArchNetworkInterrupted, XArchNetwork);
+class XArchNetworkInterrupted : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Network insufficient permission
-XARCH_SUBCLASS(XArchNetworkAccess, XArchNetwork);
+class XArchNetworkAccess : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Network insufficient resources
-XARCH_SUBCLASS(XArchNetworkResource, XArchNetwork);
+class XArchNetworkResource : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! No support for requested network resource/service
-XARCH_SUBCLASS(XArchNetworkSupport, XArchNetwork);
+class XArchNetworkSupport : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Network I/O error
-XARCH_SUBCLASS(XArchNetworkIO, XArchNetwork);
+class XArchNetworkIO : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Network address is unavailable or not local
-XARCH_SUBCLASS(XArchNetworkNoAddress, XArchNetwork);
+class XArchNetworkNoAddress : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Network address in use
-XARCH_SUBCLASS(XArchNetworkAddressInUse, XArchNetwork);
+class XArchNetworkAddressInUse : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! No route to address
-XARCH_SUBCLASS(XArchNetworkNoRoute, XArchNetwork);
+class XArchNetworkNoRoute : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Socket not connected
-XARCH_SUBCLASS(XArchNetworkNotConnected, XArchNetwork);
+class XArchNetworkNotConnected : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Remote read end of socket has closed
-XARCH_SUBCLASS(XArchNetworkShutdown, XArchNetwork);
+class XArchNetworkShutdown : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Remote end of socket has disconnected
-XARCH_SUBCLASS(XArchNetworkDisconnected, XArchNetwork);
+class XArchNetworkDisconnected : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Remote end of socket refused connection
-XARCH_SUBCLASS(XArchNetworkConnectionRefused, XArchNetwork);
+class XArchNetworkConnectionRefused : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Remote end of socket is not responding
-XARCH_SUBCLASS(XArchNetworkTimedOut, XArchNetwork);
+class XArchNetworkTimedOut : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! Generic network name lookup erros
-XARCH_SUBCLASS(XArchNetworkName, XArchNetwork);
+class XArchNetworkName : public XArchNetwork { using XArchNetwork::XArchNetwork; };
 
 //! The named host is unknown
-XARCH_SUBCLASS(XArchNetworkNameUnknown, XArchNetworkName);
+class XArchNetworkNameUnknown : public XArchNetworkName {
+    using XArchNetworkName::XArchNetworkName;
+};
 
 //! The named host is known but has no address
-XARCH_SUBCLASS(XArchNetworkNameNoAddress, XArchNetworkName);
+class XArchNetworkNameNoAddress : public XArchNetworkName {
+    using XArchNetworkName::XArchNetworkName;
+};
 
 //! Non-recoverable name server error
-XARCH_SUBCLASS(XArchNetworkNameFailure, XArchNetworkName);
+class XArchNetworkNameFailure : public XArchNetworkName {
+    using XArchNetworkName::XArchNetworkName;
+};
 
 //! Temporary name server error
-XARCH_SUBCLASS(XArchNetworkNameUnavailable, XArchNetworkName);
+class XArchNetworkNameUnavailable : public XArchNetworkName {
+    using XArchNetworkName::XArchNetworkName;
+};
 
 //! The named host is known but no supported address
-XARCH_SUBCLASS(XArchNetworkNameUnsupported, XArchNetworkName);
+class XArchNetworkNameUnsupported : public XArchNetworkName {
+    using XArchNetworkName::XArchNetworkName;
+};
 
 //! Generic daemon exception
 /*!
 Exceptions derived from this class are used by the daemon
 library to indicate various errors.
 */
-XARCH_SUBCLASS(XArchDaemon, XArch);
+class XArchDaemon : public XArch { using XArch::XArch; };
 
 //! Could not daemonize
-XARCH_SUBCLASS(XArchDaemonFailed, XArchDaemon);
+class XArchDaemonFailed : public XArchDaemon { using XArchDaemon::XArchDaemon; };
 
 //! Could not install daemon
-XARCH_SUBCLASS(XArchDaemonInstallFailed, XArchDaemon);
+class XArchDaemonInstallFailed : public XArchDaemon { using XArchDaemon::XArchDaemon; };
 
 //! Could not uninstall daemon
-XARCH_SUBCLASS(XArchDaemonUninstallFailed, XArchDaemon);
+class XArchDaemonUninstallFailed : public XArchDaemon { using XArchDaemon::XArchDaemon; };
 
 //! Attempted to uninstall a daemon that was not installed
-XARCH_SUBCLASS(XArchDaemonUninstallNotInstalled, XArchDaemonUninstallFailed);
+class XArchDaemonUninstallNotInstalled : public XArchDaemonUninstallFailed {
+    using XArchDaemonUninstallFailed::XArchDaemonUninstallFailed;
+};

--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -19,6 +19,7 @@
 #include "arch/unix/ArchDaemonUnix.h"
 
 #include "arch/unix/XArchUnix.h"
+#include "arch/XArch.h"
 #include "base/Log.h"
 
 #include <unistd.h>
@@ -79,7 +80,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
     switch (fork()) {
     case -1:
         // failed
-        throw XArchDaemonFailed(new XArchEvalUnix(errno));
+        throw XArchDaemonFailed(error_code_to_string_errno(errno));
 
     case 0:
         // child

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -23,6 +23,7 @@
 #include "arch/unix/ArchMultithreadPosix.h"
 #include "arch/unix/XArchUnix.h"
 #include "arch/Arch.h"
+#include "arch/XArch.h"
 #include "base/Time.h"
 
 #include <unistd.h>
@@ -745,11 +746,11 @@ ArchNetworkBSD::throwError(int err)
     switch (err) {
     case EINTR:
         ARCH->testCancelThread();
-        throw XArchNetworkInterrupted(new XArchEvalUnix(err));
+        throw XArchNetworkInterrupted(error_code_to_string_errno(err));
 
     case EACCES:
     case EPERM:
-        throw XArchNetworkAccess(new XArchEvalUnix(err));
+        throw XArchNetworkAccess(error_code_to_string_errno(err));
 
     case ENFILE:
     case EMFILE:
@@ -760,7 +761,7 @@ ArchNetworkBSD::throwError(int err)
 #if defined(ENOSR)
     case ENOSR:
 #endif
-        throw XArchNetworkResource(new XArchEvalUnix(err));
+        throw XArchNetworkResource(error_code_to_string_errno(err));
 
     case EPROTOTYPE:
     case EPROTONOSUPPORT:
@@ -774,40 +775,40 @@ ArchNetworkBSD::throwError(int err)
 #if defined(ENOPKG)
     case ENOPKG:
 #endif
-        throw XArchNetworkSupport(new XArchEvalUnix(err));
+        throw XArchNetworkSupport(error_code_to_string_errno(err));
 
     case EIO:
-        throw XArchNetworkIO(new XArchEvalUnix(err));
+        throw XArchNetworkIO(error_code_to_string_errno(err));
 
     case EADDRNOTAVAIL:
-        throw XArchNetworkNoAddress(new XArchEvalUnix(err));
+        throw XArchNetworkNoAddress(error_code_to_string_errno(err));
 
     case EADDRINUSE:
-        throw XArchNetworkAddressInUse(new XArchEvalUnix(err));
+        throw XArchNetworkAddressInUse(error_code_to_string_errno(err));
 
     case EHOSTUNREACH:
     case ENETUNREACH:
-        throw XArchNetworkNoRoute(new XArchEvalUnix(err));
+        throw XArchNetworkNoRoute(error_code_to_string_errno(err));
 
     case ENOTCONN:
-        throw XArchNetworkNotConnected(new XArchEvalUnix(err));
+        throw XArchNetworkNotConnected(error_code_to_string_errno(err));
 
     case EPIPE:
-        throw XArchNetworkShutdown(new XArchEvalUnix(err));
+        throw XArchNetworkShutdown(error_code_to_string_errno(err));
 
     case ECONNABORTED:
     case ECONNRESET:
-        throw XArchNetworkDisconnected(new XArchEvalUnix(err));
+        throw XArchNetworkDisconnected(error_code_to_string_errno(err));
 
     case ECONNREFUSED:
-        throw XArchNetworkConnectionRefused(new XArchEvalUnix(err));
+        throw XArchNetworkConnectionRefused(error_code_to_string_errno(err));
 
     case EHOSTDOWN:
     case ETIMEDOUT:
-        throw XArchNetworkTimedOut(new XArchEvalUnix(err));
+        throw XArchNetworkTimedOut(error_code_to_string_errno(err));
 
     default:
-        throw XArchNetwork(new XArchEvalUnix(err));
+        throw XArchNetwork(error_code_to_string_errno(err));
     }
 }
 

--- a/src/lib/arch/unix/XArchUnix.cpp
+++ b/src/lib/arch/unix/XArchUnix.cpp
@@ -20,13 +20,8 @@
 
 #include <cstring>
 
-//
-// XArchEvalUnix
-//
-
-std::string
-XArchEvalUnix::eval() const
+std::string error_code_to_string_errno(int err)
 {
     // FIXME -- not thread safe
-    return strerror(m_error);
+    return std::strerror(err);
 }

--- a/src/lib/arch/unix/XArchUnix.h
+++ b/src/lib/arch/unix/XArchUnix.h
@@ -18,16 +18,6 @@
 
 #pragma once
 
-#include "arch/XArch.h"
+#include <string>
 
-//! Lazy error message string evaluation for unix
-class XArchEvalUnix : public XArchEval {
-public:
-    XArchEvalUnix(int error) : m_error(error) { }
-    ~XArchEvalUnix() noexcept override { }
-
-    std::string eval() const override;
-
-private:
-    int m_error;
-};
+std::string error_code_to_string_errno(int err);

--- a/src/lib/arch/win32/ArchDaemonWindows.cpp
+++ b/src/lib/arch/win32/ArchDaemonWindows.cpp
@@ -20,6 +20,7 @@
 #include "arch/win32/ArchMiscWindows.h"
 #include "arch/win32/XArchWindows.h"
 #include "arch/Arch.h"
+#include "arch/XArch.h"
 #include "base/Time.h"
 #include <sstream>
 #include <vector>
@@ -85,7 +86,7 @@ ArchDaemonWindows::installDaemon(const char* name,
     SC_HANDLE mgr = OpenSCManager(nullptr, nullptr, GENERIC_WRITE);
     if (mgr == nullptr) {
         // can't open service manager
-        throw XArchDaemonInstallFailed(new XArchEvalWindows);
+        throw XArchDaemonInstallFailed(error_code_to_string_windows(GetLastError()));
     }
 
     // create the service
@@ -108,7 +109,7 @@ ArchDaemonWindows::installDaemon(const char* name,
         DWORD err = GetLastError();
         if (err != ERROR_SERVICE_EXISTS) {
             CloseServiceHandle(mgr);
-            throw XArchDaemonInstallFailed(new XArchEvalWindows(err));
+            throw XArchDaemonInstallFailed(error_code_to_string_windows(err));
         }
     }
     else {
@@ -131,7 +132,7 @@ ArchDaemonWindows::installDaemon(const char* name,
         catch (...) {
             // ignore
         }
-        throw XArchDaemonInstallFailed(new XArchEvalWindows(err));
+        throw XArchDaemonInstallFailed(error_code_to_string_windows(err));
     }
 
     // set the description
@@ -149,7 +150,7 @@ ArchDaemonWindows::installDaemon(const char* name,
         catch (...) {
             // ignore
         }
-        throw XArchDaemonInstallFailed(new XArchEvalWindows(err));
+        throw XArchDaemonInstallFailed(error_code_to_string_windows(err));
     }
     ArchMiscWindows::setValue(key, _T("CommandLine"), commandLine);
 
@@ -172,7 +173,7 @@ ArchDaemonWindows::uninstallDaemon(const char* name)
     SC_HANDLE mgr = OpenSCManager(nullptr, nullptr, GENERIC_WRITE);
     if (mgr == nullptr) {
         // can't open service manager
-        throw XArchDaemonUninstallFailed(new XArchEvalWindows);
+        throw XArchDaemonUninstallFailed(error_code_to_string_windows(GetLastError()));
     }
 
     // open the service.  oddly, you must open a service to delete it.
@@ -181,9 +182,9 @@ ArchDaemonWindows::uninstallDaemon(const char* name)
         DWORD err = GetLastError();
         CloseServiceHandle(mgr);
         if (err != ERROR_SERVICE_DOES_NOT_EXIST) {
-            throw XArchDaemonUninstallFailed(new XArchEvalWindows(err));
+            throw XArchDaemonUninstallFailed(error_code_to_string_windows(err));
         }
-        throw XArchDaemonUninstallNotInstalled(new XArchEvalWindows(err));
+        throw XArchDaemonUninstallNotInstalled(error_code_to_string_windows(err));
     }
 
     // stop the service.  we don't care if we fail.
@@ -215,9 +216,9 @@ ArchDaemonWindows::uninstallDaemon(const char* name)
             return;
         }
         if (err != ERROR_SERVICE_MARKED_FOR_DELETE) {
-            throw XArchDaemonUninstallFailed(new XArchEvalWindows(err));
+            throw XArchDaemonUninstallFailed(error_code_to_string_windows(err));
         }
-        throw XArchDaemonUninstallNotInstalled(new XArchEvalWindows(err));
+        throw XArchDaemonUninstallNotInstalled(error_code_to_string_windows(err));
     }
 }
 
@@ -243,7 +244,7 @@ ArchDaemonWindows::daemonize(const char* name, DaemonFunc func)
     if (StartServiceCtrlDispatcher(entry) == 0) {
         // StartServiceCtrlDispatcher failed
         s_daemon = nullptr;
-        throw XArchDaemonFailed(new XArchEvalWindows);
+        throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
     }
 
     s_daemon = nullptr;
@@ -606,7 +607,7 @@ ArchDaemonWindows::start(const char* name)
     // open service manager
     SC_HANDLE mgr = OpenSCManager(nullptr, nullptr, GENERIC_READ);
     if (mgr == nullptr) {
-        throw XArchDaemonFailed(new XArchEvalWindows());
+        throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
     }
 
     // open the service
@@ -615,12 +616,12 @@ ArchDaemonWindows::start(const char* name)
 
     if (service == nullptr) {
         CloseServiceHandle(mgr);
-        throw XArchDaemonFailed(new XArchEvalWindows());
+        throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
     }
 
     // start the service
     if (!StartService(service, 0, nullptr)) {
-        throw XArchDaemonFailed(new XArchEvalWindows());
+        throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
     }
 }
 
@@ -630,7 +631,7 @@ ArchDaemonWindows::stop(const char* name)
     // open service manager
     SC_HANDLE mgr = OpenSCManager(nullptr, nullptr, GENERIC_READ);
     if (mgr == nullptr) {
-        throw XArchDaemonFailed(new XArchEvalWindows());
+        throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
     }
 
     // open the service
@@ -640,7 +641,7 @@ ArchDaemonWindows::stop(const char* name)
 
     if (service == nullptr) {
         CloseServiceHandle(mgr);
-        throw XArchDaemonFailed(new XArchEvalWindows());
+        throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
     }
 
     // ask the service to stop, asynchronously
@@ -648,7 +649,7 @@ ArchDaemonWindows::stop(const char* name)
     if (!ControlService(service, SERVICE_CONTROL_STOP, &ss)) {
         DWORD dwErrCode = GetLastError();
         if (dwErrCode != ERROR_SERVICE_NOT_ACTIVE) {
-            throw XArchDaemonFailed(new XArchEvalWindows());
+            throw XArchDaemonFailed(error_code_to_string_windows(GetLastError()));
         }
     }
 }

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -21,6 +21,7 @@
 #include "arch/win32/XArchWindows.h"
 #include "arch/IArchMultithread.h"
 #include "arch/Arch.h"
+#include "arch/XArch.h"
 
 #include <malloc.h>
 
@@ -154,7 +155,7 @@ ArchNetworkWinsock::initModule(HMODULE module)
     WSADATA data;
     int err = startup(version, &data);
     if (data.wVersion != version) {
-        throw XArchNetworkSupport(new XArchEvalWinsock(err));
+        throw XArchNetworkSupport(error_code_to_string_winsock(err));
     }
     if (err != 0) {
         // some other initialization error
@@ -889,12 +890,12 @@ ArchNetworkWinsock::throwError(int err)
 {
     switch (err) {
     case WSAEACCES:
-        throw XArchNetworkAccess(new XArchEvalWinsock(err));
+        throw XArchNetworkAccess(error_code_to_string_winsock(err));
 
     case WSAEMFILE:
     case WSAENOBUFS:
     case WSAENETDOWN:
-        throw XArchNetworkResource(new XArchEvalWinsock(err));
+        throw XArchNetworkResource(error_code_to_string_winsock(err));
 
     case WSAEPROTOTYPE:
     case WSAEPROTONOSUPPORT:
@@ -908,50 +909,50 @@ ArchNetworkWinsock::throwError(int err)
     case WSANOTINITIALISED:
     case WSAVERNOTSUPPORTED:
     case WSASYSNOTREADY:
-        throw XArchNetworkSupport(new XArchEvalWinsock(err));
+        throw XArchNetworkSupport(error_code_to_string_winsock(err));
 
     case WSAEADDRNOTAVAIL:
-        throw XArchNetworkNoAddress(new XArchEvalWinsock(err));
+        throw XArchNetworkNoAddress(error_code_to_string_winsock(err));
 
     case WSAEADDRINUSE:
-        throw XArchNetworkAddressInUse(new XArchEvalWinsock(err));
+        throw XArchNetworkAddressInUse(error_code_to_string_winsock(err));
 
     case WSAEHOSTUNREACH:
     case WSAENETUNREACH:
-        throw XArchNetworkNoRoute(new XArchEvalWinsock(err));
+        throw XArchNetworkNoRoute(error_code_to_string_winsock(err));
 
     case WSAENOTCONN:
-        throw XArchNetworkNotConnected(new XArchEvalWinsock(err));
+        throw XArchNetworkNotConnected(error_code_to_string_winsock(err));
 
     case WSAEDISCON:
-        throw XArchNetworkShutdown(new XArchEvalWinsock(err));
+        throw XArchNetworkShutdown(error_code_to_string_winsock(err));
 
     case WSAENETRESET:
     case WSAECONNABORTED:
     case WSAECONNRESET:
-        throw XArchNetworkDisconnected(new XArchEvalWinsock(err));
+        throw XArchNetworkDisconnected(error_code_to_string_winsock(err));
 
     case WSAECONNREFUSED:
-        throw XArchNetworkConnectionRefused(new XArchEvalWinsock(err));
+        throw XArchNetworkConnectionRefused(error_code_to_string_winsock(err));
 
     case WSAEHOSTDOWN:
     case WSAETIMEDOUT:
-        throw XArchNetworkTimedOut(new XArchEvalWinsock(err));
+        throw XArchNetworkTimedOut(error_code_to_string_winsock(err));
 
     case WSAHOST_NOT_FOUND:
-        throw XArchNetworkNameUnknown(new XArchEvalWinsock(err));
+        throw XArchNetworkNameUnknown(error_code_to_string_winsock(err));
 
     case WSANO_DATA:
-        throw XArchNetworkNameNoAddress(new XArchEvalWinsock(err));
+        throw XArchNetworkNameNoAddress(error_code_to_string_winsock(err));
 
     case WSANO_RECOVERY:
-        throw XArchNetworkNameFailure(new XArchEvalWinsock(err));
+        throw XArchNetworkNameFailure(error_code_to_string_winsock(err));
 
     case WSATRY_AGAIN:
-        throw XArchNetworkNameUnavailable(new XArchEvalWinsock(err));
+        throw XArchNetworkNameUnavailable(error_code_to_string_winsock(err));
 
     default:
-        throw XArchNetwork(new XArchEvalWinsock(err));
+        throw XArchNetwork(error_code_to_string_winsock(err));
     }
 }
 
@@ -960,18 +961,18 @@ ArchNetworkWinsock::throwNameError(int err)
 {
     switch (err) {
     case WSAHOST_NOT_FOUND:
-        throw XArchNetworkNameUnknown(new XArchEvalWinsock(err));
+        throw XArchNetworkNameUnknown(error_code_to_string_winsock(err));
 
     case WSANO_DATA:
-        throw XArchNetworkNameNoAddress(new XArchEvalWinsock(err));
+        throw XArchNetworkNameNoAddress(error_code_to_string_winsock(err));
 
     case WSANO_RECOVERY:
-        throw XArchNetworkNameFailure(new XArchEvalWinsock(err));
+        throw XArchNetworkNameFailure(error_code_to_string_winsock(err));
 
     case WSATRY_AGAIN:
-        throw XArchNetworkNameUnavailable(new XArchEvalWinsock(err));
+        throw XArchNetworkNameUnavailable(error_code_to_string_winsock(err));
 
     default:
-        throw XArchNetworkName(new XArchEvalWinsock(err));
+        throw XArchNetworkName(error_code_to_string_winsock(err));
     }
 }

--- a/src/lib/arch/win32/ArchSystemWindows.cpp
+++ b/src/lib/arch/win32/ArchSystemWindows.cpp
@@ -26,6 +26,8 @@
 #include <windows.h>
 #include <psapi.h>
 
+#include <stdexcept>
+
 static const char* s_settingsKeyNames[] = {
     _T("SOFTWARE"),
     _T("Barrier"),
@@ -103,7 +105,7 @@ ArchSystemWindows::setting(const std::string& valueName, const std::string& valu
 {
     HKEY key = ArchMiscWindows::addKey(HKEY_LOCAL_MACHINE, s_settingsKeyNames);
     if (key == nullptr)
-        throw XArch(std::string("could not access registry key: ") + valueName);
+        throw std::runtime_error(std::string("could not access registry key: ") + valueName);
     ArchMiscWindows::setValue(key, valueName.c_str(), valueString.c_str());
 }
 

--- a/src/lib/arch/win32/XArchWindows.cpp
+++ b/src/lib/arch/win32/XArchWindows.cpp
@@ -20,38 +20,27 @@
 #include "arch/win32/ArchNetworkWinsock.h"
 #include "base/String.h"
 
-//
-// XArchEvalWindows
-//
-
-std::string
-XArchEvalWindows::eval() const noexcept
+std::string error_code_to_string_windows(DWORD err)
 {
     char* cmsg;
     if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
                             FORMAT_MESSAGE_IGNORE_INSERTS |
                             FORMAT_MESSAGE_FROM_SYSTEM,
                             0,
-                            m_error,
+                            err,
                             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                             (LPTSTR)&cmsg,
                             0,
                             nullptr) == 0) {
         cmsg = nullptr;
-        return inputleap::string::sprintf("Unknown error, code %d", m_error);
+        return inputleap::string::sprintf("Unknown error, code %d", err);
     }
     std::string smsg(cmsg);
     LocalFree(cmsg);
     return smsg;
 }
 
-
-//
-// XArchEvalWinsock
-//
-
-std::string
-XArchEvalWinsock::eval() const noexcept
+std::string error_code_to_string_winsock(int err)
 {
     // built-in windows function for looking up error message strings
     // may not look up network error messages correctly.  we'll have
@@ -112,7 +101,7 @@ XArchEvalWinsock::eval() const noexcept
     };
 
     for (unsigned int i = 0; s_netErrorCodes[i].m_code != 0; ++i) {
-        if (s_netErrorCodes[i].m_code == m_error) {
+        if (s_netErrorCodes[i].m_code == err) {
             return s_netErrorCodes[i].m_msg;
         }
     }

--- a/src/lib/arch/win32/XArchWindows.h
+++ b/src/lib/arch/win32/XArchWindows.h
@@ -18,32 +18,10 @@
 
 #pragma once
 
-#include "arch/XArch.h"
+#include <string>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-//! Lazy error message string evaluation for windows
-class XArchEvalWindows : public XArchEval {
-public:
-    XArchEvalWindows() : m_error(GetLastError()) { }
-    XArchEvalWindows(DWORD error) : m_error(error) { }
-    virtual ~XArchEvalWindows() { }
-
-    virtual std::string eval() const noexcept;
-
-private:
-    DWORD m_error;
-};
-
-//! Lazy error message string evaluation for winsock
-class XArchEvalWinsock : public XArchEval {
-public:
-    XArchEvalWinsock(int error) : m_error(error) { }
-    virtual ~XArchEvalWinsock() { }
-
-    virtual std::string eval() const noexcept;
-
-private:
-    int m_error;
-};
+std::string error_code_to_string_windows(DWORD err);
+std::string error_code_to_string_winsock(int err);

--- a/src/lib/inputleap/win32/AppUtilWindows.cpp
+++ b/src/lib/inputleap/win32/AppUtilWindows.cpp
@@ -44,7 +44,7 @@ AppUtilWindows::AppUtilWindows(IEventQueue* events) :
 {
     if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)consoleHandler, TRUE) == FALSE)
     {
-        throw XArch(error_code_to_string_windows(GetLastError()));
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 }
 

--- a/src/lib/inputleap/win32/AppUtilWindows.cpp
+++ b/src/lib/inputleap/win32/AppUtilWindows.cpp
@@ -44,7 +44,7 @@ AppUtilWindows::AppUtilWindows(IEventQueue* events) :
 {
     if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)consoleHandler, TRUE) == FALSE)
     {
-        throw XArch(new XArchEvalWindows());
+        throw XArch(error_code_to_string_windows(GetLastError()));
     }
 }
 

--- a/src/lib/inputleap/win32/DaemonApp.cpp
+++ b/src/lib/inputleap/win32/DaemonApp.cpp
@@ -143,7 +143,7 @@ DaemonApp::run(int argc, char** argv)
 
         return kExitSuccess;
     }
-    catch (XArch& e) {
+    catch (std::runtime_error& e) {
         std::string message = e.what();
         if (uninstall && (message.find("The service has not been started") != std::string::npos)) {
             // TODO: if we're keeping this use error code instead (what is it?!).
@@ -295,7 +295,7 @@ DaemonApp::handleIpcMessage(const Event& e, void*)
                         ARCH->setting("LogLevel", logLevel);
                         CLOG->setFilter(logLevel.c_str());
                     }
-                    catch (XArch& e) {
+                    catch (std::runtime_error& e) {
                         LOG((CLOG_ERR "failed to save LogLevel setting, %s", e.what()));
                     }
                 }
@@ -328,7 +328,7 @@ DaemonApp::handleIpcMessage(const Event& e, void*)
                 // TODO: it would be nice to store bools/ints...
                 ARCH->setting("Elevate", std::string(cm->elevate() ? "1" : "0"));
             }
-            catch (XArch& e) {
+            catch (std::runtime_error& e) {
                 LOG((CLOG_ERR "failed to save settings, %s", e.what()));
             }
 

--- a/src/lib/ipc/IpcLogOutputter.cpp
+++ b/src/lib/ipc/IpcLogOutputter.cpp
@@ -153,7 +153,7 @@ void IpcLogOutputter::buffer_thread()
             sendBuffer();
         }
     }
-    catch (XArch& e) {
+    catch (std::runtime_error& e) {
         LOG((CLOG_ERR "ipc log buffer thread error, %s", e.what()));
     }
 

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -39,7 +39,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
         LOG((CLOG_ERR "could not get process snapshot"));
-        throw XArch(error_code_to_string_windows(GetLastError()));
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     PROCESSENTRY32 entry;
@@ -50,7 +50,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
         LOG((CLOG_ERR "could not get first process entry"));
-        throw XArch(error_code_to_string_windows(GetLastError()));
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     // used to record process names for debug info
@@ -125,7 +125,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
     HANDLE sourceToken;
     if (!WTSQueryUserToken(m_activeSessionId, &sourceToken)) {
         LOG((CLOG_ERR "could not get token from session %d", m_activeSessionId));
-        throw XArch(error_code_to_string_windows(GetLastError());
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     HANDLE newToken;
@@ -134,7 +134,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
         SecurityImpersonation, TokenPrimary, &newToken)) {
 
         LOG((CLOG_ERR "could not duplicate token"));
-        throw XArch(error_code_to_string_windows(GetLastError());
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
@@ -165,7 +165,7 @@ MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
 
             // only worry about error if it's not the end of the snapshot
             LOG((CLOG_ERR "could not get next process entry"));
-            throw XArch(error_code_to_string_windows(GetLastError()));
+            throw std::runtime_error(error_code_to_string_windows(GetLastError()));
         }
     }
 

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -39,7 +39,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
         LOG((CLOG_ERR "could not get process snapshot"));
-        throw XArch(new XArchEvalWindows());
+        throw XArch(error_code_to_string_windows(GetLastError()));
     }
 
     PROCESSENTRY32 entry;
@@ -50,7 +50,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
         LOG((CLOG_ERR "could not get first process entry"));
-        throw XArch(new XArchEvalWindows());
+        throw XArch(error_code_to_string_windows(GetLastError()));
     }
 
     // used to record process names for debug info
@@ -125,7 +125,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
     HANDLE sourceToken;
     if (!WTSQueryUserToken(m_activeSessionId, &sourceToken)) {
         LOG((CLOG_ERR "could not get token from session %d", m_activeSessionId));
-        throw XArch(new XArchEvalWindows);
+        throw XArch(error_code_to_string_windows(GetLastError());
     }
 
     HANDLE newToken;
@@ -134,7 +134,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
         SecurityImpersonation, TokenPrimary, &newToken)) {
 
         LOG((CLOG_ERR "could not duplicate token"));
-        throw XArch(new XArchEvalWindows);
+        throw XArch(error_code_to_string_windows(GetLastError());
     }
 
     LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
@@ -165,7 +165,7 @@ MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
 
             // only worry about error if it's not the end of the snapshot
             LOG((CLOG_ERR "could not get next process entry"));
-            throw XArch(new XArchEvalWindows());
+            throw XArch(error_code_to_string_windows(GetLastError()));
         }
     }
 

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -112,7 +112,7 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
 
     if (!tokenRet) {
         LOG((CLOG_ERR "could not open token, process handle: %d", process));
-        throw XArch(error_code_to_string_windows(GetLastError()));
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     LOG((CLOG_DEBUG "got token %i, duplicating", sourceToken));
@@ -124,7 +124,7 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
 
     if (!duplicateRet) {
         LOG((CLOG_ERR "could not duplicate token %i", sourceToken));
-        throw XArch(error_code_to_string_windows(GetLastError()));
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
@@ -171,7 +171,7 @@ void MSWindowsWatchdog::main_loop()
     saAttr.lpSecurityDescriptor = nullptr;
 
     if (!CreatePipe(&m_stdOutRead, &m_stdOutWrite, &saAttr, 0)) {
-        throw XArch(error_code_to_string_windows(GetLastError()));
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     ZeroMemory(&m_processInfo, sizeof(PROCESS_INFORMATION));
@@ -304,7 +304,7 @@ MSWindowsWatchdog::startProcess()
         DWORD exitCode = 0;
         GetExitCodeProcess(m_processInfo.hProcess, &exitCode);
         LOG((CLOG_ERR "exit code: %d", exitCode));
-        throw XArch(error_code_to_string_windows(GetLastError());
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
     else {
         // wait for program to fail.
@@ -360,7 +360,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
     BOOL blockRet = CreateEnvironmentBlock(&environment, userToken, FALSE);
     if (!blockRet) {
         LOG((CLOG_ERR "could not create environment block"));
-        throw XArch(error_code_to_string_windows(GetLastError());
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     DWORD creationFlags =
@@ -488,7 +488,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
         LOG((CLOG_ERR "could not get process snapshot"));
-        throw XArch(error_code_to_string_windows(GetLastError());
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     PROCESSENTRY32 entry;
@@ -499,7 +499,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
         LOG((CLOG_ERR "could not get first process entry"));
-        throw XArch(error_code_to_string_windows(GetLastError());
+        throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
     // now just iterate until we can find winlogon.exe pid
@@ -526,7 +526,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
 
                 // only worry about error if it's not the end of the snapshot
                 LOG((CLOG_ERR "could not get subsiquent process entry"));
-                throw XArch(error_code_to_string_windows(GetLastError());
+                throw std::runtime_error(error_code_to_string_windows(GetLastError()));
             }
         }
     }

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -112,7 +112,7 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
 
     if (!tokenRet) {
         LOG((CLOG_ERR "could not open token, process handle: %d", process));
-        throw XArch(new XArchEvalWindows());
+        throw XArch(error_code_to_string_windows(GetLastError()));
     }
 
     LOG((CLOG_DEBUG "got token %i, duplicating", sourceToken));
@@ -124,7 +124,7 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
 
     if (!duplicateRet) {
         LOG((CLOG_ERR "could not duplicate token %i", sourceToken));
-        throw XArch(new XArchEvalWindows());
+        throw XArch(error_code_to_string_windows(GetLastError()));
     }
 
     LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
@@ -171,7 +171,7 @@ void MSWindowsWatchdog::main_loop()
     saAttr.lpSecurityDescriptor = nullptr;
 
     if (!CreatePipe(&m_stdOutRead, &m_stdOutWrite, &saAttr, 0)) {
-        throw XArch(new XArchEvalWindows());
+        throw XArch(error_code_to_string_windows(GetLastError()));
     }
 
     ZeroMemory(&m_processInfo, sizeof(PROCESS_INFORMATION));
@@ -304,7 +304,7 @@ MSWindowsWatchdog::startProcess()
         DWORD exitCode = 0;
         GetExitCodeProcess(m_processInfo.hProcess, &exitCode);
         LOG((CLOG_ERR "exit code: %d", exitCode));
-        throw XArch(new XArchEvalWindows);
+        throw XArch(error_code_to_string_windows(GetLastError());
     }
     else {
         // wait for program to fail.
@@ -360,7 +360,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
     BOOL blockRet = CreateEnvironmentBlock(&environment, userToken, FALSE);
     if (!blockRet) {
         LOG((CLOG_ERR "could not create environment block"));
-        throw XArch(new XArchEvalWindows);
+        throw XArch(error_code_to_string_windows(GetLastError());
     }
 
     DWORD creationFlags =
@@ -488,7 +488,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
         LOG((CLOG_ERR "could not get process snapshot"));
-        throw XArch(new XArchEvalWindows);
+        throw XArch(error_code_to_string_windows(GetLastError());
     }
 
     PROCESSENTRY32 entry;
@@ -499,7 +499,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
         LOG((CLOG_ERR "could not get first process entry"));
-        throw XArch(new XArchEvalWindows);
+        throw XArch(error_code_to_string_windows(GetLastError());
     }
 
     // now just iterate until we can find winlogon.exe pid
@@ -526,7 +526,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
 
                 // only worry about error if it's not the end of the snapshot
                 LOG((CLOG_ERR "could not get subsiquent process entry"));
-                throw XArch(new XArchEvalWindows);
+                throw XArch(error_code_to_string_windows(GetLastError());
             }
         }
     }

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -112,12 +112,12 @@ OSXScreen::OSXScreen(IEventQueue* events, bool isPrimary, bool autoShowHideCurso
 #if defined(MAC_OS_X_VERSION_10_9)
 			// we can't pass options to show the dialog, this must be done by the gui.
 			if (!AXIsProcessTrusted()) {
-				throw XArch("assistive devices does not trust this process, allow it in system settings.");
+                throw std::runtime_error("assistive devices does not trust this process, allow it in system settings.");
 			}
 #else
 			// now deprecated in mavericks.
 			if (!AXAPIEnabled()) {
-				throw XArch("assistive devices is not enabled, enable it in system settings.");
+                throw std::runtime_error("assistive devices is not enabled, enable it in system settings.");
 			}
 #endif
 		}

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -100,7 +100,7 @@ XWindowsScreen::XWindowsScreen(
 
     // initializes Xlib support for concurrent threads.
     if (m_impl->XInitThreads() == 0)
-        throw XArch("XInitThreads() returned zero");
+        throw std::runtime_error("XInitThreads() returned zero");
 
 	// set the X I/O error handler so we catch the display disconnecting
     m_impl->XSetIOErrorHandler(&XWindowsScreen::ioErrorHandler);


### PR DESCRIPTION
The error handling is more complex than necessary. There's lazy error code to string converter that's completely unused. Removing this opens the possibility for removing the XArch base exception class.