### PR TITLE
lib: Put whole project into inputleap namespace

### DIFF
--- a/src/client/MSWindowsClientTaskBarReceiver.cpp
+++ b/src/client/MSWindowsClientTaskBarReceiver.cpp
@@ -29,9 +29,7 @@
 #include "base/log_outputters.h"
 #include "base/EventTypes.h"
 
-//
-// MSWindowsClientTaskBarReceiver
-//
+namespace inputleap {
 
 const UINT MSWindowsClientTaskBarReceiver::s_stateToIconID[kMaxState] =
 {
@@ -372,3 +370,5 @@ createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events
     return new MSWindowsClientTaskBarReceiver(
         MSWindowsScreen::getWindowInstance(), logBuffer, events);
 }
+
+} // namespace inputleap

--- a/src/client/MSWindowsClientTaskBarReceiver.h
+++ b/src/client/MSWindowsClientTaskBarReceiver.h
@@ -21,6 +21,8 @@
 #include "inputleap/ClientTaskBarReceiver.h"
 #include "common/win32/winapi.h"
 
+namespace inputleap {
+
 class BufferedLogOutputter;
 class IEventQueue;
 
@@ -61,3 +63,5 @@ private:
 
     static const UINT    s_stateToIconID[];
 };
+
+} // namespace inputleap

--- a/src/client/barrierc.cpp
+++ b/src/client/barrierc.cpp
@@ -25,12 +25,13 @@
 #include "MSWindowsClientTaskBarReceiver.h"
 #endif
 
+namespace inputleap {
+
 #if WINAPI_XWINDOWS || WINAPI_CARBON
 CreateTaskBarReceiverFunc createTaskBarReceiver = nullptr;
 #endif
 
-int
-main(int argc, char** argv)
+int client_main(int argc, char** argv)
 {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
@@ -52,5 +53,11 @@ main(int argc, char** argv)
     }
 #endif
     return result;
+}
 
+} // namespace inputleap
+
+int main(int argc, char** argv)
+{
+    return inputleap::client_main(argc, argv);
 }

--- a/src/daemon/barrierd.cpp
+++ b/src/daemon/barrierd.cpp
@@ -25,7 +25,7 @@
 int
 main(int argc, char** argv)
 {
-    DaemonApp app;
+    inputleap::DaemonApp app;
     return app.run(argc, argv);
 }
 
@@ -36,7 +36,7 @@ main(int argc, char** argv)
 int WINAPI
 WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 {
-    DaemonApp app;
+    inputleap::DaemonApp app;
     return app.run(__argc, __argv);
 }
 

--- a/src/lib/arch/Arch.cpp
+++ b/src/lib/arch/Arch.cpp
@@ -18,9 +18,7 @@
 
 #include "arch/Arch.h"
 
-//
-// Arch
-//
+namespace inputleap {
 
 Arch* Arch::s_instance = nullptr;
 
@@ -58,3 +56,5 @@ Arch::getInstance()
     assert(s_instance != nullptr);
     return s_instance;
 }
+
+} // namespace inputleap

--- a/src/lib/arch/Arch.h
+++ b/src/lib/arch/Arch.h
@@ -56,6 +56,8 @@
 
 #include <mutex>
 
