### PR TITLE
Cleanup copyright information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2022 The Input Leap Developers
+Copyright (c) 2021-2023 The InputLeap Developers
 Copyright (C) 2018 Debauchee Open Source Group
 Copyright (C) 2012-2016 Symless Ltd.
 Copyright (C) 2008-2014 Nick Bolton

--- a/src/cmd/barrierc/barrierc.rc
+++ b/src/cmd/barrierc/barrierc.rc
@@ -70,7 +70,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2021-2023 InputLeap contributors\nCopyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barrierc.exe"

--- a/src/cmd/barrierc/barrierc.rc
+++ b/src/cmd/barrierc/barrierc.rc
@@ -70,7 +70,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 The InputLeap Developers\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barrierc.exe"

--- a/src/cmd/barrierd/barrierd.rc
+++ b/src/cmd/barrierd/barrierd.rc
@@ -69,7 +69,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 The InputLeap Developers\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barrierd.exe"

--- a/src/cmd/barrierd/barrierd.rc
+++ b/src/cmd/barrierd/barrierd.rc
@@ -69,7 +69,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2021-2023 InputLeap contributors\nCopyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barrierd.exe"

--- a/src/cmd/barriers/barriers.rc
+++ b/src/cmd/barriers/barriers.rc
@@ -70,7 +70,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 The InputLeap Developers\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barriers.exe"

--- a/src/cmd/barriers/barriers.rc
+++ b/src/cmd/barriers/barriers.rc
@@ -70,7 +70,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2021-2023 InputLeap contributors\nCopyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barriers.exe"

--- a/src/gui/gui.ts
+++ b/src/gui/gui.ts
@@ -12,7 +12,7 @@
         <location filename="res/AboutDialogBase.ui" line="53"/>
         <source>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Barrier is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;
@@ -21,7 +21,7 @@ The Barrier GUI is based on QSynergy by Volker Lanz.
 &lt;/p&gt;</source>
         <oldsource>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Barrier is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;

--- a/src/gui/res/lang/gui_hu.ts
+++ b/src/gui/res/lang/gui_hu.ts
@@ -12,7 +12,7 @@
         <location filename="res/AboutDialogBase.ui" line="53"/>
         <source>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Input Leap is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;
@@ -21,7 +21,7 @@ The Input Leap GUI is based on QSynergy by Volker Lanz.
 &lt;/p&gt;</source>
         <oldsource>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Input Leap is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;
@@ -30,7 +30,7 @@ The Input Leap GUI is based on QSynergy by Volker Lanz.
 &lt;/p&gt;</oldsource>
         <translation>&lt;p&gt;
 Alkalmazás egér és billentyűzet megosztásához. Rendszerfüggetlen és nyílt forráskódú.&lt;br /&gt;&lt;br /&gt;
-Szerzői jog © 2018 The InputLeap Developers&lt;br /&gt;
+Szerzői jog © 2018 Debauchee Open Source Group&lt;br /&gt;
 Szerzői jog © 2012-2016 Symless Ltd.&lt;br /&gt;
 Szerzői jog © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 A Input Leap a GNU Általános Nyilvános Licenc (GPLv2) oltalma alatt áll.&lt;br /&gt;&lt;br /&gt;

--- a/src/gui/res/lang/gui_ja-JP.ts
+++ b/src/gui/res/lang/gui_ja-JP.ts
@@ -12,7 +12,7 @@
         <location filename="res/AboutDialogBase.ui" line="53"/>
         <source>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Input Leap is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;
@@ -21,7 +21,7 @@ The Input Leap GUI is based on QSynergy by Volker Lanz.
 &lt;/p&gt;</source>
         <translation>&lt;p&gt;
 キーボードとマウスの共有ソフトウェアです。クロスプラットフォームでオープンソースです。&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Input Leap は GNU General Public (GPLv2) のライセンスで公開されています。&lt;br /&gt;&lt;br /&gt;

--- a/src/gui/res/lang/gui_zh-CN.ts
+++ b/src/gui/res/lang/gui_zh-CN.ts
@@ -28,7 +28,7 @@
         <location filename="../../src/AboutDialogBase.ui" line="53"/>
         <source>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Input Leap is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;
@@ -37,7 +37,7 @@ The Input Leap GUI is based on QSynergy by Volker Lanz.
 &lt;/p&gt;</source>
         <translation>&lt;p&gt;
 共享键盘和鼠标，跨平台并开源。&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Input Leap 适用 GNU 通用公共许可证（GPLv2）。&lt;br /&gt;&lt;br /&gt;

--- a/src/gui/res/win/Barrier.rc
+++ b/src/gui/res/win/Barrier.rc
@@ -68,7 +68,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
-            VALUE "CompanyWeb", "https://github.com/input-leap/barrier/"
+            VALUE "CompanyWeb", "https://github.com/input-leap/input-leap/"
             VALUE "FileVersion", INPUTLEAP_VERSION
             VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"

--- a/src/gui/res/win/Barrier.rc
+++ b/src/gui/res/win/Barrier.rc
@@ -70,7 +70,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/input-leap/"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2021-2023 InputLeap contributors\nCopyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barrier.exe"

--- a/src/gui/res/win/Barrier.rc
+++ b/src/gui/res/win/Barrier.rc
@@ -70,7 +70,7 @@ BEGIN
             VALUE "CompanyName", "The InputLeap Developers"
             VALUE "CompanyWeb", "https://github.com/input-leap/barrier/"
             VALUE "FileVersion", INPUTLEAP_VERSION