+namespace inputleap {
+
 /*!
 \def ARCH
 This macro evaluates to the singleton Arch object.
@@ -106,3 +108,5 @@ public:
 private:
     static Arch*        s_instance;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/IArchMultithread.cpp
+++ b/src/lib/arch/IArchMultithread.cpp
@@ -18,6 +18,8 @@
 
 #include "IArchMultithread.h"
 
+namespace inputleap {
+
 bool IArchMultithread::wait_cond_var(std::condition_variable& cv,
                                      std::unique_lock<std::mutex>& lock, double timeout)
 {
@@ -47,4 +49,4 @@ bool IArchMultithread::wait_cond_var(std::condition_variable& cv,
     return false;
 }
 
-
+} // namespace inputleap

--- a/src/lib/arch/IArchMultithread.h
+++ b/src/lib/arch/IArchMultithread.h
@@ -22,6 +22,8 @@
 #include <mutex>
 #include <condition_variable>
 
+namespace inputleap {
+
 /*!
 \class ArchThreadImpl
 \brief Internal thread data.
@@ -201,3 +203,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -20,6 +20,8 @@
 
 #include <string>
 
+namespace inputleap {
+
 class ArchThreadImpl;
 typedef ArchThreadImpl* ArchThread;
 
@@ -282,3 +284,5 @@ public:
 
     virtual void init() = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/IArchTaskBar.h
+++ b/src/lib/arch/IArchTaskBar.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+namespace inputleap {
+
 class IArchTaskBarReceiver;
 
 //! Interface for architecture dependent task bar control
@@ -61,3 +63,5 @@ public:
 
     virtual void init() = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/IArchTaskBarReceiver.h
+++ b/src/lib/arch/IArchTaskBarReceiver.h
@@ -20,6 +20,8 @@
 
 #include <string>
 
+namespace inputleap {
+
 class IScreen;
 class INode;
 
@@ -97,3 +99,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -29,9 +29,11 @@
 #include <errno.h>
 #include <cstdlib>
 
-//
-// ArchDaemonUnix
-//
+#ifdef __APPLE__
+extern char** NXArgv;
+#endif
+
+namespace inputleap {
 
 ArchDaemonUnix::ArchDaemonUnix()
 {
@@ -52,7 +54,6 @@ ArchDaemonUnix::~ArchDaemonUnix()
 int
 execSelfNonDaemonized()
 {
-    extern char** NXArgv;
     char** selfArgv = NXArgv;
 
     setenv("_INPUTLEAP_DAEMONIZED", "", 1);
@@ -131,3 +132,5 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
     // invoke function
     return func(1, &name);
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchDaemonUnix.h
+++ b/src/lib/arch/unix/ArchDaemonUnix.h
@@ -23,6 +23,8 @@
 #undef ARCH_DAEMON
 #define ARCH_DAEMON ArchDaemonUnix
 
+namespace inputleap {
+
 //! Unix implementation of IArchDaemon
 class ArchDaemonUnix : public ArchDaemonNone {
 public:
@@ -32,5 +34,7 @@ public:
     // IArchDaemon overrides
     int daemonize(const char* name, DaemonFunc func) override;
 };
+
+} // namespace inputleap
 
 #define CONFIG_FILE "/etc/barrier/barrierd.conf"

--- a/src/lib/arch/unix/ArchLogUnix.cpp
+++ b/src/lib/arch/unix/ArchLogUnix.cpp
@@ -20,9 +20,7 @@
 
 #include <syslog.h>
 
-//
-// ArchLogUnix
-//
+namespace inputleap {
 
 ArchLogUnix::ArchLogUnix()
 {
@@ -82,3 +80,5 @@ ArchLogUnix::writeLog(ELevel level, const char* msg)
     // log it
     syslog(priority, "%s", msg);
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchLogUnix.h
+++ b/src/lib/arch/unix/ArchLogUnix.h
@@ -22,6 +22,8 @@
 
 #define ARCH_LOG ArchLogUnix
 
+namespace inputleap {
+
 //! Unix implementation of IArchLog
 class ArchLogUnix : public IArchLog {
 public:
@@ -34,3 +36,5 @@ public:
     void showLog(bool) override;
     void writeLog(ELevel, const char*) override;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -40,9 +40,7 @@ setSignalSet(sigset_t* sigset)
     sigaddset(sigset, SIGUSR2);
 }
 
-//
-// ArchThreadImpl
-//
+namespace inputleap {
 
 class ArchThreadImpl {
 public:
@@ -599,3 +597,5 @@ ArchMultithreadPosix::threadSignalHandler(void*)
 
     return nullptr;
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -28,6 +28,8 @@
 
 #define ARCH_MULTITHREAD ArchMultithreadPosix
 
+namespace inputleap {
+
 //! Posix implementation of IArchMultithread
 class ArchMultithreadPosix : public IArchMultithread {
 public:
@@ -96,3 +98,5 @@ private:
     SignalFunc m_signalFunc[kNUM_SIGNALS];
     void* m_signalUserData[kNUM_SIGNALS];
 };
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -39,6 +39,7 @@
 
 #include <poll.h>
 
+namespace inputleap {
 
 static const int s_family[] = {
     PF_UNSPEC,
@@ -840,3 +841,5 @@ ArchNetworkBSD::throwNameError(int err)
         throw XArchNetworkName(s_msg[4]);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -28,7 +28,6 @@
 #    include <sys/socket.h>
 #endif
 
-
 // old systems may use char* for [gs]etsockopt()'s optval argument.
 // this should be void on modern systems but char is forwards
 // compatible so we always use it.
@@ -36,6 +35,8 @@ typedef char optval_t;
 
 #define ARCH_NETWORK ArchNetworkBSD
 #define TYPED_ADDR(type_, addr_) (reinterpret_cast<type_*>(&addr_->m_addr))
+
+namespace inputleap {
 
 class ArchSocketImpl {
 public:
@@ -100,3 +101,5 @@ private:
 private:
     std::mutex mutex_;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchSystemUnix.cpp
+++ b/src/lib/arch/unix/ArchSystemUnix.cpp
@@ -20,9 +20,7 @@
 
 #include <sys/utsname.h>
 
-//
-// ArchSystemUnix
-//
+namespace inputleap {
 
 ArchSystemUnix::ArchSystemUnix()
 {
@@ -78,3 +76,5 @@ ArchSystemUnix::getLibsUsed(void) const
 {
     return "not implemented.\nuse lsof on shell";
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchSystemUnix.h
+++ b/src/lib/arch/unix/ArchSystemUnix.h
@@ -24,6 +24,8 @@
 
 #define ARCH_SYSTEM ArchSystemUnix
 
+namespace inputleap {
+
 //! Unix implementation of IArchSystem
 class ArchSystemUnix : public IArchSystem {
 public:
@@ -38,3 +40,5 @@ public:
     std::string getLibsUsed(void) const override;
 
 };
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchTaskBarXWindows.cpp
+++ b/src/lib/arch/unix/ArchTaskBarXWindows.cpp
@@ -18,9 +18,7 @@
 
 #include "arch/unix/ArchTaskBarXWindows.h"
 
-//
-// ArchTaskBarXWindows
-//
+namespace inputleap {
 
 ArchTaskBarXWindows::ArchTaskBarXWindows()
 {
@@ -49,3 +47,5 @@ ArchTaskBarXWindows::updateReceiver(IArchTaskBarReceiver* /*receiver*/)
 {
     // do nothing
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/ArchTaskBarXWindows.h
+++ b/src/lib/arch/unix/ArchTaskBarXWindows.h
@@ -22,6 +22,8 @@
 
 #define ARCH_TASKBAR ArchTaskBarXWindows
 
+namespace inputleap {
+
 //! X11 implementation of IArchTaskBar
 class ArchTaskBarXWindows : public IArchTaskBar {
 public:
@@ -33,3 +35,5 @@ public:
     void removeReceiver(IArchTaskBarReceiver*) override;
     void updateReceiver(IArchTaskBarReceiver*) override;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/unix/XArchUnix.cpp
+++ b/src/lib/arch/unix/XArchUnix.cpp
@@ -20,8 +20,12 @@
 
 #include <cstring>
 
+namespace inputleap {
+
 std::string error_code_to_string_errno(int err)
 {
     // FIXME -- not thread safe
     return std::strerror(err);
 }
+
+} // namespace inputleap

--- a/src/lib/arch/unix/XArchUnix.h
+++ b/src/lib/arch/unix/XArchUnix.h
@@ -20,4 +20,8 @@
 
 #include <string>
 
+namespace inputleap {
+
 std::string error_code_to_string_errno(int err);
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchDaemonWindows.cpp
+++ b/src/lib/arch/win32/ArchDaemonWindows.cpp
@@ -25,9 +25,7 @@
 #include <sstream>
 #include <vector>
 
-//
-// ArchDaemonWindows
-//
+namespace inputleap {
 
 ArchDaemonWindows*        ArchDaemonWindows::s_daemon = nullptr;
 
@@ -682,3 +680,5 @@ ArchDaemonWindows::uninstallDaemon()
         uninstallDaemon(DEFAULT_DAEMON_NAME);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchDaemonWindows.h
+++ b/src/lib/arch/win32/ArchDaemonWindows.h
@@ -30,6 +30,8 @@
 
 #define ARCH_DAEMON ArchDaemonWindows
 
+namespace inputleap {
+
 //! Win32 implementation of IArchDaemon
 class ArchDaemonWindows : public IArchDaemon {
 public:
@@ -151,3 +153,5 @@ static const TCHAR* const g_daemonKeyPath[] = {
     _T("Service"),
     nullptr
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchLogWindows.cpp
+++ b/src/lib/arch/win32/ArchLogWindows.cpp
@@ -21,9 +21,7 @@
 
 #include <string.h>
 
-//
-// ArchLogWindows
-//
+namespace inputleap {
 
 ArchLogWindows::ArchLogWindows() : m_eventLog(nullptr)
 {
@@ -93,3 +91,5 @@ ArchLogWindows::writeLog(ELevel level, const char* msg)
                     const_cast<char*>(msg)); // raw data
     }
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchLogWindows.h
+++ b/src/lib/arch/win32/ArchLogWindows.h
@@ -25,6 +25,8 @@
 
 #define ARCH_LOG ArchLogWindows
 
+namespace inputleap {
+
 //! Win32 implementation of IArchLog
 class ArchLogWindows : public IArchLog {
 public:
@@ -40,3 +42,5 @@ public:
 private:
     HANDLE m_eventLog;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -40,9 +40,7 @@
 #endif
 typedef DWORD EXECUTION_STATE;
 
-//
-// ArchMiscWindows
-//
+namespace inputleap {
 
 ArchMiscWindows::Dialogs* ArchMiscWindows::s_dialogs = nullptr;
 DWORD ArchMiscWindows::s_busyState = 0;
@@ -525,3 +523,5 @@ ArchMiscWindows::setInstanceWin32(HINSTANCE instance)
     assert(instance != nullptr);
     s_instanceWin32 = instance;
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -27,6 +27,8 @@
 #include <set>
 #include <string>
 
+namespace inputleap {
+
 //! Miscellaneous win32 functions.
 class ArchMiscWindows {
 public:
@@ -200,3 +202,5 @@ private:
     static HICON        s_smallIcon;
     static HINSTANCE    s_instanceWin32;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchMultithreadWindows.cpp
+++ b/src/lib/arch/win32/ArchMultithreadWindows.cpp
@@ -36,9 +36,7 @@
 // can cause busy waiting.
 //
 
-//
-// ArchThreadImpl
-//
+namespace inputleap {
 
 class ArchThreadImpl {
 public:
@@ -529,3 +527,5 @@ ArchMultithreadWindows::doThreadFunc(ArchThread thread)
     // done with thread
     closeThread(thread);
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -28,6 +28,8 @@
 
 #define ARCH_MULTITHREAD ArchMultithreadWindows
 
+namespace inputleap {
+
 //! Win32 implementation of IArchMultithread
 class ArchMultithreadWindows : public IArchMultithread {
 public:
@@ -92,3 +94,5 @@ private:
     SignalFunc m_signalFunc[kNUM_SIGNALS];
     void* m_signalUserData[kNUM_SIGNALS];
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -25,6 +25,8 @@
 
 #include <malloc.h>
 
+namespace inputleap {
+
 static const int s_family[] = {
     PF_UNSPEC,
     PF_INET,
@@ -976,3 +978,5 @@ ArchNetworkWinsock::throwNameError(int err)
         throw XArchNetworkName(error_code_to_string_winsock(err));
     }
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -39,6 +39,8 @@
 
 #define ARCH_NETWORK ArchNetworkWinsock
 
+namespace inputleap {
+
 class ArchSocketImpl {
 public:
     SOCKET m_socket;
@@ -111,3 +113,5 @@ private:
     std::mutex mutex_;
     EventList m_unblockEvents;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchSystemWindows.cpp
+++ b/src/lib/arch/win32/ArchSystemWindows.cpp
@@ -34,9 +34,7 @@ static const char* s_settingsKeyNames[] = {
     nullptr
 };
 
-//
-// ArchSystemWindows
-//
+namespace inputleap {
 
 ArchSystemWindows::ArchSystemWindows()
 {
@@ -166,3 +164,5 @@ ArchSystemWindows::getLibsUsed(void) const
     CloseHandle(hProcess);
     return msg;
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchSystemWindows.h
+++ b/src/lib/arch/win32/ArchSystemWindows.h
@@ -22,6 +22,8 @@
 
 #define ARCH_SYSTEM ArchSystemWindows
 
+namespace inputleap {
+
 //! Win32 implementation of IArchSystem
 class ArchSystemWindows : public IArchSystem {
 public:
@@ -37,3 +39,5 @@ public:
 
     bool isWOW64() const;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchTaskBarWindows.cpp
+++ b/src/lib/arch/win32/ArchTaskBarWindows.cpp
@@ -32,9 +32,7 @@ static const UINT        kUpdateReceiver  = WM_USER + 12;
 static const UINT        kNotifyReceiver  = WM_USER + 13;
 static const UINT        kFirstReceiverID = WM_USER + 14;
 
-//
-// ArchTaskBarWindows
-//
+namespace inputleap {
 
 ArchTaskBarWindows* ArchTaskBarWindows::s_instance = nullptr;
 
@@ -484,3 +482,5 @@ HINSTANCE ArchTaskBarWindows::instanceWin32()
 {
     return ArchMiscWindows::instanceWin32();
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/ArchTaskBarWindows.h
+++ b/src/lib/arch/win32/ArchTaskBarWindows.h
@@ -30,6 +30,8 @@
 
 #define ARCH_TASKBAR ArchTaskBarWindows
 
+namespace inputleap {
+
 //! Win32 implementation of IArchTaskBar
 class ArchTaskBarWindows : public IArchTaskBar {
 public:
@@ -113,3 +115,5 @@ private:
     Dialogs m_dialogs;
     Dialogs m_addedDialogs;
 };
+
+} // namespace inputleap

--- a/src/lib/arch/win32/XArchWindows.cpp
+++ b/src/lib/arch/win32/XArchWindows.cpp
@@ -20,6 +20,8 @@
 #include "arch/win32/ArchNetworkWinsock.h"
 #include "base/String.h"
 
+namespace inputleap {
+
 std::string error_code_to_string_windows(DWORD err)
 {
     char* cmsg;
@@ -107,3 +109,5 @@ std::string error_code_to_string_winsock(int err)
     }
     return "Unknown error";
 }
+
+} // namespace inputleap

--- a/src/lib/arch/win32/XArchWindows.h
+++ b/src/lib/arch/win32/XArchWindows.h
@@ -23,5 +23,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 std::string error_code_to_string_windows(DWORD err);
 std::string error_code_to_string_winsock(int err);
+
+} // namespace inputleap

--- a/src/lib/base/Event.cpp
+++ b/src/lib/base/Event.cpp
@@ -19,9 +19,7 @@
 #include "base/Event.h"
 #include "base/EventQueue.h"
 
-//
-// Event
-//
+namespace inputleap {
 
 Event::Event() :
     m_type(kUnknown),
@@ -98,3 +96,5 @@ Event::setDataObject(EventData* dataObject)
     assert(m_dataObject == nullptr);
     m_dataObject = dataObject;
 }
+
+} // namespace inputleap

--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -22,6 +22,8 @@
 #include <cstdint>
 #include <map>
 
+namespace inputleap {
+
 class EventData {
 public:
     EventData() { }
@@ -124,3 +126,5 @@ private:
     Flags m_flags;
     EventData* m_dataObject;
 };
+
+} // namespace inputleap

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -27,6 +27,8 @@
 #include "base/XBase.h"
 #include "../gui/src/ShutdownCh.h"
 
+namespace inputleap {
+
 EVENT_TYPE_ACCESSOR(Client)
 EVENT_TYPE_ACCESSOR(IStream)
 EVENT_TYPE_ACCESSOR(IpcClient)
@@ -631,3 +633,5 @@ EventQueue::Timer::operator<(const Timer& t) const
 {
     return m_time < t.m_time;
 }
+
+} // namespace inputleap

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -32,6 +32,8 @@
 #include <queue>
 #include <set>
 
+namespace inputleap {
+
 //! Event queue
 /*!
 An event queue that implements the platform independent parts and
@@ -191,3 +193,5 @@ EventQueue::for##type_() {                                                \
     }                                                                        \
     return *m_typesFor##type_;                                                \
 }
+
+} // namespace inputleap

--- a/src/lib/base/EventTypes.cpp
+++ b/src/lib/base/EventTypes.cpp
@@ -21,6 +21,8 @@
 #include <assert.h>
 #include <stddef.h>
 
+namespace inputleap {
+
 EventTypes::EventTypes() :
     m_events(nullptr)
 {
@@ -203,3 +205,5 @@ REGISTER_EVENT(Clipboard, clipboardSending)
 REGISTER_EVENT(File, fileChunkSending)
 REGISTER_EVENT(File, fileReceiveCompleted)
 REGISTER_EVENT(File, keepAlive)
+
+} // namespace inputleap

--- a/src/lib/base/EventTypes.h
+++ b/src/lib/base/EventTypes.h
@@ -19,6 +19,8 @@
 
 #include "base/Event.h"
 
+namespace inputleap {
+
 class IEventQueue;
 
 class EventTypes {
@@ -767,3 +769,5 @@ private:
     Event::Type m_fileReceiveCompleted;
     Event::Type m_keepAlive;
 };
+
+} // namespace inputleap

--- a/src/lib/base/FunctionEventJob.cpp
+++ b/src/lib/base/FunctionEventJob.cpp
@@ -18,9 +18,7 @@
 
 #include "base/FunctionEventJob.h"
 
-//
-// FunctionEventJob
-//
+namespace inputleap {
 
 FunctionEventJob::FunctionEventJob(
                 void (*func)(const Event&, void*), void* arg) :
@@ -42,3 +40,5 @@ FunctionEventJob::run(const Event& event)
         m_func(event, m_arg);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/base/FunctionEventJob.h
+++ b/src/lib/base/FunctionEventJob.h
@@ -21,6 +21,8 @@
 #include "base/IEventJob.h"
 #include <cstddef>
 
+namespace inputleap {
+
 //! Use a function as an event job
 /*!
 An event job class that invokes a function.
@@ -38,3 +40,5 @@ private:
     void  (*m_func)(const Event&, void*);
     void* m_arg;
 };
+
+} // namespace inputleap

--- a/src/lib/base/IEventJob.h
+++ b/src/lib/base/IEventJob.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+namespace inputleap {
 
 class Event;
 
@@ -32,3 +33,5 @@ public:
     //! Run the job
     virtual void run(const Event&) = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -21,6 +21,8 @@
 #include "base/Event.h"
 #include <string>
 
+namespace inputleap {
+
 class IEventJob;
 class IEventQueueBuffer;
 
@@ -242,3 +244,5 @@ public:
     virtual ClipboardEvents& forClipboard() = 0;
     virtual FileEvents& forFile() = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/base/IEventQueueBuffer.h
+++ b/src/lib/base/IEventQueueBuffer.h
@@ -20,6 +20,8 @@
 
 #include <cstdint>
 
+namespace inputleap {
+
 class Event;
 class EventQueueTimer;
 
@@ -100,3 +102,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/base/ILogOutputter.h
+++ b/src/lib/base/ILogOutputter.h
@@ -21,6 +21,8 @@
 #include "base/Log.h"
 #include "base/ELevel.h"
 
+namespace inputleap {
+
 //! Outputter interface
 /*!
 Type of outputter interface.  The logger performs all output through
@@ -68,3 +70,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -27,6 +27,8 @@
 #include <iostream>
 #include <ctime>
 
+namespace inputleap {
+
 // names of priorities
 static const char*        g_priority[] = {
     "FATAL",
@@ -302,3 +304,5 @@ Log::output(ELevel priority, char* msg)
         }
     }
 }
+
+} // namespace inputleap

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -29,6 +29,8 @@
 #define CLOG (Log::getInstance())
 #define BYE "\nTry `%s --help' for more information."
 
+namespace inputleap {
+
 class ILogOutputter;
 class Thread;
 
@@ -209,3 +211,5 @@ otherwise it expands to a call that doesn't.
 #define CLOG_DEBUG3        CLOG_TRACE "%z\070"
 #define CLOG_DEBUG4        CLOG_TRACE "%z\071" // char is '9'
 #define CLOG_DEBUG5        CLOG_TRACE "%z\072" // char is ':'
+
+} // namespace inputleap

--- a/src/lib/base/SimpleEventQueueBuffer.cpp
+++ b/src/lib/base/SimpleEventQueueBuffer.cpp
@@ -20,6 +20,8 @@
 #include "base/Stopwatch.h"
 #include "arch/Arch.h"
 
+namespace inputleap {
+
 class EventQueueTimer { };
 
 //
@@ -93,3 +95,5 @@ SimpleEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
 {
     delete timer;
 }
+
+} // namespace inputleap

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -23,6 +23,8 @@
 #include <condition_variable>
 #include <deque>
 
+namespace inputleap {
+
 //! In-memory event queue buffer
 /*!
 An event queue buffer provides a queue of events for an IEventQueue.
@@ -50,3 +52,4 @@ private:
     EventDeque m_queue;
 };
 
+} // namespace inputleap

--- a/src/lib/base/TMethodEventJob.h
+++ b/src/lib/base/TMethodEventJob.h
@@ -20,6 +20,8 @@
 
 #include "IEventJob.h"
 
+namespace inputleap {
+
 //! Use a member function as an event job
 /*!
 An event job class that invokes a member function.
@@ -67,3 +69,5 @@ TMethodEventJob<T>::run(const Event& event)
         (m_object->*m_method)(event, m_arg);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/base/log_outputters.cpp
+++ b/src/lib/base/log_outputters.cpp
@@ -23,13 +23,11 @@
 #include <fstream>
 #include <iostream>
 
+namespace inputleap {
+
 enum EFileLogOutputter {
     kFileSizeLimit = 1024 // kb
 };
-
-//
-// StopLogOutputter
-//
 
 StopLogOutputter::StopLogOutputter()
 {
@@ -341,3 +339,5 @@ MesssageBoxLogOutputter::write(ELevel level, const char* msg)
 
     return true;
 }
+
+} // namespace inputleap

--- a/src/lib/base/log_outputters.h
+++ b/src/lib/base/log_outputters.h
@@ -27,6 +27,8 @@
 #include <fstream>
 #include <string>
 
+namespace inputleap {
+
 //! Stop traversing log chain outputter
 /*!
 This outputter performs no output and returns false from \c write(),
@@ -170,3 +172,5 @@ public:
     void show(bool showIfEmpty) override;
     bool write(ELevel level, const char* message) override;
 };
+
+} // namespace inputleap

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -45,9 +45,7 @@
 #include <stdexcept>
 #include <fstream>
 
-//
-// Client
-//
+namespace inputleap {
 
 Client::Client(IEventQueue* events, const std::string& name, const NetworkAddress& address,
                ISocketFactory* socketFactory,
@@ -821,3 +819,5 @@ void Client::sendDragInfo(std::uint32_t fileCount, std::string& info, size_t siz
 {
     m_server->sendDragInfo(fileCount, info.c_str(), size);
 }
+
+} // namespace inputleap

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -27,12 +27,14 @@
 #include "net/NetworkAddress.h"
 #include "base/EventTypes.h"
 
+namespace inputleap {
+
 class EventQueueTimer;
-namespace inputleap { class Screen; }
+class Screen;
 class ServerProxy;
 class IDataSocket;
 class ISocketFactory;
-namespace inputleap { class IStream; }
+class IStream;
 class IEventQueue;
 class Thread;
 class TCPSocket;
@@ -222,3 +224,5 @@ private:
     ClientArgs m_args;
     bool m_enableClipboard;
 };
+
+} // namespace inputleap

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -35,9 +35,7 @@
 
 #include <memory>
 
-//
-// ServerProxy
-//
+namespace inputleap {
 
 ServerProxy::ServerProxy(Client* client, inputleap::IStream* stream, IEventQueue* events) :
     m_client(client),
@@ -918,3 +916,5 @@ void ServerProxy::sendDragInfo(std::uint32_t fileCount, const char* info, size_t
     std::string data(info, size);
     ProtocolUtil::writef(m_stream, kMsgDDragInfo, fileCount, &data);
 }
+
+} // namespace inputleap

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -22,11 +22,13 @@
 #include "inputleap/key_types.h"
 #include "base/Event.h"
 
+namespace inputleap {
+
 class Client;
 class ClientInfo;
 class EventQueueTimer;
 class IClipboard;
-namespace inputleap { class IStream; }
+class IStream;
 class IEventQueue;
 
 //! Proxy for server
@@ -129,3 +131,5 @@ private:
     MessageParser m_parser;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/App.cpp
+++ b/src/lib/inputleap/App.cpp
@@ -47,11 +47,9 @@
 #include "platform/OSXDragSimulator.h"
 #endif
 
-App* App::s_instance = nullptr;
+namespace inputleap {
 
-//
-// App
-//
+App* App::s_instance = nullptr;
 
 App::App(IEventQueue* events, CreateTaskBarReceiverFunc createTaskBarReceiver, ArgsBase* args) :
     m_bye(&exit),
@@ -331,3 +329,5 @@ MinimalApp::parseArgs(int argc, const char* const* argv)
     (void) argc;
     (void) argv;
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/App.h
+++ b/src/lib/inputleap/App.h
@@ -32,11 +32,13 @@
 #include "inputleap/unix/AppUtilUnix.h"
 #endif
 
+namespace inputleap {
+
 class IArchTaskBarReceiver;
 class BufferedLogOutputter;
 class ILogOutputter;
 class FileLogOutputter;
-namespace inputleap { class Screen; }
+class Screen;
 class IEventQueue;
 class SocketMultiplexer;
 
@@ -200,3 +202,5 @@ private:
     "      --exit-pause         wait for key press on exit, can be useful for\n" \
     "                             reading error messages that occur on exit.\n"
 #endif
+
+} // namespace inputleap

--- a/src/lib/inputleap/AppUtil.cpp
+++ b/src/lib/inputleap/AppUtil.cpp
@@ -19,6 +19,8 @@
 #include "inputleap/AppUtil.h"
 #include <cassert>
 
+namespace inputleap {
+
 AppUtil* AppUtil::s_instance = nullptr;
 
 AppUtil::AppUtil() :
@@ -51,3 +53,5 @@ AppUtil::instance()
     assert(s_instance != nullptr);
     return *s_instance;
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/AppUtil.h
+++ b/src/lib/inputleap/AppUtil.h
@@ -21,6 +21,8 @@
 #include "inputleap/IAppUtil.h"
 #include "inputleap/XBarrier.h"
 
+namespace inputleap {
+
 class AppUtil : public IAppUtil {
 public:
     AppUtil();
@@ -38,3 +40,5 @@ private:
     IApp* m_app;
     static AppUtil* s_instance;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -30,6 +30,8 @@
 #include <VersionHelpers.h>
 #endif
 
+namespace inputleap {
+
 XArgvParserError::XArgvParserError(const char *fmt, ...) :
     message("Unknown reason")
 {
@@ -505,3 +507,5 @@ std::string ArgParser::parse_exename(const char* arg)
     // FIXME: we assume UTF-8 encoding, but on Windows this is not correct
     return inputleap::fs::u8path(arg).filename().u8string();
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ArgParser.h
+++ b/src/lib/inputleap/ArgParser.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+namespace inputleap {
+
 class ServerArgs;
 class ClientArgs;
 class ArgsBase;
@@ -102,3 +104,5 @@ private:
 
     static ArgsBase* m_argsBase;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ArgsBase.cpp
+++ b/src/lib/inputleap/ArgsBase.cpp
@@ -18,6 +18,8 @@
 
 #include "inputleap/ArgsBase.h"
 
+namespace inputleap {
+
 ArgsBase::ArgsBase() :
 #if SYSAPI_WIN32
 m_daemon(false), // daemon mode not supported on windows (use --service)
@@ -48,3 +50,5 @@ m_pluginDirectory("")
 ArgsBase::~ArgsBase()
 {
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ArgsBase.h
+++ b/src/lib/inputleap/ArgsBase.h
@@ -20,6 +20,8 @@
 
 #include "io/filesystem.h"
 
+namespace inputleap {
+
 class ArgsBase {
 public:
     ArgsBase();
@@ -50,3 +52,5 @@ public:
     inputleap::fs::path m_profileDirectory;
     inputleap::fs::path m_pluginDirectory;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -60,6 +60,8 @@
 
 #define RETRY_TIME 1.0
 
+namespace inputleap {
+
 ClientApp::ClientApp(IEventQueue* events, CreateTaskBarReceiverFunc createTaskBarReceiver) :
     App(events, createTaskBarReceiver, new ClientArgs()),
     m_client(nullptr),
@@ -556,3 +558,5 @@ ClientApp::startNode()
         m_bye(kExitFailed);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClientApp.h
+++ b/src/lib/inputleap/ClientApp.h
@@ -21,7 +21,9 @@
 #include "inputleap/App.h"
 #include "ClientArgs.h"
 
-namespace inputleap { class Screen; }
+namespace inputleap {
+
+class Screen;
 class Event;
 class Client;
 class NetworkAddress;
@@ -81,3 +83,5 @@ private:
     inputleap::Screen* m_clientScreen;
     NetworkAddress* m_serverAddress;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClientArgs.cpp
+++ b/src/lib/inputleap/ClientArgs.cpp
@@ -17,7 +17,11 @@
 
 #include "inputleap/ClientArgs.h"
 
+namespace inputleap {
+
 ClientArgs::ClientArgs() :
     m_yscroll(0)
 {
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClientArgs.h
+++ b/src/lib/inputleap/ClientArgs.h
@@ -19,6 +19,8 @@
 
 #include "inputleap/ArgsBase.h"
 
+namespace inputleap {
+
 class NetworkAddress;
 
 class ClientArgs : public ArgsBase {
@@ -28,3 +30,5 @@ public:
 public:
     int m_yscroll;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClientTaskBarReceiver.cpp
+++ b/src/lib/inputleap/ClientTaskBarReceiver.cpp
@@ -23,9 +23,7 @@
 #include "arch/Arch.h"
 #include "common/Version.h"
 
-//
-// ClientTaskBarReceiver
-//
+namespace inputleap {
 
 ClientTaskBarReceiver::ClientTaskBarReceiver(IEventQueue* events) :
     m_state(kNotRunning),
@@ -137,3 +135,5 @@ ClientTaskBarReceiver::getToolTip() const
         return "";
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClientTaskBarReceiver.h
+++ b/src/lib/inputleap/ClientTaskBarReceiver.h
@@ -23,6 +23,8 @@
 #include "base/log_outputters.h"
 #include "client/Client.h"
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Implementation of IArchTaskBarReceiver for the barrier server
@@ -87,5 +89,7 @@ private:
 };
 
 IArchTaskBarReceiver* createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events);
+
+} // namespace inputleap
 
 #endif

--- a/src/lib/inputleap/Clipboard.cpp
+++ b/src/lib/inputleap/Clipboard.cpp
@@ -19,9 +19,7 @@
 #include "inputleap/Clipboard.h"
 #include <cassert>
 
-//
-// Clipboard
-//
+namespace inputleap {
 
 Clipboard::Clipboard() :
     m_open(false),
@@ -115,3 +113,5 @@ std::string Clipboard::marshall() const
 {
     return IClipboard::marshall(this);
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/Clipboard.h
+++ b/src/lib/inputleap/Clipboard.h
@@ -20,6 +20,8 @@
 
 #include "inputleap/IClipboard.h"
 
+namespace inputleap {
+
 //! Memory buffer clipboard
 /*!
 This class implements a clipboard that stores data in memory.
@@ -69,3 +71,5 @@ private:
     bool m_added[kNumFormats];
     std::string m_data[kNumFormats];
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClipboardChunk.cpp
+++ b/src/lib/inputleap/ClipboardChunk.cpp
@@ -24,6 +24,8 @@
 #include "base/String.h"
 #include <cstring>
 
+namespace inputleap {
+
 size_t ClipboardChunk::s_expectedSize = 0;
 
 ClipboardChunk::ClipboardChunk(size_t size) :
@@ -145,3 +147,5 @@ ClipboardChunk::send(inputleap::IStream* stream, void* data)
 
     ProtocolUtil::writef(stream, kMsgDClipboard, id, sequence, mark, &dataChunk);
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ClipboardChunk.h
+++ b/src/lib/inputleap/ClipboardChunk.h
@@ -26,8 +26,8 @@
 #define CLIPBOARD_CHUNK_META_SIZE 7
 
 namespace inputleap {
+
 class IStream;
-}
 
 class ClipboardChunk : public Chunk {
 public:
@@ -47,3 +47,5 @@ public:
 private:
     static size_t        s_expectedSize;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/DragInformation.cpp
+++ b/src/lib/inputleap/DragInformation.cpp
@@ -24,6 +24,8 @@
 
 using namespace std;
 
+namespace inputleap {
+
 DragInformation::DragInformation() :
     m_filename(),
     m_filesize(0)
@@ -150,3 +152,5 @@ std::string DragInformation::getFileSize(std::string& filename)
 
     return ss.str();
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/DragInformation.h
+++ b/src/lib/inputleap/DragInformation.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+namespace inputleap {
+
 class DragInformation;
 typedef std::vector<DragInformation> DragFileList;
 
@@ -51,3 +53,5 @@ private:
     std::string m_filename;
     size_t m_filesize;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/DropHelper.cpp
+++ b/src/lib/inputleap/DropHelper.cpp
@@ -22,6 +22,8 @@
 
 #include <fstream>
 
+namespace inputleap {
+
 void
 DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, std::string& data)
 {
@@ -36,7 +38,7 @@ DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, s
         dropTarget.append("/");
 #endif
         dropTarget.append(fileList.at(0).getFilename());
-        inputleap::open_utf8_path(file, dropTarget, std::ios::out | std::ios::binary);
+        open_utf8_path(file, dropTarget, std::ios::out | std::ios::binary);
         if (!file.is_open()) {
             LOG((CLOG_ERR "drop file failed: can not open %s", dropTarget.c_str()));
         }
@@ -52,3 +54,5 @@ DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, s
         LOG((CLOG_ERR "drop file failed: drop target is empty"));
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/DropHelper.h
+++ b/src/lib/inputleap/DropHelper.h
@@ -20,8 +20,12 @@
 #include "inputleap/DragInformation.h"
 #include <string>
 
+namespace inputleap {
+
 class DropHelper {
 public:
     static void writeToDir(const std::string& destination,
                            DragFileList& fileList, std::string& data);
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/FileChunk.cpp
+++ b/src/lib/inputleap/FileChunk.cpp
@@ -24,6 +24,8 @@
 #include "base/String.h"
 #include "base/Log.h"
 
+namespace inputleap {
+
 static const std::uint16_t kIntervalThreshold = 1;
 
 FileChunk::FileChunk(size_t size) :
@@ -155,3 +157,5 @@ void FileChunk::send(inputleap::IStream* stream, std::uint8_t mark, char* data, 
 
     ProtocolUtil::writef(stream, kMsgDFileTransfer, mark, &chunk);
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/FileChunk.h
+++ b/src/lib/inputleap/FileChunk.h
@@ -25,8 +25,8 @@
 #define FILE_CHUNK_META_SIZE 2
 
 namespace inputleap {
+
 class IStream;
-}
 
 class FileChunk : public Chunk {
 public:
@@ -38,3 +38,5 @@ public:
     static int assemble(inputleap::IStream* stream, std::string& dataCached, size_t& expectedSize);
     static void send(inputleap::IStream* stream, std::uint8_t mark, char* data, size_t dataSize);
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IApp.h
+++ b/src/lib/inputleap/IApp.h
@@ -18,12 +18,14 @@
 
 #pragma once
 
+namespace inputleap {
+
 typedef int (*StartupFunc)(int, char**);
 
 class ILogOutputter;
 class ArgsBase;
 class IArchTaskBarReceiver;
-namespace inputleap { class Screen; }
+class Screen;
 class IEventQueue;
 
 class IApp {
@@ -44,3 +46,5 @@ public:
     virtual inputleap::Screen* createScreen() = 0;
     virtual IEventQueue* getEvents() const = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IAppUtil.h
+++ b/src/lib/inputleap/IAppUtil.h
@@ -20,6 +20,8 @@
 
 #include "inputleap/IApp.h"
 
+namespace inputleap {
+
 class IAppUtil {
 public:
     virtual ~IAppUtil() { }
@@ -30,3 +32,5 @@ public:
     virtual void beforeAppExit() = 0;
     virtual void startNode() = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IClient.h
+++ b/src/lib/inputleap/IClient.h
@@ -25,6 +25,8 @@
 #include "inputleap/option_types.h"
 #include <string>
 
+namespace inputleap {
+
 //! Client interface
 /*!
 This interface defines the methods necessary for the server to
@@ -165,3 +167,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IClipboard.cpp
+++ b/src/lib/inputleap/IClipboard.cpp
@@ -20,9 +20,7 @@
 #include <cassert>
 #include <vector>
 
-//
-// IClipboard
-//
+namespace inputleap {
 
 void IClipboard::unmarshall(IClipboard* clipboard, const std::string& data, Time time)
 {
@@ -163,3 +161,5 @@ void IClipboard::writeUInt32(std::string* buf, std::uint32_t v)
     *buf += static_cast<std::uint8_t>((v >>  8) & 0xff);
     *buf += static_cast<std::uint8_t>( v & 0xff);
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/IClipboard.h
+++ b/src/lib/inputleap/IClipboard.h
@@ -21,6 +21,8 @@
 #include "base/EventTypes.h"
 #include <string>
 
+namespace inputleap {
+
 //! Clipboard interface
 /*!
 This interface defines the methods common to all clipboards.
@@ -167,3 +169,5 @@ private:
     static std::uint32_t readUInt32(const char*);
     static void writeUInt32(std::string*, std::uint32_t);
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IKeyState.cpp
+++ b/src/lib/inputleap/IKeyState.cpp
@@ -22,9 +22,7 @@
 #include <cstring>
 #include <cstdlib>
 
-//
-// IKeyState
-//
+namespace inputleap {
 
 IKeyState::IKeyState(IEventQueue* events)
 {
@@ -154,3 +152,5 @@ void IKeyState::KeyInfo::split(const char* screens, std::set<std::string>& dst)
         i = j + 1;
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/IKeyState.h
+++ b/src/lib/inputleap/IKeyState.h
@@ -24,6 +24,8 @@
 #include "base/EventTypes.h"
 #include <set>
 
+namespace inputleap {
+
 //! Key state interface
 /*!
 This interface provides access to set and query the keyboard state and
@@ -172,3 +174,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/INode.h
+++ b/src/lib/inputleap/INode.h
@@ -18,7 +18,11 @@
 
 #pragma once
 
+namespace inputleap {
+
 class INode {
 public:
     virtual ~INode() { }
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IPlatformScreen.cpp
+++ b/src/lib/inputleap/IPlatformScreen.cpp
@@ -17,9 +17,13 @@
 
 #include "inputleap/IPlatformScreen.h"
 
+namespace inputleap {
+
 bool
 IPlatformScreen::fakeMediaKey(KeyID id)
 {
     (void) id;
     return false;
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/IPlatformScreen.h
+++ b/src/lib/inputleap/IPlatformScreen.h
@@ -28,6 +28,8 @@
 
 class IClipboard;
 
+namespace inputleap {
+
 //! Screen interface
 /*!
 This interface defines the methods common to all platform dependent
@@ -183,3 +185,5 @@ protected:
     */
     virtual void handleSystemEvent(const Event& event, void*) = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IScreen.h
+++ b/src/lib/inputleap/IScreen.h
@@ -22,6 +22,8 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 
+namespace inputleap {
+
 class IClipboard;
 
 //! Screen interface
@@ -70,3 +72,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/IScreenSaver.h
+++ b/src/lib/inputleap/IScreenSaver.h
@@ -20,6 +20,8 @@
 
 #include "base/Event.h"
 
+namespace inputleap {
+
 //! Screen saver interface
 /*!
 This interface defines the methods common to all screen savers.
@@ -74,3 +76,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/KeyState.cpp
+++ b/src/lib/inputleap/KeyState.cpp
@@ -24,6 +24,8 @@
 #include <iterator>
 #include <list>
 
+namespace inputleap {
+
 static const KeyButton kButtonMask = static_cast<KeyButton>(IKeyState::kNumButtons - 1);
 
 static const KeyID s_decomposeTable[] = {
@@ -926,3 +928,5 @@ KeyState::AddActiveModifierContext::AddActiveModifierContext(std::int32_t group,
 {
     // do nothing
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/KeyState.h
+++ b/src/lib/inputleap/KeyState.h
@@ -21,6 +21,8 @@
 #include "inputleap/IKeyState.h"
 #include "inputleap/KeyMap.h"
 
+namespace inputleap {
+
 //! Core key state
 /*!
 This class provides key state services.  Subclasses must implement a few
@@ -221,3 +223,5 @@ private:
 
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/PacketStreamFilter.cpp
+++ b/src/lib/inputleap/PacketStreamFilter.cpp
@@ -24,9 +24,7 @@
 #include <cstring>
 #include <memory>
 
-//
-// PacketStreamFilter
-//
+namespace inputleap {
 
 PacketStreamFilter::PacketStreamFilter(IEventQueue* events, inputleap::IStream* stream, bool adoptStream) :
     StreamFilter(events, stream, adoptStream),
@@ -202,3 +200,5 @@ PacketStreamFilter::filterEvent(const Event& event)
     // pass event
     StreamFilter::filterEvent(event);
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/PacketStreamFilter.h
+++ b/src/lib/inputleap/PacketStreamFilter.h
@@ -23,6 +23,8 @@
 
 #include <mutex>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Packetizing stream filter
@@ -60,3 +62,5 @@ private:
     bool m_inputShutdown;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/PlatformScreen.cpp
+++ b/src/lib/inputleap/PlatformScreen.cpp
@@ -20,6 +20,8 @@
 #include "inputleap/App.h"
 #include "inputleap/ArgsBase.h"
 
+namespace inputleap {
+
 PlatformScreen::PlatformScreen(IEventQueue* events) :
     IPlatformScreen(events),
     m_draggingStarted(false),
@@ -119,3 +121,5 @@ PlatformScreen::isDraggingStarted()
     }
     return false;
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/PlatformScreen.h
+++ b/src/lib/inputleap/PlatformScreen.h
@@ -22,6 +22,8 @@
 #include "inputleap/DragInformation.h"
 #include <stdexcept>
 
+namespace inputleap {
+
 //! Base screen implementation
 /*!
 This screen implementation is the superclass of all other screen
@@ -84,3 +86,5 @@ protected:
     bool m_draggingStarted;
     bool m_fakeDraggingStarted;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/PortableTaskBarReceiver.cpp
+++ b/src/lib/inputleap/PortableTaskBarReceiver.cpp
@@ -22,9 +22,7 @@
 #include "arch/Arch.h"
 #include "common/Version.h"
 
-//
-// PortableTaskBarReceiver
-//
+namespace inputleap {
 
 PortableTaskBarReceiver::PortableTaskBarReceiver(IEventQueue* events) :
     m_state(kNotRunning),
@@ -116,3 +114,5 @@ PortableTaskBarReceiver::getToolTip() const
         return "";
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/PortableTaskBarReceiver.h
+++ b/src/lib/inputleap/PortableTaskBarReceiver.h
@@ -25,6 +25,8 @@
 #include "base/Event.h"
 #include <vector>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Implementation of IArchTaskBarReceiver for the barrier server
@@ -89,3 +91,5 @@ private:
 };
 
 IArchTaskBarReceiver* createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events);
+
+} // namespace inputleap

--- a/src/lib/inputleap/ProtocolUtil.cpp
+++ b/src/lib/inputleap/ProtocolUtil.cpp
@@ -26,9 +26,7 @@
 #include <cstring>
 #include <vector>
 
-//
-// ProtocolUtil
-//
+namespace inputleap {
 
 void
 ProtocolUtil::writef(inputleap::IStream* stream, const char* fmt, ...)
@@ -566,3 +564,5 @@ std::string XIOReadMismatch::getWhat() const noexcept
 {
     return format("XIOReadMismatch", "ProtocolUtil::readf() mismatch");
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ProtocolUtil.h
+++ b/src/lib/inputleap/ProtocolUtil.h
@@ -23,7 +23,9 @@
 
 #include <stdarg.h>
 
-namespace inputleap { class IStream; }
+namespace inputleap {
+
+class IStream;
 
 //! Barrier protocol utilities
 /*!
@@ -90,3 +92,5 @@ public:
     // XBase overrides
     std::string getWhat() const noexcept override;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/Screen.h
+++ b/src/lib/inputleap/Screen.h
@@ -25,11 +25,11 @@
 #include "inputleap/mouse_types.h"
 #include "inputleap/option_types.h"
 
+namespace inputleap {
+
 class IClipboard;
 class IPlatformScreen;
 class IEventQueue;
-
-namespace inputleap {
 
 //! Platform independent screen
 /*!

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -65,9 +65,7 @@
 #include <fstream>
 #include <sstream>
 
-//
-// ServerApp
-//
+namespace inputleap {
 
 ServerApp::ServerApp(IEventQueue* events, CreateTaskBarReceiverFunc createTaskBarReceiver) :
     App(events, createTaskBarReceiver, new ServerArgs()),
@@ -924,3 +922,5 @@ ServerApp::startNode()
         m_bye(kExitFailed);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ServerApp.h
+++ b/src/lib/inputleap/ServerApp.h
@@ -29,6 +29,8 @@
 
 #include <map>
 
+namespace inputleap {
+
 enum EServerState {
     kUninitialized,
     kInitializing,
@@ -39,7 +41,7 @@ enum EServerState {
 };
 
 class Server;
-namespace inputleap { class Screen; }
+class Screen;
 class ClientListener;
 class EventQueueTimer;
 class ILogOutputter;
@@ -124,3 +126,5 @@ private:
 #define USR_CONFIG_NAME ".barrier.conf"
 #define SYS_CONFIG_NAME "barrier.conf"
 #endif
+
+} // namespace inputleap

--- a/src/lib/inputleap/ServerArgs.cpp
+++ b/src/lib/inputleap/ServerArgs.cpp
@@ -17,6 +17,8 @@
 
 #include "inputleap/ServerArgs.h"
 
+namespace inputleap {
+
 ServerArgs::ServerArgs() :
     m_configFile(),
     m_config(nullptr),
@@ -24,3 +26,4 @@ ServerArgs::ServerArgs() :
 {
 }
 
+} // namespace inputleap

--- a/src/lib/inputleap/ServerArgs.h
+++ b/src/lib/inputleap/ServerArgs.h
@@ -19,6 +19,8 @@
 
 #include "inputleap/ArgsBase.h"
 
+namespace inputleap {
+
 class NetworkAddress;
 class Config;
 
@@ -32,3 +34,5 @@ public:
     std::string m_screenChangeScript;
     bool check_client_certificates = true;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/ServerTaskBarReceiver.cpp
+++ b/src/lib/inputleap/ServerTaskBarReceiver.cpp
@@ -22,9 +22,7 @@
 #include "arch/Arch.h"
 #include "common/Version.h"
 
-//
-// ServerTaskBarReceiver
-//
+namespace inputleap {
 
 ServerTaskBarReceiver::ServerTaskBarReceiver(IEventQueue* events) :
     m_state(kNotRunning),
@@ -132,3 +130,5 @@ ServerTaskBarReceiver::getToolTip() const
         return "";
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/ServerTaskBarReceiver.h
+++ b/src/lib/inputleap/ServerTaskBarReceiver.h
@@ -26,6 +26,8 @@
 #include "base/Event.h"
 #include <vector>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Implementation of IArchTaskBarReceiver for the barrier server
@@ -93,3 +95,5 @@ private:
 };
 
 IArchTaskBarReceiver* createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events);
+
+} // namespace inputleap

--- a/src/lib/inputleap/StreamChunker.cpp
+++ b/src/lib/inputleap/StreamChunker.cpp
@@ -30,6 +30,8 @@
 #include <fstream>
 #include <stdexcept>
 
+namespace inputleap {
+
 using namespace std;
 
 static const size_t g_chunkSize = 32 * 1024; //32kb
@@ -159,3 +161,5 @@ StreamChunker::interruptFile()
         LOG((CLOG_INFO "previous dragged file has become invalid"));
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/StreamChunker.h
+++ b/src/lib/inputleap/StreamChunker.h
@@ -21,6 +21,8 @@
 
 #include <string>
 
+namespace inputleap {
+
 class IEventQueue;
 
 class StreamChunker {
@@ -34,3 +36,5 @@ private:
     static bool            s_isChunkingFile;
     static bool            s_interruptFile;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/XBarrier.cpp
+++ b/src/lib/inputleap/XBarrier.cpp
@@ -19,9 +19,7 @@
 #include "inputleap/XBarrier.h"
 #include "base/String.h"
 
-//
-// XBadClient
-//
+namespace inputleap {
 
 std::string XBadClient::getWhat() const noexcept
 {
@@ -121,3 +119,5 @@ std::string XExitApp::getWhat() const noexcept
         "XExitApp", "exiting with code %{1}",
         inputleap::string::sprintf("%d", m_code).c_str());
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/XBarrier.h
+++ b/src/lib/inputleap/XBarrier.h
@@ -20,6 +20,8 @@
 
 #include "base/XBase.h"
 
+namespace inputleap {
+
 //! Generic barrier exception
 XBASE_SUBCLASS(XBarrier, XBase);
 
@@ -131,3 +133,5 @@ protected:
 private:
     int m_code;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/XScreen.cpp
+++ b/src/lib/inputleap/XScreen.cpp
@@ -18,9 +18,7 @@
 
 #include "inputleap/XScreen.h"
 
-//
-// XScreenOpenFailure
-//
+namespace inputleap {
 
 std::string XScreenOpenFailure::getWhat() const noexcept
 {
@@ -63,3 +61,5 @@ std::string XScreenUnavailable::getWhat() const noexcept
 {
     return format("XScreenUnavailable", "unable to open screen");
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/XScreen.h
+++ b/src/lib/inputleap/XScreen.h
@@ -20,6 +20,8 @@
 
 #include "base/XBase.h"
 
+namespace inputleap {
+
 //! Generic screen exception
 XBASE_SUBCLASS(XScreen, XBase);
 
@@ -66,3 +68,5 @@ protected:
 private:
     double m_timeUntilRetry;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/protocol_types.cpp
+++ b/src/lib/inputleap/protocol_types.cpp
@@ -18,6 +18,8 @@
 
 #include "inputleap/protocol_types.h"
 
+namespace inputleap {
+
 const char*                kMsgHello            = "Barrier%2i%2i";
 const char*                kMsgHelloBack        = "Barrier%2i%2i%s";
 const char*                kMsgCNoop             = "CNOP";
@@ -51,3 +53,5 @@ const char*                kMsgEIncompatible    = "EICV%2i%2i";
 const char*                kMsgEBusy             = "EBSY";
 const char*                kMsgEUnknown        = "EUNK";
 const char*                kMsgEBad            = "EBAD";
+
+} // namespace inputleap

--- a/src/lib/inputleap/protocol_types.h
+++ b/src/lib/inputleap/protocol_types.h
@@ -22,6 +22,8 @@
 
 #include <cstdint>
 
+namespace inputleap {
+
 // protocol version number
 // 1.0:  initial protocol
 // 1.1:  adds KeyCode to key press, release, and repeat
@@ -343,3 +345,5 @@ public:
     */
     std::int32_t m_mx, m_my;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/unix/AppUtilUnix.cpp
+++ b/src/lib/inputleap/unix/AppUtilUnix.cpp
@@ -19,6 +19,8 @@
 #include "inputleap/unix/AppUtilUnix.h"
 #include "inputleap/ArgsBase.h"
 
+namespace inputleap {
+
 AppUtilUnix::AppUtilUnix(IEventQueue* events)
 {
     (void) events;
@@ -45,3 +47,5 @@ AppUtilUnix::startNode()
 {
     app().startNode();
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/unix/AppUtilUnix.h
+++ b/src/lib/inputleap/unix/AppUtilUnix.h
@@ -22,6 +22,8 @@
 
 #define ARCH_APP_UTIL AppUtilUnix
 
+namespace inputleap {
+
 class IEventQueue;
 
 class AppUtilUnix : public AppUtil {
@@ -32,3 +34,5 @@ public:
     int run(int argc, char** argv) override;
     void startNode() override;
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/win32/AppUtilWindows.cpp
+++ b/src/lib/inputleap/win32/AppUtilWindows.cpp
@@ -38,6 +38,8 @@
 #include <conio.h>
 #include <VersionHelpers.h>
 
+namespace inputleap {
+
 AppUtilWindows::AppUtilWindows(IEventQueue* events) :
     m_events(events),
     m_exitMode(kExitModeNormal)
@@ -184,3 +186,5 @@ AppUtilWindows::startNode()
 {
     app().startNode();
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/win32/AppUtilWindows.h
+++ b/src/lib/inputleap/win32/AppUtilWindows.h
@@ -25,6 +25,8 @@
 
 #define ARCH_APP_UTIL AppUtilWindows
 
+namespace inputleap {
+
 class IEventQueue;
 
 enum AppExitMode {
@@ -59,3 +61,5 @@ private:
 
     static BOOL WINAPI consoleHandler(DWORD Event);
 };
+
+} // namespace inputleap

--- a/src/lib/inputleap/win32/DaemonApp.cpp
+++ b/src/lib/inputleap/win32/DaemonApp.cpp
@@ -50,6 +50,8 @@
 #include <iostream>
 #include <sstream>
 
+namespace inputleap {
+
 using namespace std;
 
 DaemonApp* DaemonApp::s_instance = nullptr;
@@ -361,3 +363,5 @@ DaemonApp::handleIpcMessage(const Event& e, void*)
             break;
     }
 }
+
+} // namespace inputleap

--- a/src/lib/inputleap/win32/DaemonApp.h
+++ b/src/lib/inputleap/win32/DaemonApp.h
@@ -23,6 +23,8 @@
 
 #include <string>
 
+namespace inputleap {
+
 class Event;
 class IpcLogOutputter;
 class FileLogOutputter;
@@ -56,3 +58,5 @@ private:
 };
 
 #define LOG_FILENAME "barrierd.log"
+
+} // namespace inputleap

--- a/src/lib/io/StreamFilter.cpp
+++ b/src/lib/io/StreamFilter.cpp
@@ -20,11 +20,9 @@
 #include "base/IEventQueue.h"
 #include "base/TMethodEventJob.h"
 
-//
-// StreamFilter
-//
+namespace inputleap {
 
-StreamFilter::StreamFilter(IEventQueue* events, inputleap::IStream* stream, bool adoptStream) :
+StreamFilter::StreamFilter(IEventQueue* events, IStream* stream, bool adoptStream) :
     m_stream(stream),
     m_adopted(adoptStream),
     m_events(events)
@@ -113,3 +111,5 @@ StreamFilter::handleUpstreamEvent(const Event& event, void*)
 {
     filterEvent(event);
 }
+
+} // namespace inputleap

--- a/src/lib/io/StreamFilter.h
+++ b/src/lib/io/StreamFilter.h
@@ -21,19 +21,21 @@
 #include "io/IStream.h"
 #include "base/IEventQueue.h"
 
+namespace inputleap {
+
 //! A stream filter
 /*!
 This class wraps a stream.  Subclasses provide indirect access
 to the wrapped stream, typically performing some filtering.
 */
-class StreamFilter : public inputleap::IStream {
+class StreamFilter : public IStream {
 public:
     /*!
     Create a wrapper around \c stream.  Iff \c adoptStream is true then
     this object takes ownership of the stream and will delete it in the
     d'tor.
     */
-    StreamFilter(IEventQueue* events, inputleap::IStream* stream, bool adoptStream = true);
+    StreamFilter(IEventQueue* events, IStream* stream, bool adoptStream = true);
     ~StreamFilter() override;
 
     // IStream overrides
@@ -71,3 +73,5 @@ private:
     bool m_adopted;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcClient.cpp
+++ b/src/lib/ipc/IpcClient.cpp
@@ -23,9 +23,7 @@
 #include "base/TMethodEventJob.h"
 #include <cassert>
 
-//
-// IpcClient
-//
+namespace inputleap {
 
 IpcClient::IpcClient(IEventQueue* events, SocketMultiplexer* socketMultiplexer) :
     m_serverAddress(NetworkAddress(IPC_HOST, IPC_PORT)),
@@ -104,3 +102,5 @@ IpcClient::handleMessageReceived(const Event& e, void*)
     event.setDataObject(e.getDataObject());
     m_events->addEvent(event);
 }
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcClient.h
+++ b/src/lib/ipc/IpcClient.h
@@ -23,6 +23,8 @@
 #include "base/EventTypes.h"
 #include <memory>
 
+namespace inputleap {
+
 class IpcServerProxy;
 class IpcMessage;
 class IEventQueue;
@@ -63,3 +65,5 @@ private:
     std::unique_ptr<IpcServerProxy> server_;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -26,11 +26,9 @@
 #include "base/TMethodEventJob.h"
 #include "base/Log.h"
 
-//
-// IpcClientProxy
-//
+namespace inputleap {
 
-IpcClientProxy::IpcClientProxy(std::unique_ptr<inputleap::IStream>&& stream, IEventQueue* events) :
+IpcClientProxy::IpcClientProxy(std::unique_ptr<IStream>&& stream, IEventQueue* events) :
     stream_(std::move(stream)),
     m_clientType(kIpcClientUnknown),
     m_disconnecting(false),
@@ -186,3 +184,5 @@ IpcClientProxy::disconnect()
     stream_->close();
     m_events->addEvent(Event(m_events->forIpcClientProxy().disconnected(), this));
 }
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcClientProxy.h
+++ b/src/lib/ipc/IpcClientProxy.h
@@ -25,11 +25,13 @@
 
 #include <mutex>
 
-namespace inputleap { class IStream; }
+namespace inputleap {
+
 class IpcMessage;
 class IpcCommandMessage;
 class IpcHelloMessage;
 class IEventQueue;
+class IStream;
 
 class IpcClientProxy {
     friend class IpcServer;
@@ -55,3 +57,5 @@ private:
     std::mutex m_writeMutex;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcLogOutputter.cpp
+++ b/src/lib/ipc/IpcLogOutputter.cpp
@@ -30,6 +30,8 @@
 #include "base/Time.h"
 #include "base/TMethodEventJob.h"
 
+namespace inputleap {
+
 enum EIpcLogOutputter {
     kBufferMaxSize = 1000,
     kMaxSendLines = 100,
@@ -212,3 +214,5 @@ void IpcLogOutputter::bufferRateLimit(std::uint16_t writeLimit, double timeLimit
     m_bufferRateWriteLimit = writeLimit;
     m_bufferRateTimeLimit = timeLimit;
 }
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -27,6 +27,8 @@
 #include <condition_variable>
 #include <mutex>
 
+namespace inputleap {
+
 class IpcServer;
 class Event;
 class IpcClientProxy;
@@ -119,3 +121,5 @@ private:
     EIpcClientType m_clientType;
     std::mutex m_runningMutex;
 };
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcMessage.cpp
+++ b/src/lib/ipc/IpcMessage.cpp
@@ -19,6 +19,8 @@
 #include "ipc/IpcMessage.h"
 #include "ipc/Ipc.h"
 
+namespace inputleap {
+
 IpcMessage::IpcMessage(std::uint8_t type) :
     m_type(type)
 {
@@ -67,3 +69,5 @@ IpcCommandMessage::IpcCommandMessage(const std::string& command, bool elevate) :
 IpcCommandMessage::~IpcCommandMessage()
 {
 }
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcMessage.h
+++ b/src/lib/ipc/IpcMessage.h
@@ -23,6 +23,8 @@
 #include "base/Event.h"
 #include <string>
 
+namespace inputleap {
+
 class IpcMessage : public EventData {
 public:
     virtual ~IpcMessage();
@@ -83,3 +85,5 @@ private:
     std::string m_command;
     bool m_elevate;
 };
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -28,9 +28,7 @@
 #include "base/Event.h"
 #include "base/Log.h"
 
-//
-// IpcServer
-//
+namespace inputleap {
 
 IpcServer::IpcServer(IEventQueue* events, SocketMultiplexer* socketMultiplexer) :
     m_mock(false),
@@ -182,3 +180,5 @@ IpcServer::send(const IpcMessage& message, EIpcClientType filterType)
         }
     }
 }
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -27,6 +27,8 @@
 #include <list>
 #include <mutex>
 
+namespace inputleap {
+
 class Event;
 class IpcClientProxy;
 class IpcMessage;
@@ -90,3 +92,5 @@ public:
         m_socketMultiplexer(nullptr) { }
 #endif
 };
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -25,9 +25,7 @@
 #include "base/TMethodEventJob.h"
 #include "base/Log.h"
 
-//
-// IpcServerProxy
-//
+namespace inputleap {
 
 IpcServerProxy::IpcServerProxy(inputleap::IStream& stream, IEventQueue* events) :
     m_stream(stream),
@@ -121,3 +119,5 @@ IpcServerProxy::disconnect()
     LOG((CLOG_DEBUG "ipc disconnect, closing stream"));
     m_stream.close();
 }
+
+} // namespace inputleap

--- a/src/lib/ipc/IpcServerProxy.h
+++ b/src/lib/ipc/IpcServerProxy.h
@@ -21,7 +21,9 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 
-namespace inputleap { class IStream; }
+namespace inputleap {
+
+class IStream;
 class IpcMessage;
 class IpcLogLineMessage;
 class IEventQueue;
@@ -44,3 +46,5 @@ private:
     inputleap::IStream& m_stream;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -24,9 +24,7 @@
 #include "base/Log.h"
 #include "base/IJob.h"
 
-//
-// Thread
-//
+namespace inputleap {
 
 Thread::Thread(const std::function<void()>& fun)
 {
@@ -158,3 +156,5 @@ void Thread::threadFunc(const std::function<void()>& func)
         throw;
     }
 }
+
+} // namespace inputleap

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -21,6 +21,8 @@
 #include "arch/IArchMultithread.h"
 #include <functional>
 
+namespace inputleap {
+
 //! Thread handle
 /*!
 Creating a Thread creates a new context of execution (i.e. thread) that
@@ -195,3 +197,5 @@ private:
 private:
     ArchThread m_thread;
 };
+
+} // namespace inputleap

--- a/src/lib/net/IDataSocket.cpp
+++ b/src/lib/net/IDataSocket.cpp
@@ -19,9 +19,7 @@
 #include "net/IDataSocket.h"
 #include "base/EventQueue.h"
 
-//
-// IDataSocket
-//
+namespace inputleap {
 
 void
 IDataSocket::close()
@@ -37,3 +35,5 @@ IDataSocket::getEventTarget() const
     assert(0 && "bad call");
     return nullptr;
 }
+
+} // namespace inputleap

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -23,6 +23,8 @@
 #include "base/EventTypes.h"
 #include <string>
 
+namespace inputleap {
+
 //! Data stream socket interface
 /*!
 This interface defines the methods common to all network sockets that
@@ -63,3 +65,5 @@ public:
     // IStream overrides
     virtual bool isFatal() const = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/net/IListenSocket.h
+++ b/src/lib/net/IListenSocket.h
@@ -22,6 +22,8 @@
 #include "base/EventTypes.h"
 #include <memory>
 
+namespace inputleap {
+
 class IDataSocket;
 
 //! Listen socket interface
@@ -39,3 +41,5 @@ public:
     */
     virtual std::unique_ptr<IDataSocket> accept() = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/net/ISocket.h
+++ b/src/lib/net/ISocket.h
@@ -21,6 +21,8 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 
+namespace inputleap {
+
 class NetworkAddress;
 
 //! Generic socket interface
@@ -59,3 +61,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/net/ISocketFactory.h
+++ b/src/lib/net/ISocketFactory.h
@@ -21,6 +21,8 @@
 #include "arch/IArchNetwork.h"
 #include "net/ConnectionSecurityLevel.h"
 
+namespace inputleap {
+
 class IDataSocket;
 class IListenSocket;
 
@@ -46,3 +48,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/net/ISocketMultiplexerJob.h
+++ b/src/lib/net/ISocketMultiplexerJob.h
@@ -21,6 +21,8 @@
 #include "arch/IArchNetwork.h"
 #include <memory>
 
+namespace inputleap {
+
 class ISocketMultiplexerJob;
 
 struct MultiplexerJobStatus
@@ -88,3 +90,5 @@ public:
     virtual bool isCursor() const { return false; }
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -24,9 +24,7 @@
 
 #include <cstdlib>
 
-//
-// NetworkAddress
-//
+namespace inputleap {
 
 static bool parse_address(const std::string& address, std::string& host, int& port)
 {
@@ -209,3 +207,5 @@ NetworkAddress::checkPort()
         throw XSocketAddress(XSocketAddress::kBadPort, m_hostname, m_port);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -21,6 +21,8 @@
 #include "base/EventTypes.h"
 #include "arch/IArchNetwork.h"
 
+namespace inputleap {
+
 //! Network address type
 /*!
 This class represents a network address.
@@ -120,3 +122,5 @@ private:
     std::string m_hostname;
     int m_port;
 };
+
+} // namespace inputleap

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -25,6 +25,8 @@
 #include "common/DataDirectories.h"
 #include "base/String.h"
 
+namespace inputleap {
+
 SecureListenSocket::SecureListenSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer,
                                        IArchNetwork::EAddressFamily family,
                                        ConnectionSecurityLevel security_level) :
@@ -65,3 +67,5 @@ std::unique_ptr<IDataSocket> SecureListenSocket::accept()
         throw ex;
     }
 }
+
+} // namespace inputleap

--- a/src/lib/net/SecureListenSocket.h
+++ b/src/lib/net/SecureListenSocket.h
@@ -20,6 +20,8 @@
 #include "net/TCPListenSocket.h"
 #include "ConnectionSecurityLevel.h"
 
+namespace inputleap {
+
 class IEventQueue;
 class SocketMultiplexer;
 class IDataSocket;
@@ -35,3 +37,5 @@ public:
 private:
     ConnectionSecurityLevel security_level_;
 };
+
+} // namespace inputleap

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -38,9 +38,7 @@
 #include <fstream>
 #include <memory>
 
-//
-// SecureSocket
-//
+namespace inputleap {
 
 #define MAX_ERROR_SIZE 65535
 
@@ -885,3 +883,5 @@ SecureSocket::handleTCPConnected(const Event& event, void*)
     }
     secureConnect();
 }
+
+} // namespace inputleap

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -23,6 +23,8 @@
 #include "io/filesystem.h"
 #include <mutex>
 
+namespace inputleap {
+
 class IEventQueue;
 class SocketMultiplexer;
 class ISocketMultiplexerJob;
@@ -110,3 +112,5 @@ private:
     std::unique_ptr<char[]> do_write_retry_buffer_;
     std::size_t do_write_retry_buffer_size_ = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -25,9 +25,7 @@
 #include "base/Log.h"
 #include <vector>
 
-//
-// SocketMultiplexer
-//
+namespace inputleap {
 
 class CursorMultiplexerJob : public ISocketMultiplexerJob {
 public:
@@ -335,3 +333,5 @@ SocketMultiplexer::unlockJobList()
         cv_jobs_ready_.notify_one();
     }
 }
+
+} // namespace inputleap

--- a/src/lib/net/SocketMultiplexer.h
+++ b/src/lib/net/SocketMultiplexer.h
@@ -25,6 +25,8 @@
 #include <memory>
 #include <mutex>
 
+namespace inputleap {
+
 class Thread;
 class ISocket;
 class ISocketMultiplexerJob;
@@ -113,3 +115,5 @@ private:
     SocketJobs m_socketJobs;
     SocketJobMap m_socketJobMap;
 };
+
+} // namespace inputleap

--- a/src/lib/net/TCPListenSocket.cpp
+++ b/src/lib/net/TCPListenSocket.cpp
@@ -28,9 +28,7 @@
 #include "arch/XArch.h"
 #include "base/IEventQueue.h"
 
-//
-// TCPListenSocket
-//
+namespace inputleap {
 
 TCPListenSocket::TCPListenSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, IArchNetwork::EAddressFamily family) :
     m_events(events),
@@ -153,3 +151,5 @@ MultiplexerJobStatus TCPListenSocket::serviceListening(ISocketMultiplexerJob* jo
     }
     return {true, {}};
 }
+
+} // namespace inputleap

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -24,6 +24,8 @@
 
 #include <mutex>
 
+namespace inputleap {
+
 class IEventQueue;
 class SocketMultiplexer;
 
@@ -56,3 +58,5 @@ protected:
     IEventQueue* m_events;
     SocketMultiplexer* m_socketMultiplexer;
 };
+
+} // namespace inputleap

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -32,6 +32,8 @@
 #include <cstdlib>
 #include <memory>
 
+namespace inputleap {
+
 static const std::size_t MAX_INPUT_BUFFER_SIZE = 1024 * 1024;
 
 TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, IArchNetwork::EAddressFamily family) :
@@ -607,3 +609,5 @@ MultiplexerJobStatus TCPSocket::serviceConnected(ISocketMultiplexerJob* job,
         return {true, {}};
     }
 }
+
+} // namespace inputleap

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -26,6 +26,8 @@
 #include <memory>
 #include <mutex>
 
+namespace inputleap {
+
 class Thread;
 class IEventQueue;
 class SocketMultiplexer;
@@ -110,3 +112,5 @@ private:
     bool is_flushed_ = true;
     SocketMultiplexer* m_socketMultiplexer;
 };
+
+} // namespace inputleap

--- a/src/lib/net/TCPSocketFactory.cpp
+++ b/src/lib/net/TCPSocketFactory.cpp
@@ -24,9 +24,7 @@
 #include "arch/Arch.h"
 #include "base/Log.h"
 
-//
-// TCPSocketFactory
-//
+namespace inputleap {
 
 TCPSocketFactory::TCPSocketFactory(IEventQueue* events, SocketMultiplexer* socketMultiplexer) :
     m_events(events),
@@ -67,3 +65,5 @@ IListenSocket* TCPSocketFactory::createListen(IArchNetwork::EAddressFamily famil
 
     return socket;
 }
+
+} // namespace inputleap

--- a/src/lib/net/TCPSocketFactory.h
+++ b/src/lib/net/TCPSocketFactory.h
@@ -21,6 +21,8 @@
 #include "net/ISocketFactory.h"
 #include "arch/IArchNetwork.h"
 
+namespace inputleap {
+
 class IEventQueue;
 class SocketMultiplexer;
 
@@ -41,3 +43,5 @@ private:
     IEventQueue* m_events;
     SocketMultiplexer* m_socketMultiplexer;
 };
+
+} // namespace inputleap

--- a/src/lib/net/TSocketMultiplexerMethodJob.h
+++ b/src/lib/net/TSocketMultiplexerMethodJob.h
@@ -21,6 +21,8 @@
 #include "net/ISocketMultiplexerJob.h"
 #include "arch/Arch.h"
 
+namespace inputleap {
+
 //! Use a method as a socket multiplexer job
 /*!
 A socket multiplexer job class that invokes a member function.
@@ -64,4 +66,4 @@ private:
     bool m_writable;
 };
 
-
+} // namespace inputleap

--- a/src/lib/platform/IMSWindowsClipboardFacade.h
+++ b/src/lib/platform/IMSWindowsClipboardFacade.h
@@ -22,6 +22,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 class IMSWindowsClipboardConverter;
 
 class IMSWindowsClipboardFacade {
@@ -29,5 +31,7 @@ public:
     virtual void write(HANDLE win32Data, UINT win32Format) = 0;
     virtual ~IMSWindowsClipboardFacade() { }
 };
+
+} // namespace inputleap
 
 #endif

--- a/src/lib/platform/IOSXKeyResource.cpp
+++ b/src/lib/platform/IOSXKeyResource.cpp
@@ -19,6 +19,8 @@
 
 #include <Carbon/Carbon.h>
 
+namespace inputleap {
+
 KeyID IOSXKeyResource::getKeyID(std::uint8_t c)
 {
     if (c == 0) {
@@ -186,3 +188,5 @@ IOSXKeyResource::unicharToKeyID(UniChar c)
         return static_cast<KeyID>(c);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/platform/IOSXKeyResource.h
+++ b/src/lib/platform/IOSXKeyResource.h
@@ -20,6 +20,8 @@
 #include "inputleap/KeyState.h"
 #include <CoreServices/CoreServices.h>
 
+namespace inputleap {
+
 class IOSXKeyResource {
 public:
     virtual ~IOSXKeyResource() { }
@@ -36,3 +38,5 @@ public:
     // Convert a unicode character to the equivalent KeyID.
     static KeyID unicharToKeyID(UniChar);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/IXWindowsImpl.h
+++ b/src/lib/platform/IXWindowsImpl.h
@@ -15,6 +15,8 @@
 #include <X11/XKBlib.h>
 #include <X11/extensions/XInput2.h>
 
+namespace inputleap {
+
 class IXWindowsImpl {
 public:
 
@@ -211,3 +213,5 @@ public:
                                              KeyCode keycode) = 0;
     virtual int XNextEvent(Display* display, XEvent* event_return) = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/ImmuneKeysReader.cpp
+++ b/src/lib/platform/ImmuneKeysReader.cpp
@@ -19,6 +19,8 @@
 
 #include <fstream>
 
+namespace inputleap {
+
 const std::size_t AllocatedLineSize = 1024;
 const char CommentChar = '#';
 
@@ -51,3 +53,5 @@ static void add_key(const char * const buffer, std::vector<DWORD> &keys)
     }
     return true;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/ImmuneKeysReader.h
+++ b/src/lib/platform/ImmuneKeysReader.h
@@ -23,8 +23,12 @@
 // let's not import all of Windows just to get this typedef
 typedef unsigned long DWORD;
 
+namespace inputleap {
+
 class ImmuneKeysReader
 {
 public:
     static bool get_list(const char * const path, std::vector<DWORD> &keys, std::string &badLine);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -26,9 +26,7 @@
 #include "arch/win32/ArchMiscWindows.h"
 #include "base/Log.h"
 
-//
-// MSWindowsClipboard
-//
+namespace inputleap {
 
 UINT                    MSWindowsClipboard::s_ownershipFormat = 0;
 
@@ -229,3 +227,5 @@ MSWindowsClipboard::getOwnershipFormat()
     // return the format
     return s_ownershipFormat;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -26,6 +26,8 @@
 
 #include <vector>
 
+namespace inputleap {
+
 class IMSWindowsClipboardConverter;
 class IMSWindowsClipboardFacade;
 
@@ -113,3 +115,5 @@ public:
     // (i.e., the reverse of fromIClipboard()).
     virtual std::string toIClipboard(HANDLE data) const = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
@@ -18,9 +18,7 @@
 
 #include "platform/MSWindowsClipboardAnyTextConverter.h"
 
-//
-// MSWindowsClipboardAnyTextConverter
-//
+namespace inputleap {
 
 MSWindowsClipboardAnyTextConverter::MSWindowsClipboardAnyTextConverter()
 {
@@ -141,3 +139,5 @@ std::string MSWindowsClipboardAnyTextConverter::convertLinefeedToUnix(const std:
 
     return dst;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/MSWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class MSWindowsClipboardAnyTextConverter :
                 public IMSWindowsClipboardConverter {
@@ -54,3 +56,5 @@ private:
     std::string convertLinefeedToWin32(const std::string&) const;
     std::string convertLinefeedToUnix(const std::string&) const;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Log.h"
 
-//
-// MSWindowsClipboardBitmapConverter
-//
+namespace inputleap {
 
 MSWindowsClipboardBitmapConverter::MSWindowsClipboardBitmapConverter()
 {
@@ -148,3 +146,5 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
 
     return image;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.h
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/MSWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class MSWindowsClipboardBitmapConverter :
                 public IMSWindowsClipboardConverter {
@@ -33,3 +35,5 @@ public:
     virtual HANDLE fromIClipboard(const std::string&) const;
     virtual std::string toIClipboard(HANDLE) const;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardFacade.cpp
+++ b/src/lib/platform/MSWindowsClipboardFacade.cpp
@@ -20,6 +20,8 @@
 
 #include "platform/MSWindowsClipboard.h"
 
+namespace inputleap {
+
 void MSWindowsClipboardFacade::write(HANDLE win32Data, UINT win32Format)
 {
     if (SetClipboardData(win32Format, win32Data) == nullptr) {
@@ -29,3 +31,5 @@ void MSWindowsClipboardFacade::write(HANDLE win32Data, UINT win32Format)
         GlobalFree(win32Data);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardFacade.h
+++ b/src/lib/platform/MSWindowsClipboardFacade.h
@@ -22,8 +22,12 @@
 
 #include "inputleap/IClipboard.h"
 
+namespace inputleap {
+
 class MSWindowsClipboardFacade : public IMSWindowsClipboardFacade
 {
 public:
     virtual void write(HANDLE win32Data, UINT win32Format);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/String.h"
 
-//
-// MSWindowsClipboardHTMLConverter
-//
+namespace inputleap {
 
 MSWindowsClipboardHTMLConverter::MSWindowsClipboardHTMLConverter()
 {
@@ -115,3 +113,5 @@ std::string MSWindowsClipboardHTMLConverter::findArg(const std::string& data,
     }
     return data.substr(i, j - i);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/MSWindowsClipboardAnyTextConverter.h"
 
+namespace inputleap {
+
 //! Convert to/from HTML encoding
 class MSWindowsClipboardHTMLConverter :
                 public MSWindowsClipboardAnyTextConverter {
@@ -42,3 +44,5 @@ private:
 private:
     UINT m_format;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardTextConverter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// MSWindowsClipboardTextConverter
-//
+namespace inputleap {
 
 MSWindowsClipboardTextConverter::MSWindowsClipboardTextConverter()
 {
@@ -56,3 +54,5 @@ std::string MSWindowsClipboardTextConverter::doToIClipboard(const std::string& d
     }
     return dst;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardTextConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/MSWindowsClipboardAnyTextConverter.h"
 
+namespace inputleap {
+
 //! Convert to/from locale text encoding
 class MSWindowsClipboardTextConverter :
                 public MSWindowsClipboardAnyTextConverter {
@@ -35,3 +37,5 @@ protected:
     virtual std::string doFromIClipboard(const std::string&) const;
     virtual std::string doToIClipboard(const std::string&) const;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardUTF16Converter.cpp
+++ b/src/lib/platform/MSWindowsClipboardUTF16Converter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// MSWindowsClipboardUTF16Converter
-//
+namespace inputleap {
 
 MSWindowsClipboardUTF16Converter::MSWindowsClipboardUTF16Converter()
 {
@@ -56,3 +54,5 @@ std::string MSWindowsClipboardUTF16Converter::doToIClipboard(const std::string& 
     }
     return dst;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsClipboardUTF16Converter.h
+++ b/src/lib/platform/MSWindowsClipboardUTF16Converter.h
@@ -20,6 +20,8 @@
 
 #include "platform/MSWindowsClipboardAnyTextConverter.h"
 
+namespace inputleap {
+
 //! Convert to/from UTF-16 encoding
 class MSWindowsClipboardUTF16Converter :
                 public MSWindowsClipboardAnyTextConverter {
@@ -35,3 +37,5 @@ protected:
     virtual std::string doFromIClipboard(const std::string&) const;
     virtual std::string doToIClipboard(const std::string&) const;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsDebugOutputter.cpp
+++ b/src/lib/platform/MSWindowsDebugOutputter.cpp
@@ -22,6 +22,8 @@
 #include <Windows.h>
 #include <string>
 
+namespace inputleap {
+
 MSWindowsDebugOutputter::MSWindowsDebugOutputter()
 {
 }
@@ -56,3 +58,5 @@ void
 MSWindowsDebugOutputter::flush()
 {
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsDebugOutputter.h
+++ b/src/lib/platform/MSWindowsDebugOutputter.h
@@ -20,6 +20,8 @@
 
 #include "base/ILogOutputter.h"
 
+namespace inputleap {
+
 //! Write log to debugger
 /*!
 This outputter writes output to the debugger. In Visual Studio, this
@@ -37,3 +39,5 @@ public:
     virtual bool write(ELevel level, const char* message);
     virtual void flush();
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -32,6 +32,8 @@
 #include <malloc.h>
 #include <VersionHelpers.h>
 
+namespace inputleap {
+
 // these are only defined when WINVER >= 0x0500
 #if !defined(SPI_GETMOUSESPEED)
 #define SPI_GETMOUSESPEED 112
@@ -907,3 +909,5 @@ MSWindowsDesks::getForegroundWindow() const
     }
     return GetForegroundWindow();
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -33,6 +33,8 @@
 
 #include <map>
 
+namespace inputleap {
+
 class Event;
 class EventQueueTimer;
 class Thread;
@@ -296,3 +298,5 @@ private:
     // true if program should stop on desk switch.
     bool m_stopOnDeskSwitch;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsDropTarget.cpp
+++ b/src/lib/platform/MSWindowsDropTarget.cpp
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <Shlobj.h>
 
+namespace inputleap {
+
 void getDropData(IDataObject *pDataObject);
 
 MSWindowsDropTarget* MSWindowsDropTarget::s_instance = nullptr;
@@ -176,3 +178,5 @@ MSWindowsDropTarget::Release(void)
         return count;
     }
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsDropTarget.h
+++ b/src/lib/platform/MSWindowsDropTarget.h
@@ -22,6 +22,8 @@
 #include <Windows.h>
 #include <oleidl.h>
 
+namespace inputleap {
+
 class MSWindowsScreen;
 
 class MSWindowsDropTarget : public IDropTarget {
@@ -56,3 +58,5 @@ private:
     static MSWindowsDropTarget*
                         s_instance;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.cpp
@@ -23,6 +23,8 @@
 #include "base/IEventQueue.h"
 #include <VersionHelpers.h>
 
+namespace inputleap {
+
 //
 // EventQueueTimer
 //
@@ -150,3 +152,5 @@ MSWindowsEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
 {
     delete timer;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsEventQueueBuffer.h
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.h
@@ -23,6 +23,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Event queue buffer for Win32
@@ -48,3 +50,5 @@ private:
     IEventQueue* m_events;
     UINT m_os_supported_message_types;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -37,6 +37,8 @@
  //
 #define NO_GRAB_KEYBOARD 0
 
+namespace inputleap {
+
 static const DWORD      g_threadID = GetCurrentThreadId();
 
 static WindowsHookResource  g_hkMessage;
@@ -636,3 +638,5 @@ MSWindowsHook::uninstallScreenSaver()
 {
     g_hkMessage.unset();
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -24,6 +24,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 //! Loads and provides functions for the Windows hook
 class MSWindowsHook
 {
@@ -38,3 +40,5 @@ public:
     static bool installScreenSaver();
     static void uninstallScreenSaver();
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsHookResource.cpp
+++ b/src/lib/platform/MSWindowsHookResource.cpp
@@ -1,5 +1,7 @@
 #include "MSWindowsHookResource.h"
 
+namespace inputleap {
+
 WindowsHookResource::WindowsHookResource() :
     _hook(nullptr)
 {
@@ -31,3 +33,5 @@ bool WindowsHookResource::unset()
 
 bool WindowsHookResource::is_set() const { return _hook != nullptr; }
 WindowsHookResource::operator HHOOK() const { return _hook; }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsHookResource.h
+++ b/src/lib/platform/MSWindowsHookResource.h
@@ -3,6 +3,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 class WindowsHookResource
 {
 public:
@@ -18,3 +20,5 @@ public:
 private:
     HHOOK _hook;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -31,9 +31,7 @@
 #define VK_XBUTTON2				0x06
 #endif
 
-//
-// MSWindowsKeyState
-//
+namespace inputleap {
 
 // map virtual keys to barrier key enumeration
 const KeyID				MSWindowsKeyState::s_virtualKey[] =
@@ -1378,3 +1376,4 @@ MSWindowsKeyState::addKeyEntry(inputleap::KeyMap& keyMap, inputleap::KeyMap::Key
 	}
 }
 
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsKeyState.h
+++ b/src/lib/platform/MSWindowsKeyState.h
@@ -25,6 +25,8 @@
 
 #include <vector>
 
+namespace inputleap {
+
 class Event;
 class EventQueueTimer;
 class MSWindowsDesks;
@@ -229,3 +231,5 @@ private:
 
 	static const KeyID	s_virtualKey[];
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -81,9 +81,7 @@
 #define PBT_APMRESUMEAUTOMATIC    0x0012
 #endif
 
-//
-// MSWindowsScreen
-//
+namespace inputleap {
 
 HINSTANCE MSWindowsScreen::s_windowInstance = nullptr;
 MSWindowsScreen* MSWindowsScreen::s_screen  = nullptr;
@@ -1935,3 +1933,5 @@ MSWindowsScreen::isModifierRepeat(KeyModifierMask oldState, KeyModifierMask stat
 
     return result;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -28,6 +28,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 class EventQueueTimer;
 class MSWindowsDesks;
 class MSWindowsKeyState;
@@ -340,3 +342,5 @@ private:
 
     PrimaryKeyDownList m_primaryKeyDownList;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsScreenSaver.cpp
+++ b/src/lib/platform/MSWindowsScreenSaver.cpp
@@ -32,6 +32,8 @@
 #define SPI_GETSCREENSAVERRUNNING 114
 #endif
 
+namespace inputleap {
+
 static const TCHAR* g_isSecureNT = "ScreenSaverIsSecure";
 static const TCHAR* g_isSecure9x = "ScreenSaveUsePassword";
 static const TCHAR* const g_pathScreenSaverIsSecure[] = {
@@ -353,3 +355,5 @@ MSWindowsScreenSaver::isSecure(bool* wasSecureFlagAnInt) const
     ArchMiscWindows::closeKey(hkey);
     return result;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsScreenSaver.h
+++ b/src/lib/platform/MSWindowsScreenSaver.h
@@ -23,6 +23,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 class Thread;
 
 //! Microsoft windows screen saver implementation
@@ -86,3 +88,5 @@ private:
     // for deactivation (and is therefore active).
     bool m_active;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -23,6 +23,8 @@
 
 #include <Wtsapi32.h>
 
+namespace inputleap {
+
 MSWindowsSession::MSWindowsSession() :
     m_activeSessionId(-1)
 {
@@ -192,3 +194,5 @@ std::string MSWindowsSession::getActiveDesktopName()
 
     return result;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsSession.h
+++ b/src/lib/platform/MSWindowsSession.h
@@ -23,6 +23,8 @@
 #include <Windows.h>
 #include <Tlhelp32.h>
 
+namespace inputleap {
+
 class MSWindowsSession {
 public:
     MSWindowsSession();
@@ -50,3 +52,5 @@ private:
 private:
     DWORD m_activeSessionId;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsUtil.cpp
+++ b/src/lib/platform/MSWindowsUtil.cpp
@@ -21,9 +21,7 @@
 #include <stdio.h>
 #include "base/String.h"
 
-//
-// MSWindowsUtil
-//
+namespace inputleap {
 
 std::string MSWindowsUtil::getString(HINSTANCE instance, DWORD id)
 {
@@ -79,3 +77,5 @@ MSWindowsUtil::createDirectory(const std::string& path, bool stripLast)
         // create innermost directory
         CreateDirectory(path.c_str(), nullptr);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsUtil.h
+++ b/src/lib/platform/MSWindowsUtil.h
@@ -23,6 +23,8 @@
 #define WINDOWS_LEAN_AND_MEAN
 #include <Windows.h>
 
+namespace inputleap {
+
 class MSWindowsUtil {
 public:
     //! Get message string
@@ -45,3 +47,5 @@ public:
     */
     static void createDirectory(const std::string& path, bool stripLast = false);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -37,6 +37,8 @@
 #include <UserEnv.h>
 #include <Shellapi.h>
 
+namespace inputleap {
+
 #define MAXIMUM_WAIT_TIME 3
 enum {
     kOutputBufferSize = 4096
@@ -534,3 +536,5 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     CloseHandle(snapshot);
     m_processRunning = false;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <list>
 
+namespace inputleap {
+
 class Thread;
 class IpcLogOutputter;
 class IpcServer;
@@ -90,3 +92,5 @@ public:
     // XBase overrides
     virtual std::string getWhat() const noexcept { return what(); }
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -26,9 +26,7 @@
 #include "base/Log.h"
 #include "arch/XArch.h"
 
-//
-// OSXClipboard
-//
+namespace inputleap {
 
 OSXClipboard::OSXClipboard() :
     m_time(0),
@@ -256,3 +254,5 @@ OSXClipboard::clearConverters()
     }
     m_converters.clear();
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+namespace inputleap {
+
 class IOSXClipboardConverter;
 
 //! OS X clipboard implementation
@@ -94,3 +96,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
@@ -19,6 +19,8 @@
 #include "platform/OSXClipboardAnyBitmapConverter.h"
 #include <algorithm>
 
+namespace inputleap {
+
 OSXClipboardAnyBitmapConverter::OSXClipboardAnyBitmapConverter()
 {
     // do nothing
@@ -44,3 +46,5 @@ std::string OSXClipboardAnyBitmapConverter::toIClipboard(const std::string& data
 {
     return doToIClipboard(data);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/OSXClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class OSXClipboardAnyBitmapConverter : public IOSXClipboardConverter {
 public:
@@ -45,3 +47,5 @@ protected:
     */
     virtual std::string doToIClipboard(const std::string&) const = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.cpp
@@ -20,9 +20,7 @@
 
 #include <algorithm>
 
-//
-// OSXClipboardAnyTextConverter
-//
+namespace inputleap {
 
 OSXClipboardAnyTextConverter::OSXClipboardAnyTextConverter()
 {
@@ -84,3 +82,5 @@ std::string OSXClipboardAnyTextConverter::convertLinefeedToUnix(const std::strin
 
     return copy;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardAnyTextConverter.h
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/OSXClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class OSXClipboardAnyTextConverter : public IOSXClipboardConverter {
 public:
@@ -50,3 +52,5 @@ private:
     static std::string convertLinefeedToMacOS(const std::string&);
     static std::string convertLinefeedToUnix(const std::string&);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardBMPConverter.cpp
+++ b/src/lib/platform/OSXClipboardBMPConverter.cpp
@@ -19,6 +19,8 @@
 #include "platform/OSXClipboardBMPConverter.h"
 #include "base/Log.h"
 
+namespace inputleap {
+
 // BMP file header structure
 struct CBMPHeader {
 public:
@@ -122,3 +124,5 @@ std::string OSXClipboardBMPConverter::toIClipboard(const std::string& bmp) const
         return bmp.substr(14, 40) + bmp.substr(offset, bmp.size() - offset);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardBMPConverter.h
+++ b/src/lib/platform/OSXClipboardBMPConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/OSXClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class OSXClipboardBMPConverter : public IOSXClipboardConverter {
 public:
@@ -41,3 +43,5 @@ public:
     static std::string convertString(const std::string& data, CFStringEncoding fromEncoding,
                                      CFStringEncoding toEncoding);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardHTMLConverter.cpp
+++ b/src/lib/platform/OSXClipboardHTMLConverter.cpp
@@ -20,6 +20,8 @@
 
 #include "base/Unicode.h"
 
+namespace inputleap {
+
 OSXClipboardHTMLConverter::OSXClipboardHTMLConverter()
 {
     // do nothing
@@ -88,3 +90,5 @@ std::string OSXClipboardHTMLConverter::doToIClipboard(const std::string& data) c
     return convertString(data, CFStringGetSystemEncoding(),
                 kCFStringEncodingUTF8);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardHTMLConverter.h
+++ b/src/lib/platform/OSXClipboardHTMLConverter.h
@@ -20,6 +20,8 @@
 
 #include "OSXClipboardAnyTextConverter.h"
 
+namespace inputleap {
+
 //! Convert to/from HTML encoding
 class OSXClipboardHTMLConverter : public OSXClipboardAnyTextConverter {
 public:
@@ -41,3 +43,5 @@ protected:
     static std::string convertString(const std::string& data, CFStringEncoding fromEncoding,
                                      CFStringEncoding toEncoding);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardTextConverter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// OSXClipboardTextConverter
-//
+namespace inputleap {
 
 OSXClipboardTextConverter::OSXClipboardTextConverter()
 {
@@ -86,3 +84,5 @@ std::string OSXClipboardTextConverter::doToIClipboard(const std::string& data) c
     return convertString(data, CFStringGetSystemEncoding(),
                             kCFStringEncodingUTF8);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardTextConverter.h
+++ b/src/lib/platform/OSXClipboardTextConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/OSXClipboardAnyTextConverter.h"
 
+namespace inputleap {
+
 //! Convert to/from locale text encoding
 class OSXClipboardTextConverter : public OSXClipboardAnyTextConverter {
 public:
@@ -39,3 +41,5 @@ protected:
     static std::string convertString(const std::string& data, CFStringEncoding fromEncoding,
                                      CFStringEncoding toEncoding);
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardUTF16Converter.cpp
+++ b/src/lib/platform/OSXClipboardUTF16Converter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// OSXClipboardUTF16Converter
-//
+namespace inputleap {
 
 OSXClipboardUTF16Converter::OSXClipboardUTF16Converter()
 {
@@ -51,3 +49,5 @@ std::string OSXClipboardUTF16Converter::doToIClipboard(const std::string& data) 
     // convert and strip nul terminator
     return Unicode::UTF16ToUTF8(data);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXClipboardUTF16Converter.h
+++ b/src/lib/platform/OSXClipboardUTF16Converter.h
@@ -20,6 +20,8 @@
 
 #include "platform/OSXClipboardAnyTextConverter.h"
 
+namespace inputleap {
+
 //! Convert to/from UTF-16 encoding
 class OSXClipboardUTF16Converter : public OSXClipboardAnyTextConverter {
 public:
@@ -35,3 +37,5 @@ protected:
     virtual std::string doFromIClipboard(const std::string&) const;
     virtual std::string doToIClipboard(const std::string&) const;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXDragSimulator.h
+++ b/src/lib/platform/OSXDragSimulator.h
@@ -21,6 +21,8 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 
+namespace inputleap {
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -32,3 +34,5 @@ CFStringRef getCocoaDropTarget();
 #if defined(__cplusplus)
 }
 #endif
+
+} // namespace inputleap

--- a/src/lib/platform/OSXDragSimulator.mm
+++ b/src/lib/platform/OSXDragSimulator.mm
@@ -20,6 +20,8 @@
 #import <CoreData/CoreData.h>
 #import <Cocoa/Cocoa.h>
 
+namespace inputleap {
+
 #if defined(MAC_OS_X_VERSION_10_7)
 
 NSWindow* g_dragWindow = nullptr;
@@ -100,3 +102,5 @@ getCocoaDropTarget()
 }
 
 #endif
+
+} // namespace inputleap

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -21,15 +21,9 @@
 #include "base/Event.h"
 #include "base/IEventQueue.h"
 
-//
-// EventQueueTimer
-//
+namespace inputleap {
 
 class EventQueueTimer { };
-
-//
-// OSXEventQueueBuffer
-//
 
 OSXEventQueueBuffer::OSXEventQueueBuffer(IEventQueue* events) :
     m_event(nullptr),
@@ -139,3 +133,5 @@ OSXEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
 {
     delete timer;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXEventQueueBuffer.h
+++ b/src/lib/platform/OSXEventQueueBuffer.h
@@ -22,6 +22,8 @@
 
 #include <Carbon/Carbon.h>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Event queue buffer for OS X
@@ -44,3 +46,5 @@ private:
     IEventQueue* m_eventQueue;
     EventQueueRef m_carbonEventQueue;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -26,6 +26,8 @@
 #include <CoreServices/CoreServices.h>
 #include <IOKit/hidsystem/IOHIDLib.h>
 
+namespace inputleap {
+
 // Note that some virtual keys codes appear more than once.  The
 // first instance of a virtual key code maps to the KeyID that we
 // want to generate for that code.  The others are for mapping
@@ -910,3 +912,5 @@ std::uint32_t OSXKeyState::mapKeyButtonToVirtualKey(KeyButton keyButton)
 {
     return static_cast<std::uint32_t>(keyButton - KeyButtonOffset);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -26,6 +26,8 @@
 #include <set>
 #include <vector>
 
+namespace inputleap {
+
 typedef TISInputSourceRef KeyLayout;
 class IOSXKeyResource;
 
@@ -173,3 +175,5 @@ private:
     bool m_superPressed;
     bool m_capsPressed;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXMediaKeySimulator.h
+++ b/src/lib/platform/OSXMediaKeySimulator.h
@@ -21,6 +21,8 @@
 
 #include "inputleap/key_types.h"
 
+namespace inputleap {
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -28,3 +30,5 @@ bool fakeNativeMediaKey(KeyID id);
 #if defined(__cplusplus)
 }
 #endif
+
+} // namespace inputleap

--- a/src/lib/platform/OSXMediaKeySimulator.mm
+++ b/src/lib/platform/OSXMediaKeySimulator.mm
@@ -16,6 +16,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+namespace inputleap {
+
 int convertKeyIDToNXKeyType(KeyID id)
 {
 	// hidsystem/ev_keymap.h
@@ -90,3 +92,5 @@ fakeNativeMediaKey(KeyID id)
 	
 	return true;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXMediaKeySupport.h
+++ b/src/lib/platform/OSXMediaKeySupport.h
@@ -22,6 +22,8 @@
 
 #include "inputleap/key_types.h"
 
+namespace inputleap {
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -31,3 +33,5 @@ bool getMediaKeyEventInfo(CGEventRef event, KeyID* keyId, bool* down, bool* isRe
 #if defined(__cplusplus)
 }
 #endif
+
+} // namespace inputleap

--- a/src/lib/platform/OSXMediaKeySupport.mm
+++ b/src/lib/platform/OSXMediaKeySupport.mm
@@ -16,6 +16,8 @@
 #import <Cocoa/Cocoa.h>
 #import <IOKit/hidsystem/ev_keymap.h>
 
+namespace inputleap {
+
 int convertKeyIDToNXKeyType(KeyID id)
 {
 	int type = -1;
@@ -152,3 +154,5 @@ fakeNativeMediaKey(KeyID id)
 	
 	return true;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXPasteboardPeeker.h
+++ b/src/lib/platform/OSXPasteboardPeeker.h
@@ -21,6 +21,8 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 
+namespace inputleap {
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -30,3 +32,5 @@ CFStringRef getDraggedFileURL();
 #if defined(__cplusplus)
 }
 #endif
+
+} // namespace inputleap

--- a/src/lib/platform/OSXPasteboardPeeker.mm
+++ b/src/lib/platform/OSXPasteboardPeeker.mm
@@ -18,6 +18,8 @@
 #import <CoreData/CoreData.h>
 #import <Cocoa/Cocoa.h>
 
+namespace inputleap {
+
 CFStringRef
 getDraggedFileURL()
 {
@@ -35,3 +37,5 @@ getDraggedFileURL()
 	
 	return (CFStringRef)string;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -36,6 +36,8 @@
 #include <mutex>
 #include <vector>
 
+namespace inputleap {
+
 extern "C" {
     typedef int CGSConnectionID;
     CGError CGSSetConnectionProperty(CGSConnectionID cid, CGSConnectionID targetCID, CFStringRef key, CFTypeRef value);
@@ -347,3 +349,5 @@ private:
 
     class OSXScreenImpl* m_impl;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -43,6 +43,8 @@
 #include <IOKit/hidsystem/event_status_driver.h>
 #include <AppKit/NSEvent.h>
 
+namespace inputleap {
+
 // This isn't in any Apple SDK that I know of as of yet.
 enum {
 	kBarrierEventMouseScroll = 11,
@@ -2100,3 +2102,5 @@ avoidHesitatingCursor()
 }
 
 #pragma GCC diagnostic error "-Wdeprecated-declarations"
+
+} // namespace inputleap

--- a/src/lib/platform/OSXScreenSaver.cpp
+++ b/src/lib/platform/OSXScreenSaver.cpp
@@ -26,13 +26,12 @@
 #import <string.h>
 #import <sys/sysctl.h>
 
+
+namespace inputleap {
+
 // TODO: upgrade deprecated function usage in these functions.
 void getProcessSerialNumber(const char* name, ProcessSerialNumber& psn);
 bool testProcessName(const char* name, const ProcessSerialNumber& psn);
-
-//
-// OSXScreenSaver
-//
 
 OSXScreenSaver::OSXScreenSaver(IEventQueue* events, void* eventTarget) :
     m_eventTarget(eventTarget),
@@ -199,3 +198,5 @@ testProcessName(const char* name, const ProcessSerialNumber& psn)
 }
 
 #pragma GCC diagnostic error "-Wdeprecated-declarations"
+
+} // namespace inputleap

--- a/src/lib/platform/OSXScreenSaver.h
+++ b/src/lib/platform/OSXScreenSaver.h
@@ -22,6 +22,8 @@
 
 #include <Carbon/Carbon.h>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! OSX screen saver implementation
@@ -57,3 +59,5 @@ private:
     ProcessSerialNumber m_screenSaverPSN;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/OSXScreenSaverControl.h
+++ b/src/lib/platform/OSXScreenSaverControl.h
@@ -51,4 +51,3 @@
 - (double)screenSaverTimeRemaining;
 
 @end
-

--- a/src/lib/platform/OSXScreenSaverUtil.h
+++ b/src/lib/platform/OSXScreenSaverUtil.h
@@ -20,6 +20,8 @@
 
 #include "common/common.h"
 
+namespace inputleap {
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -38,3 +40,5 @@ int screenSaverUtilIsActive(void*);
 #if defined(__cplusplus)
 }
 #endif
+
+} // namespace inputleap

--- a/src/lib/platform/OSXScreenSaverUtil.mm
+++ b/src/lib/platform/OSXScreenSaverUtil.mm
@@ -18,6 +18,8 @@
 
 #import <Foundation/NSAutoreleasePool.h>
 
+namespace inputleap {
+
 //
 // screenSaverUtil functions
 //
@@ -81,3 +83,5 @@ screenSaverUtilIsActive(void* controller)
 {
 	return [(ScreenSaverController*)controller screenSaverIsRunning];
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXUchrKeyResource.cpp
+++ b/src/lib/platform/OSXUchrKeyResource.cpp
@@ -19,9 +19,7 @@
 
 #include <Carbon/Carbon.h>
 
-//
-// OSXUchrKeyResource
-//
+namespace inputleap {
 
 OSXUchrKeyResource::OSXUchrKeyResource(const void* resource, std::uint32_t keyboardType) :
     m_m(nullptr),
@@ -285,3 +283,5 @@ OSXUchrKeyResource::addSequence(
 
     return true;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/OSXUchrKeyResource.h
+++ b/src/lib/platform/OSXUchrKeyResource.h
@@ -22,6 +22,8 @@
 
 #include <Carbon/Carbon.h>
 
+namespace inputleap {
+
 typedef TISInputSourceRef KeyLayout;
 
 class OSXUchrKeyResource : public IOSXKeyResource {
@@ -52,3 +54,5 @@ private:
     const UCKeyStateTerminators* m_st;
     std::uint16_t m_spaceOutput;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -36,9 +36,7 @@
 #include <cstring>
 #include <vector>
 
-//
-// XWindowsClipboard
-//
+namespace inputleap {
 
 XWindowsClipboard::XWindowsClipboard(IXWindowsImpl* impl, Display* display,
                 Window window, ClipboardID id) :
@@ -1529,3 +1527,5 @@ XWindowsClipboard::Reply::Reply(Window requestor, Atom target, ::Time time,
 {
     // do nothing
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -28,6 +28,8 @@
 #include <list>
 #include <vector>
 
+namespace inputleap {
+
 class IXWindowsClipboardConverter;
 
 //! X11 clipboard implementation
@@ -376,3 +378,5 @@ public:
 
     //@}
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
@@ -18,6 +18,8 @@
 
 #include "platform/XWindowsClipboardAnyBitmapConverter.h"
 
+namespace inputleap {
+
 // BMP info header structure
 struct CBMPInfoHeader {
 public:
@@ -175,3 +177,5 @@ std::string XWindowsClipboardAnyBitmapConverter::toIClipboard(const std::string&
     return std::string(reinterpret_cast<const char*>(infoHeader),
                        sizeof(infoHeader)) + rawBMP;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/XWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class XWindowsClipboardAnyBitmapConverter :
                 public IXWindowsClipboardConverter {
@@ -56,3 +58,5 @@ protected:
     virtual std::string doToIClipboard(const std::string&, std::uint32_t& w, std::uint32_t& h,
                                        std::uint32_t& depth) const = 0;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardBMPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.cpp
@@ -18,6 +18,8 @@
 
 #include "platform/XWindowsClipboardBMPConverter.h"
 
+namespace inputleap {
+
 // BMP file header structure
 struct CBMPHeader {
 public:
@@ -131,3 +133,5 @@ std::string XWindowsClipboardBMPConverter::toIClipboard(const std::string& bmp) 
         return bmp.substr(14, 40) + bmp.substr(offset, bmp.size() - offset);
     }
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/XWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from some text encoding
 class XWindowsClipboardBMPConverter :
                 public IXWindowsClipboardConverter {
@@ -37,3 +39,5 @@ public:
 private:
     Atom m_atom;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// XWindowsClipboardHTMLConverter
-//
+namespace inputleap {
 
 XWindowsClipboardHTMLConverter::XWindowsClipboardHTMLConverter(
                 Display* display, const char* name) :
@@ -70,3 +68,5 @@ std::string XWindowsClipboardHTMLConverter::toIClipboard(const std::string& data
     }
     return data;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/XWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from HTML encoding
 class XWindowsClipboardHTMLConverter : public IXWindowsClipboardConverter {
 public:
@@ -39,3 +41,5 @@ public:
 private:
     Atom m_atom;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTextConverter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// XWindowsClipboardTextConverter
-//
+namespace inputleap {
 
 XWindowsClipboardTextConverter::XWindowsClipboardTextConverter(
                 Display* display, const char* name) :
@@ -75,3 +73,5 @@ std::string XWindowsClipboardTextConverter::toIClipboard(const std::string& data
 
     return utf8;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardTextConverter.h
+++ b/src/lib/platform/XWindowsClipboardTextConverter.h
@@ -20,6 +20,8 @@
 
 #include "platform/XWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from locale text encoding
 class XWindowsClipboardTextConverter : public IXWindowsClipboardConverter {
 public:
@@ -39,3 +41,5 @@ public:
 private:
     Atom m_atom;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
@@ -20,9 +20,7 @@
 
 #include "base/Unicode.h"
 
-//
-// XWindowsClipboardUCS2Converter
-//
+namespace inputleap {
 
 XWindowsClipboardUCS2Converter::XWindowsClipboardUCS2Converter(
                 Display* display, const char* name) :
@@ -63,3 +61,5 @@ std::string XWindowsClipboardUCS2Converter::toIClipboard(const std::string& data
 {
     return Unicode::UCS2ToUTF8(data);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.h
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.h
@@ -20,6 +20,8 @@
 
 #include "platform/XWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from UCS-2 encoding
 class XWindowsClipboardUCS2Converter : public IXWindowsClipboardConverter {
 public:
@@ -39,3 +41,5 @@ public:
 private:
     Atom m_atom;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
@@ -18,9 +18,7 @@
 
 #include "platform/XWindowsClipboardUTF8Converter.h"
 
-//
-// XWindowsClipboardUTF8Converter
-//
+namespace inputleap {
 
 XWindowsClipboardUTF8Converter::XWindowsClipboardUTF8Converter(
                 Display* display, const char* name) :
@@ -61,3 +59,5 @@ std::string XWindowsClipboardUTF8Converter::toIClipboard(const std::string& data
 {
     return data;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -20,6 +20,8 @@
 
 #include "platform/XWindowsClipboard.h"
 
+namespace inputleap {
+
 //! Convert to/from UTF-8 encoding
 class XWindowsClipboardUTF8Converter : public IXWindowsClipboardConverter {
 public:
@@ -39,3 +41,5 @@ public:
 private:
     Atom m_atom;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -26,9 +26,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-//
-// EventQueueTimer
-//
+namespace inputleap {
 
 class EventQueueTimer { };
 
@@ -241,3 +239,5 @@ XWindowsEventQueueBuffer::flush()
     m_impl->XFlush(m_display);
     m_postedEvents.clear();
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -27,6 +27,8 @@
 #include <mutex>
 #include <vector>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Event queue buffer for X11
@@ -64,3 +66,5 @@ private:
     int m_pipefd[2];
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsImpl.cpp
+++ b/src/lib/platform/XWindowsImpl.cpp
@@ -1,6 +1,8 @@
 
 #include "XWindowsImpl.h"
 
+namespace inputleap {
+
 Status XWindowsImpl::XInitThreads()
 {
     return ::XInitThreads();
@@ -628,3 +630,5 @@ int XWindowsImpl::XNextEvent(Display* display, XEvent* event_return)
 {
     return ::XNextEvent(display, event_return);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsImpl.h
+++ b/src/lib/platform/XWindowsImpl.h
@@ -5,6 +5,8 @@
 
 #include "IXWindowsImpl.h"
 
+namespace inputleap {
+
 class XWindowsImpl : public IXWindowsImpl {
 public:
 
@@ -145,3 +147,5 @@ public:
     unsigned char do_XkbKeyGroupInfo(XkbDescPtr m_xkb, KeyCode keycode) override;
     int XNextEvent(Display* display, XEvent* event_return) override;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -32,6 +32,7 @@
 #include <cstddef>
 #include <map>
 
+namespace inputleap {
 
 static const size_t ModifiersFromXDefaultSize = 32;
 
@@ -854,3 +855,5 @@ std::uint32_t XWindowsKeyState::getGroupFromState(unsigned int state) const
     }
     return 0;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -30,6 +30,8 @@
 #include <map>
 #include <vector>
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! X Windows key state
@@ -165,3 +167,5 @@ public:
     KeyModifierMaskList& modifierFromX() { return m_modifierFromX; }
 #endif
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -38,6 +38,8 @@
 #include <cstdlib>
 #include <algorithm>
 
+namespace inputleap {
+
 static int xi_opcode;
 
 //
@@ -2035,3 +2037,5 @@ XWindowsScreen::selectXIRawMotion()
     m_impl->XISelectEvents(m_display, DefaultRootWindow(m_display), &mask, 1);
 	free(mask.mask);
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -29,6 +29,8 @@
 #include <set>
 #include <vector>
 
+namespace inputleap {
+
 class XWindowsClipboard;
 class XWindowsKeyState;
 class XWindowsScreenSaver;
@@ -262,3 +264,5 @@ private:
     // ioErrorHandler().
     static XWindowsScreen*    s_screen;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -30,9 +30,7 @@
 #include <X11/Xmd.h>
 #include <X11/extensions/dpms.h>
 
-//
-// XWindowsScreenSaver
-//
+namespace inputleap {
 
 XWindowsScreenSaver::XWindowsScreenSaver(IXWindowsImpl* impl, Display* display,
                                          Window window, void* eventTarget,
@@ -570,3 +568,5 @@ XWindowsScreenSaver::isDPMSActivated() const
         return false;
     }
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsScreenSaver.h
+++ b/src/lib/platform/XWindowsScreenSaver.h
@@ -28,6 +28,8 @@
 
 #include <map>
 
+namespace inputleap {
+
 class Event;
 class EventQueueTimer;
 
@@ -170,3 +172,5 @@ private:
 
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -60,6 +60,8 @@
 #define XK_Ydiaeresis          0x13be
 #endif
 
+namespace inputleap {
+
 /*
  * This table maps keysym values into the corresponding ISO 10646
  * (UCS, Unicode) values.
@@ -1822,3 +1824,5 @@ XWindowsUtil::ErrorLock::saveHandler(Display* display, XErrorEvent* e, void* fla
     LOG((CLOG_DEBUG1 "flagging X error: %d - %.1023s", e->error_code, errtxt));
     *static_cast<bool*>(flag) = true;
 }
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+namespace inputleap {
+
 //! X11 utility functions
 class XWindowsUtil {
 public:
@@ -177,3 +179,5 @@ private:
 
     static KeySymMap    s_keySymToUCS4;
 };
+
+} // namespace inputleap

--- a/src/lib/server/BaseClientProxy.cpp
+++ b/src/lib/server/BaseClientProxy.cpp
@@ -18,9 +18,7 @@
 
 #include "server/BaseClientProxy.h"
 
-//
-// BaseClientProxy
-//
+namespace inputleap {
 
 BaseClientProxy::BaseClientProxy(const std::string& name) :
     m_name(name),
@@ -51,3 +49,5 @@ std::string BaseClientProxy::getName() const
 {
     return m_name;
 }
+
+} // namespace inputleap

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -20,7 +20,9 @@
 
 #include "inputleap/IClient.h"
 
-namespace inputleap { class IStream; }
+namespace inputleap {
+
+class IStream;
 
 //! Generic proxy for client or primary
 class BaseClientProxy : public IClient {
@@ -68,3 +70,5 @@ private:
     std::string m_name;
     std::int32_t m_x, m_y;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -29,9 +29,7 @@
 #include "base/IEventQueue.h"
 #include "base/TMethodEventJob.h"
 
-//
-// ClientListener
-//
+namespace inputleap {
 
 ClientListener::ClientListener(const NetworkAddress& address,
                 ISocketFactory* socketFactory,
@@ -245,3 +243,5 @@ ClientListener::cleanupClientSockets()
 {
     client_sockets_.clear();
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -27,6 +27,8 @@
 #include <memory>
 #include <set>
 
+namespace inputleap {
+
 class ClientProxy;
 class ClientProxyUnknown;
 class NetworkAddress;
@@ -89,3 +91,5 @@ private:
     ConnectionSecurityLevel security_level_;
     UniquePtrContainer<IDataSocket> client_sockets_;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -23,11 +23,9 @@
 #include "base/Log.h"
 #include "base/EventQueue.h"
 
-//
-// ClientProxy
-//
+namespace inputleap {
 
-ClientProxy::ClientProxy(const std::string& name, inputleap::IStream* stream) :
+ClientProxy::ClientProxy(const std::string& name, IStream* stream) :
     BaseClientProxy(name),
     m_stream(stream)
 {
@@ -59,3 +57,5 @@ ClientProxy::getEventTarget() const
 {
     return static_cast<IScreen*>(const_cast<ClientProxy*>(this));
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -22,7 +22,9 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 
-namespace inputleap { class IStream; }
+namespace inputleap {
+
+class IStream;
 
 //! Generic proxy for client
 class ClientProxy : public BaseClientProxy {
@@ -30,7 +32,7 @@ public:
     /*!
     \c name is the name of the client.
     */
-    ClientProxy(const std::string& name, inputleap::IStream* adoptedStream);
+    ClientProxy(const std::string& name, IStream* adoptedStream);
     ~ClientProxy();
 
     //! @name manipulators
@@ -50,7 +52,7 @@ public:
     /*!
     Returns the original stream passed to the c'tor.
     */
-    inputleap::IStream* getStream() const override;
+    IStream* getStream() const override;
 
     //@}
 
@@ -58,5 +60,7 @@ public:
     void* getEventTarget() const override;
 
 private:
-    inputleap::IStream* m_stream;
+    IStream* m_stream;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -27,9 +27,7 @@
 
 #include <cstring>
 
-//
-// ClientProxy1_0
-//
+namespace inputleap {
 
 ClientProxy1_0::ClientProxy1_0(const std::string& name, inputleap::IStream* stream,
                                IEventQueue* events) :
@@ -500,3 +498,5 @@ ClientProxy1_0::ClientClipboard::ClientClipboard() :
 {
     // do nothing
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -22,6 +22,8 @@
 #include "inputleap/Clipboard.h"
 #include "inputleap/protocol_types.h"
 
+namespace inputleap {
+
 class Event;
 class EventQueueTimer;
 class IEventQueue;
@@ -103,3 +105,5 @@ private:
     MessageParser m_parser;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_1.cpp
+++ b/src/lib/server/ClientProxy1_1.cpp
@@ -23,9 +23,7 @@
 
 #include <cstring>
 
-//
-// ClientProxy1_1
-//
+namespace inputleap {
 
 ClientProxy1_1::ClientProxy1_1(const std::string& name, inputleap::IStream* stream,
                                IEventQueue* events) :
@@ -59,3 +57,5 @@ ClientProxy1_1::keyUp(KeyID key, KeyModifierMask mask, KeyButton button)
     LOG((CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x", getName().c_str(), key, mask, button));
     ProtocolUtil::writef(getStream(), kMsgDKeyUp, key, mask, button);
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_1.h
+++ b/src/lib/server/ClientProxy1_1.h
@@ -20,6 +20,8 @@
 
 #include "server/ClientProxy1_0.h"
 
+namespace inputleap {
+
 //! Proxy for client implementing protocol version 1.1
 class ClientProxy1_1 : public ClientProxy1_0 {
 public:
@@ -31,3 +33,5 @@ public:
     void keyRepeat(KeyID, KeyModifierMask, std::int32_t count, KeyButton) override;
     void keyUp(KeyID, KeyModifierMask, KeyButton) override;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_2.cpp
+++ b/src/lib/server/ClientProxy1_2.cpp
@@ -21,9 +21,7 @@
 #include "inputleap/ProtocolUtil.h"
 #include "base/Log.h"
 
-//
-// ClientProxy1_1
-//
+namespace inputleap {
 
 ClientProxy1_2::ClientProxy1_2(const std::string& name, inputleap::IStream* stream,
                                IEventQueue* events) :
@@ -42,3 +40,5 @@ void ClientProxy1_2::mouseRelativeMove(std::int32_t xRel, std::int32_t yRel)
     LOG((CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", getName().c_str(), xRel, yRel));
     ProtocolUtil::writef(getStream(), kMsgDMouseRelMove, xRel, yRel);
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_2.h
+++ b/src/lib/server/ClientProxy1_2.h
@@ -20,6 +20,8 @@
 
 #include "server/ClientProxy1_1.h"
 
+namespace inputleap {
+
 class IEventQueue;
 
 //! Proxy for client implementing protocol version 1.2
@@ -31,3 +33,5 @@ public:
     // IClient overrides
     void mouseRelativeMove(std::int32_t xRel, std::int32_t yRel) override;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_3.cpp
+++ b/src/lib/server/ClientProxy1_3.cpp
@@ -26,12 +26,9 @@
 #include <cstring>
 #include <memory>
 
-//
-// ClientProxy1_3
-//
+namespace inputleap {
 
-ClientProxy1_3::ClientProxy1_3(const std::string& name, inputleap::IStream* stream,
-                               IEventQueue* events) :
+ClientProxy1_3::ClientProxy1_3(const std::string& name, IStream* stream, IEventQueue* events) :
     ClientProxy1_2(name, stream, events),
     m_keepAliveRate(kKeepAliveRate),
     m_keepAliveTimer(nullptr),
@@ -126,3 +123,5 @@ ClientProxy1_3::keepAlive()
 {
     ProtocolUtil::writef(getStream(), kMsgCKeepAlive);
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_3.h
+++ b/src/lib/server/ClientProxy1_3.h
@@ -20,10 +20,12 @@
 
 #include "server/ClientProxy1_2.h"
 
+namespace inputleap {
+
 //! Proxy for client implementing protocol version 1.3
 class ClientProxy1_3 : public ClientProxy1_2 {
 public:
-    ClientProxy1_3(const std::string& name, inputleap::IStream* adoptedStream, IEventQueue* events);
+    ClientProxy1_3(const std::string& name, IStream* adoptedStream, IEventQueue* events);
     ~ClientProxy1_3() override;
 
     // IClient overrides
@@ -46,3 +48,5 @@ private:
     EventQueueTimer* m_keepAliveTimer;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_4.cpp
+++ b/src/lib/server/ClientProxy1_4.cpp
@@ -27,9 +27,7 @@
 #include <cstring>
 #include <memory>
 
-//
-// ClientProxy1_4
-//
+namespace inputleap {
 
 ClientProxy1_4::ClientProxy1_4(const std::string& name, inputleap::IStream* stream, Server* server,
                                IEventQueue* events) :
@@ -65,3 +63,5 @@ ClientProxy1_4::keepAlive()
 {
     ClientProxy1_3::keepAlive();
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_4.h
+++ b/src/lib/server/ClientProxy1_4.h
@@ -20,6 +20,8 @@
 
 #include "server/ClientProxy1_3.h"
 
+namespace inputleap {
+
 class Server;
 
 //! Proxy for client implementing protocol version 1.4
@@ -45,3 +47,5 @@ public:
 
     Server* m_server;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_5.cpp
+++ b/src/lib/server/ClientProxy1_5.cpp
@@ -27,9 +27,7 @@
 
 #include <sstream>
 
-//
-// ClientProxy1_5
-//
+namespace inputleap {
 
 ClientProxy1_5::ClientProxy1_5(const std::string& name, inputleap::IStream* stream, Server* server,
                                IEventQueue* events) :
@@ -106,3 +104,5 @@ ClientProxy1_5::dragInfoReceived()
 
     m_server->dragInfoReceived(fileNum, content);
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -20,6 +20,8 @@
 #include "server/ClientProxy1_4.h"
 #include <vector>
 
+namespace inputleap {
+
 class Server;
 class IEventQueue;
 
@@ -39,3 +41,5 @@ public:
 private:
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -25,9 +25,7 @@
 #include "base/TMethodEventJob.h"
 #include "base/Log.h"
 
-//
-// ClientProxy1_6
-//
+namespace inputleap {
 
 ClientProxy1_6::ClientProxy1_6(const std::string& name, inputleap::IStream* stream, Server* server,
                                IEventQueue* events) :
@@ -99,3 +97,5 @@ ClientProxy1_6::recvClipboard()
 
     return true;
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -19,6 +19,8 @@
 
 #include "server/ClientProxy1_5.h"
 
+namespace inputleap {
+
 class Server;
 class IEventQueue;
 
@@ -38,3 +40,5 @@ private:
 private:
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -35,9 +35,7 @@
 #include "base/IEventQueue.h"
 #include "base/TMethodEventJob.h"
 
-//
-// ClientProxyUnknown
-//
+namespace inputleap {
 
 ClientProxyUnknown::ClientProxyUnknown(inputleap::IStream* stream, double timeout, Server* server, IEventQueue* events) :
     m_stream(stream),
@@ -300,3 +298,5 @@ ClientProxyUnknown::handleReady(const Event&, void*)
 {
     sendSuccess();
 }
+
+} // namespace inputleap

--- a/src/lib/server/ClientProxyUnknown.h
+++ b/src/lib/server/ClientProxyUnknown.h
@@ -21,9 +21,11 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 
+namespace inputleap {
+
 class ClientProxy;
 class EventQueueTimer;
-namespace inputleap { class IStream; }
+class IStream;
 class Server;
 class IEventQueue;
 
@@ -69,3 +71,5 @@ private:
     Server* m_server;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -26,11 +26,9 @@
 
 #include <cstdlib>
 
-using namespace inputleap::string;
+namespace inputleap {
 
-//
-// Config
-//
+using namespace inputleap::string;
 
 Config::Config(IEventQueue* events) :
 	m_inputFilter(events),
@@ -2281,3 +2279,5 @@ std::string XConfigRead::getWhat() const noexcept
 {
 	return format("XConfigRead", "read error: %{1}", m_error.c_str());
 }
+
+} // namespace inputleap

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -30,13 +30,11 @@
 #include <map>
 #include <set>
 
-class Config;
-class ConfigReadContext;
-class IEventQueue;
+namespace inputleap { class Config; }
 
 namespace std {
 template <>
-struct iterator_traits<Config> {
+struct iterator_traits<inputleap::Config> {
     typedef std::string value_type;
     typedef ptrdiff_t                    difference_type;
     typedef bidirectional_iterator_tag    iterator_category;
@@ -44,6 +42,12 @@ struct iterator_traits<Config> {
     typedef std::string& reference;
 };
 }
+
+namespace inputleap {
+
+class Config;
+class ConfigReadContext;
+class IEventQueue;
 
 //! Server configuration
 /*!
@@ -529,3 +533,5 @@ protected:
 private:
     std::string m_error;
 };
+
+} // namespace inputleap

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -27,6 +27,8 @@
 #include <cstdlib>
 #include <cstring>
 
+namespace inputleap {
+
 // -----------------------------------------------------------------------------
 // Input Filter Condition Classes
 // -----------------------------------------------------------------------------
@@ -1091,3 +1093,5 @@ InputFilter::handleEvent(const Event& event, void*)
     // not handled so pass through
     m_events->addEvent(myEvent);
 }
+
+} // namespace inputleap

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -26,6 +26,8 @@
 #include <map>
 #include <set>
 
+namespace inputleap {
+
 class PrimaryClient;
 class Event;
 class IEventQueue;
@@ -369,3 +371,5 @@ private:
     PrimaryClient* m_primaryClient;
     IEventQueue* m_events;
 };
+
+} // namespace inputleap

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -22,9 +22,7 @@
 #include "inputleap/Clipboard.h"
 #include "base/Log.h"
 
-//
-// PrimaryClient
-//
+namespace inputleap {
 
 PrimaryClient::PrimaryClient(const std::string& name, inputleap::Screen* screen) :
     BaseClientProxy(name),
@@ -266,3 +264,5 @@ PrimaryClient::setOptions(const OptionsList& options)
 {
     m_screen->setOptions(options);
 }
+
+} // namespace inputleap

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -21,7 +21,9 @@
 #include "server/BaseClientProxy.h"
 #include "inputleap/protocol_types.h"
 
-namespace inputleap { class Screen; }
+namespace inputleap {
+
+class Screen;
 
 //! Primary screen as pseudo-client
 /*!
@@ -151,3 +153,5 @@ private:
     bool m_clipboardDirty[kClipboardEnd];
     std::int32_t m_fakeInputCount;
 };
+
+} // namespace inputleap

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -50,9 +50,8 @@
 #include <fstream>
 #include <ctime>
 #include <stdexcept>
-//
-// Server
-//
+
+namespace inputleap {
 
 Server::Server(
 		Config& config,
@@ -2407,3 +2406,5 @@ void Server::dragInfoReceived(std::uint32_t fileNum, std::string content)
 
 	m_screen->startDraggingFiles(m_fakeDragFileList);
 }
+
+} // namespace inputleap

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -34,11 +34,13 @@
 #include <set>
 #include <vector>
 
+namespace inputleap {
+
 class BaseClientProxy;
 class EventQueueTimer;
 class PrimaryClient;
 class InputFilter;
-namespace inputleap { class Screen; }
+class Screen;
 class IEventQueue;
 class Thread;
 class ClientListener;
@@ -478,3 +480,5 @@ private:
     ClientListener* m_clientListener;
     ServerArgs m_args;
 };
+
+} // namespace inputleap

--- a/src/server/MSWindowsServerTaskBarReceiver.cpp
+++ b/src/server/MSWindowsServerTaskBarReceiver.cpp
@@ -30,9 +30,7 @@
 #include "base/log_outputters.h"
 #include "base/EventTypes.h"
 
-//
-// MSWindowsServerTaskBarReceiver
-//
+namespace inputleap {
 
 const UINT MSWindowsServerTaskBarReceiver::s_stateToIconID[kMaxState] =
 {
@@ -404,3 +402,5 @@ createTaskBarReceiver(const BufferedLogOutputter* logBuffer, IEventQueue* events
     return new MSWindowsServerTaskBarReceiver(
         MSWindowsScreen::getWindowInstance(), logBuffer, events);
 }
+
+} // namespace inputleap

--- a/src/server/MSWindowsServerTaskBarReceiver.h
+++ b/src/server/MSWindowsServerTaskBarReceiver.h
@@ -21,6 +21,8 @@
 #include "inputleap/ServerTaskBarReceiver.h"
 #include "common/win32/winapi.h"
 
+namespace inputleap {
+
 class BufferedLogOutputter;
 class IEventQueue;
 
@@ -65,3 +67,5 @@ private:
 
     static const UINT    s_stateToIconID[];
 };
+
+} // namespace inputleap

--- a/src/server/barriers.cpp
+++ b/src/server/barriers.cpp
@@ -24,12 +24,14 @@
 #if WINAPI_MSWINDOWS
 #include "MSWindowsServerTaskBarReceiver.h"
 #endif
+
+namespace inputleap {
+
 #if WINAPI_XWINDOWS || WINAPI_CARBON
 CreateTaskBarReceiverFunc createTaskBarReceiver = nullptr;
 #endif
 
-int
-main(int argc, char** argv)
+int server_main(int argc, char** argv)
 {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
@@ -58,4 +60,11 @@ main(int argc, char** argv)
     }
 #endif
     return result;
+}
+
+} // namespace inputleap
+
+int main(int argc, char** argv)
+{
+    return inputleap::server_main(argc, argv);
 }

--- a/src/test/global/TestEventQueue.cpp
+++ b/src/test/global/TestEventQueue.cpp
@@ -22,6 +22,8 @@
 #include "base/SimpleEventQueueBuffer.h"
 #include <stdexcept>
 
+namespace inputleap {
+
 void
 TestEventQueue::raiseQuitEvent()
 {
@@ -59,3 +61,5 @@ TestEventQueue::parent_requests_shutdown() const
 {
     return false;
 }
+
+} // namespace inputleap

--- a/src/test/global/TestEventQueue.h
+++ b/src/test/global/TestEventQueue.h
@@ -19,6 +19,8 @@
 
 #include "base/EventQueue.h"
 
+namespace inputleap {
+
 class EventQueueTimer {};
 
 class TestEventQueue : public EventQueue {
@@ -37,3 +39,5 @@ private:
 private:
     EventQueueTimer* m_quitTimeoutTimer;
 };
+
+} // namespace inputleap

--- a/src/test/integtests/Main.cpp
+++ b/src/test/integtests/Main.cpp
@@ -40,13 +40,13 @@ main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
-    ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
+    inputleap::ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif
 
-    Arch arch;
+    inputleap::Arch arch;
     arch.init();
 
-    Log log;
+    inputleap::Log log;
     log.setFilter(kDEBUG2);
 
     string lockFile;

--- a/src/test/integtests/ipc/IpcTests.cpp
+++ b/src/test/integtests/ipc/IpcTests.cpp
@@ -39,6 +39,8 @@
 
 #define TEST_IPC_PORT 24802
 
+namespace inputleap {
+
 class IpcTests : public ::testing::Test
 {
 public:
@@ -205,5 +207,7 @@ IpcTests::sendMessageToClient_clientHandleMessageReceived(const Event& e, void*)
         m_events.raiseQuitEvent();
     }
 }
+
+} // namespace inputleap
 
 #endif // WINAPI_CARBON

--- a/src/test/integtests/net/NetworkTests.cpp
+++ b/src/test/integtests/net/NetworkTests.cpp
@@ -45,6 +45,8 @@
 #include <iostream>
 #include <stdio.h>
 
+namespace inputleap {
+
 using namespace std;
 using ::testing::_;
 using ::testing::NiceMock;
@@ -521,5 +523,7 @@ void getCursorPos(std::int32_t& x, std::int32_t& y)
     x = 0;
     y = 0;
 }
+
+} // namespace inputleap
 
 #endif // WINAPI_CARBON

--- a/src/test/integtests/platform/MSWindowsClipboardTests.cpp
+++ b/src/test/integtests/platform/MSWindowsClipboardTests.cpp
@@ -22,6 +22,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+namespace inputleap {
+
 class MSWindowsClipboardTests : public ::testing::Test
 {
 protected:
@@ -227,3 +229,5 @@ TEST_F(MSWindowsClipboardTests, isOwnedByBarrier_defaultState_noError)
 
     EXPECT_EQ(true, actual);
 }
+
+} // namespace inputleap

--- a/src/test/integtests/platform/MSWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/MSWindowsKeyStateTests.cpp
@@ -31,6 +31,8 @@
 // wParam = flags, HIBYTE(lParam) = virtual key, LOBYTE(lParam) = scan code
 #define INPUTLEAP_MSG_FAKE_KEY		INPUTLEAP_HOOK_LAST_MSG + 4
 
+namespace inputleap {
+
 using ::testing::_;
 using ::testing::NiceMock;
 
@@ -135,3 +137,4 @@ TEST_F(MSWindowsKeyStateTests, testKoreanLocale_inputModeKey_resultCorrectKeyID)
 	delete desks;
 }
 
+} // namespace inputleap

--- a/src/test/integtests/platform/OSXClipboardTests.cpp
+++ b/src/test/integtests/platform/OSXClipboardTests.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 #include <iostream>
 
+namespace inputleap {
+
 TEST(OSXClipboardTests, empty_openCalled_returnsTrue)
 {
     OSXClipboard clipboard;
@@ -162,3 +164,5 @@ TEST(OSXClipboardTests, get_withFormatAdded_returnsExpected)
 
     EXPECT_EQ("barrier rocks!", actual);
 }
+
+} // namespace inputleap

--- a/src/test/integtests/platform/OSXKeyStateTests.cpp
+++ b/src/test/integtests/platform/OSXKeyStateTests.cpp
@@ -31,6 +31,8 @@
 #define A_CHAR_ID 0x00000061
 #define A_CHAR_BUTTON 001
 
+namespace inputleap {
+
 class OSXKeyStateTests : public ::testing::Test {
 public:
     static bool isKeyPressed(const OSXKeyState& keyState, KeyButton button);
@@ -118,3 +120,4 @@ OSXKeyStateTests::isKeyPressed(const OSXKeyState& keyState, KeyButton button)
 
 #endif
 
+} // namespace inputleap

--- a/src/test/integtests/platform/XWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/XWindowsKeyStateTests.cpp
@@ -35,6 +35,8 @@
 #include <gmock/gmock.h>
 #include <errno.h>
 
+namespace inputleap {
+
 class XWindowsKeyStateTests : public ::testing::Test
 {
 protected:
@@ -232,3 +234,4 @@ TEST_F(XWindowsKeyStateTests, pollActiveGroup_xkb_areEqual)
     }
 }
 
+} // namespace inputleap

--- a/src/test/integtests/platform/XWindowsScreenTests.cpp
+++ b/src/test/integtests/platform/XWindowsScreenTests.cpp
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 #include <cstdlib>
 
+namespace inputleap {
+
 using ::testing::_;
 
 TEST(CXWindowsScreenTests, fakeMouseMove_nonPrimary_getCursorPosValuesCorrect)
@@ -44,3 +46,5 @@ TEST(CXWindowsScreenTests, fakeMouseMove_nonPrimary_getCursorPosValuesCorrect)
     ASSERT_EQ(10, x);
     ASSERT_EQ(20, y);
 }
+
+} // namespace inputleap

--- a/src/test/mock/inputleap/MockApp.h
+++ b/src/test/mock/inputleap/MockApp.h
@@ -23,6 +23,8 @@
 
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 class MockApp : public App
 {
 public:
@@ -42,3 +44,5 @@ public:
     MOCK_METHOD2(foregroundStartup, int(int, char**));
     MOCK_METHOD0(createScreen, inputleap::Screen*());
 };
+
+} // namespace inputleap

--- a/src/test/mock/inputleap/MockArgParser.h
+++ b/src/test/mock/inputleap/MockArgParser.h
@@ -23,6 +23,8 @@
 
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 class MockArgParser : public ArgParser
 {
 public:
@@ -31,3 +33,5 @@ public:
     MOCK_METHOD3(parseGenericArgs, bool(int, const char* const*, int&));
     MOCK_METHOD0(checkUnexpectedArgs, bool());
 };
+
+} // namespace inputleap

--- a/src/test/mock/inputleap/MockEventQueue.h
+++ b/src/test/mock/inputleap/MockEventQueue.h
@@ -22,6 +22,8 @@
 
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 class MockEventQueue : public IEventQueue
 {
 public:
@@ -65,3 +67,5 @@ public:
     MOCK_METHOD0(forFile, FileEvents&());
     MOCK_CONST_METHOD0(waitForReady, void());
 };
+
+} // namespace inputleap

--- a/src/test/mock/inputleap/MockKeyState.h
+++ b/src/test/mock/inputleap/MockKeyState.h
@@ -25,6 +25,8 @@
 #include "MockEventQueue.h"
 #include "MockKeyMap.h"
 
+namespace inputleap {
+
 // NOTE: do not mock methods that are not pure virtual. this mock exists only
 // to provide an implementation of the KeyState abstract class.
 class MockKeyState : public KeyState
@@ -55,3 +57,5 @@ typedef std::uint32_t KeyID;
 
 typedef void (*ForeachKeyCallback)(KeyID, std::int32_t group, inputleap::KeyMap::KeyItem&,
                                    void* userData);
+
+} // namespace inputleap

--- a/src/test/mock/ipc/MockIpcServer.h
+++ b/src/test/mock/ipc/MockIpcServer.h
@@ -26,6 +26,8 @@
 #include <condition_variable>
 #include <mutex>
 
+namespace inputleap {
+
 using ::testing::_;
 using ::testing::Invoke;
 
@@ -60,3 +62,5 @@ private:
     std::condition_variable send_cv_;
     std::mutex send_mutex_;
 };
+
+} // namespace inputleap

--- a/src/test/mock/server/MockConfig.h
+++ b/src/test/mock/server/MockConfig.h
@@ -23,6 +23,8 @@
 
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 class MockConfig : public Config
 {
 public:
@@ -30,3 +32,5 @@ public:
     MOCK_METHOD0(getInputFilter, InputFilter*());
     MOCK_CONST_METHOD1(isScreen, bool(const std::string&));
 };
+
+} // namespace inputleap

--- a/src/test/mock/server/MockInputFilter.h
+++ b/src/test/mock/server/MockInputFilter.h
@@ -23,8 +23,12 @@
 
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 class MockInputFilter : public InputFilter
 {
 public:
      MOCK_METHOD1(setPrimaryClient, void(PrimaryClient*));
 };
+
+} // namespace inputleap

--- a/src/test/mock/server/MockPrimaryClient.h
+++ b/src/test/mock/server/MockPrimaryClient.h
@@ -23,6 +23,8 @@
 
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 class MockPrimaryClient : public PrimaryClient
 {
 public:
@@ -38,3 +40,5 @@ public:
     MOCK_CONST_METHOD0(getToggleMask, KeyModifierMask());
     MOCK_METHOD1(unregisterHotKey, void(std::uint32_t));
 };
+
+} // namespace inputleap

--- a/src/test/unittests/Main.cpp
+++ b/src/test/unittests/Main.cpp
@@ -30,13 +30,13 @@ main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
     // HACK: shouldn't be needed, but logging fails without this.
-    ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
+    inputleap::ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif
 
-    Arch arch;
+    inputleap::Arch arch;
     arch.init();
 
-    Log log;
+    inputleap::Log log;
     log.setFilter(kDEBUG4);
 
     testing::InitGoogleTest(&argc, argv);

--- a/src/test/unittests/inputleap/ArgParserTests.cpp
+++ b/src/test/unittests/inputleap/ArgParserTests.cpp
@@ -20,6 +20,8 @@
 
 #include <gtest/gtest.h>
 
+namespace inputleap {
+
 TEST(ArgParserTests, isArg_abbreviationsArg_returnTrue)
 {
     const int argc = 2;
@@ -221,3 +223,4 @@ TEST(ArgParserTests, assembleCommand_stringArrayWithSpace_returnCommand)
     EXPECT_EQ("\"stub1 space\" stub2 \"stub3 space\"", command);
 }
 
+} // namespace inputleap

--- a/src/test/unittests/inputleap/ClientArgsParsingTests.cpp
+++ b/src/test/unittests/inputleap/ClientArgsParsingTests.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+namespace inputleap {
+
 using ::testing::_;
 using ::testing::Invoke;
 using ::testing::NiceMock;
@@ -93,3 +95,5 @@ TEST(ClientArgsParsingTests, parseClientArgs_unrecognizedArg_returnFalse)
 
     EXPECT_FALSE(result);
 }
+
+} // namespace inputleap

--- a/src/test/unittests/inputleap/ClipboardChunkTests.cpp
+++ b/src/test/unittests/inputleap/ClipboardChunkTests.cpp
@@ -20,6 +20,8 @@
 
 #include <gtest/gtest.h>
 
+namespace inputleap {
+
 TEST(ClipboardChunkTests, start_formatStartChunk)
 {
     ClipboardID id = 0;
@@ -74,3 +76,5 @@ TEST(ClipboardChunkTests, end_formatDataChunk)
 
     delete chunk;
 }
+
+} // namespace inputleap

--- a/src/test/unittests/inputleap/ClipboardTests.cpp
+++ b/src/test/unittests/inputleap/ClipboardTests.cpp
@@ -20,6 +20,8 @@
 
 #include <gtest/gtest.h>
 
+namespace inputleap {
+
 TEST(ClipboardTests, empty_openCalled_returnsTrue)
 {
     Clipboard clipboard;
@@ -402,3 +404,5 @@ TEST(ClipboardTests, copy_withSingleText_clipboardsAreEqual)
     std::string actual = clipboard2.get(Clipboard::kText);
     EXPECT_EQ("barrier rocks!", actual);
 }
+
+} // namespace inputleap

--- a/src/test/unittests/inputleap/KeyStateTests.cpp
+++ b/src/test/unittests/inputleap/KeyStateTests.cpp
@@ -23,6 +23,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Invoke;
@@ -491,3 +493,5 @@ const inputleap::KeyMap::KeyItem* stubMapKey(inputleap::KeyMap::Keystrokes& keys
     keys.push_back(s_stubKeystroke);
     return &s_stubKeyItem;
 }
+
+} // namespace inputleap

--- a/src/test/unittests/inputleap/ServerArgsParsingTests.cpp
+++ b/src/test/unittests/inputleap/ServerArgsParsingTests.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+namespace inputleap {
+
 using ::testing::_;
 using ::testing::Invoke;
 using ::testing::NiceMock;
@@ -64,3 +66,5 @@ TEST(ServerArgsParsingTests, parseServerArgs_configArg_setConfigFile)
 
     EXPECT_EQ("mock_configFile", serverArgs.m_configFile);
 }
+
+} // namespace inputleap

--- a/src/test/unittests/ipc/IpcLogOutputterTests.cpp
+++ b/src/test/unittests/ipc/IpcLogOutputterTests.cpp
@@ -30,6 +30,8 @@
 // HACK: ipc logging only used on windows anyway
 #if WINAPI_MSWINDOWS
 
+namespace inputleap {
+
 using ::testing::_;
 using ::testing::Return;
 using ::testing::AtLeast;
@@ -154,5 +156,7 @@ TEST(IpcLogOutputterTests, write_underBufferRateLimit_allLinesAreSent)
     outputter.write(kNOTE, "mock 4");
     outputter.sendBuffer();
 }
+
+} // namespace inputleap
 
 #endif // WINAPI_MSWINDOWS

--- a/src/test/unittests/platform/OSXKeyStateTests.cpp
+++ b/src/test/unittests/platform/OSXKeyStateTests.cpp
@@ -23,6 +23,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+namespace inputleap {
+
 TEST(OSXKeyStateTests, mapModifiersFromOSX_OSXMask_returnBarrierMask)
 {
     inputleap::KeyMap keyMap;
@@ -55,3 +57,5 @@ TEST(OSXKeyStateTests, mapModifiersFromOSX_OSXMask_returnBarrierMask)
     outMask = keyState.mapModifiersFromOSX(numMask);
     EXPECT_EQ(KeyModifierNumLock, outMask);
 }
+
+} // namespace inputleap


### PR DESCRIPTION
The primary reason for doing this right now is that there exists a global EventType type in system headers on MacOS, which interferes with a future refactoring in which such type is introduced to InputLeap project.