-            VALUE "LegalCopyright", "Copyright (C) 2018 The InputLeap Developers\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
+            VALUE "LegalCopyright", "Copyright (C) 2018 Debauchee Open Source Group\nCopyright (C) 2012-2016 Symless Ltd.\nCopyright (C) 2008-2014 Nick Bolton\nCopyright (C) 2002-2014 Chris Schoeneman"
             VALUE "ProductName", "Barrier"
             VALUE "ProductVersion", INPUTLEAP_VERSION
             VALUE "OriginalFilename", "barrier.exe"

--- a/src/gui/src/AboutDialogBase.ui
+++ b/src/gui/src/AboutDialogBase.ui
@@ -52,7 +52,7 @@
      <property name="text">
       <string>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
-Copyright © 2018 The InputLeap Developers&lt;br /&gt;
+Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;
 Barrier is released under the GNU General Public License (GPLv2).&lt;br /&gt;&lt;br /&gt;

--- a/src/gui/src/LogWindow.cpp
+++ b/src/gui/src/LogWindow.cpp
@@ -1,6 +1,6 @@
 /*
 * InputLeap -- mouse and keyboard sharing utility
-* Copyright (C) 2018 The InputLeap Developers
+* Copyright (C) 2018 Debauchee Open Source Group
 *
 * This package is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License

--- a/src/gui/src/LogWindow.h
+++ b/src/gui/src/LogWindow.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/gui/src/ShutdownCh.h
+++ b/src/gui/src/ShutdownCh.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -67,9 +67,9 @@ int main(int argc, char* argv[])
     /* Workaround for QTBUG-40332 - "High ping when QNetworkAccessManager is instantiated" */
     ::setenv ("QT_BEARER_POLL_TIMEOUT", "-1", 1);
 #endif
-	QCoreApplication::setOrganizationName("input-leap");
+	QCoreApplication::setOrganizationName("Debauchee");
 	QCoreApplication::setOrganizationDomain("github.com");
-	QCoreApplication::setApplicationName("InputLeap");
+	QCoreApplication::setApplicationName("Barrier");
 
 	QBarrierApplication app(argc, argv);
 

--- a/src/lib/base/NonBlockingStream.cpp
+++ b/src/lib/base/NonBlockingStream.cpp
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2008 The InputLeap Developers
+ * Copyright (C) 2008 Debauchee Open Source Group
  *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/lib/base/NonBlockingStream.h
+++ b/src/lib/base/NonBlockingStream.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2008 The InputLeap Developers
+ * Copyright (C) 2008 Debauchee Open Source Group
  *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/lib/common/DataDirectories.h
+++ b/src/lib/common/DataDirectories.h
@@ -1,6 +1,6 @@
 /*
 * InputLeap -- mouse and keyboard sharing utility
-* Copyright (C) 2018 The InputLeap Developers
+* Copyright (C) 2018 Debauchee Open Source Group
 *
 * This package is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License

--- a/src/lib/common/DataDirectories_static.cpp
+++ b/src/lib/common/DataDirectories_static.cpp
@@ -1,6 +1,6 @@
 /*
 * InputLeap -- mouse and keyboard sharing utility
-* Copyright (C) 2018 The InputLeap Developers
+* Copyright (C) 2018 Debauchee Open Source Group
 *
 * This package is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License

--- a/src/lib/common/Version.cpp
+++ b/src/lib/common/Version.cpp
@@ -19,11 +19,11 @@
 #include "common/Version.h"
 
 const char* kApplication = "Barrier";
-const char* kCopyright   = "Copyright (C) 2018 The InputLeap Developers\n"
+const char* kCopyright   = "Copyright (C) 2018 Debauchee Open Source Group\n"
                            "Copyright (C) 2012-2016 Symless Ltd.\n"
                            "Copyright (C) 2008-2014 Nick Bolton\n"
                            "Copyright (C) 2002-2014 Chris Schoeneman";
 const char* kContact     = "Email: todo@mail.com";
-const char* kWebsite     = "https://github.com/input-leap/barrier/";
+const char* kWebsite     = "https://github.com/debauchee/barrier/";
 const char* kVersion = INPUTLEAP_VERSION;
 const char* kAppVersion = "Barrier " INPUTLEAP_VERSION;

--- a/src/lib/common/unix/DataDirectories.cpp
+++ b/src/lib/common/unix/DataDirectories.cpp
@@ -1,6 +1,6 @@
 /*
 * InputLeap -- mouse and keyboard sharing utility
-* Copyright (C) 2018 The InputLeap Developers
+* Copyright (C) 2018 Debauchee Open Source Group
 *
 * This package is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License

--- a/src/lib/common/win32/DataDirectories.cpp
+++ b/src/lib/common/win32/DataDirectories.cpp
@@ -1,6 +1,6 @@
 /*
 * InputLeap -- mouse and keyboard sharing utility
-* Copyright (C) 2018 The InputLeap Developers
+* Copyright (C) 2018 Debauchee Open Source Group
 *
 * This package is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
  *

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
  *

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
  *

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
  *

--- a/src/lib/platform/synwinhk.h
+++ b/src/lib/platform/synwinhk.h
@@ -1,6 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2018 The InputLeap Developers
+ * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
  *


### PR DESCRIPTION
This PR reverts some past changes that adjusted copyright notices. InputLeap copyright notices have been added to some important files where missing.

I think that this should clear any pending issues with regard copyright information.

cc @shymega 