### PR TITLE
lib/clipboard: Do not try to use clipboard if it failed

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1503,7 +1503,11 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 	assert(sender == m_clients.find(clipboard.m_clipboardOwner)->second);
 
 	// get data
-	sender->getClipboard(id, &clipboard.m_clipboard);
+	if (!sender->getClipboard(id, &clipboard.m_clipboard)) {
+		LOG((CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (failed to get clipboard)",
+				clipboard.m_clipboardOwner.c_str(), id));
+		return;
+	}
 
 	// ignore if data hasn't changed
     std::string data = clipboard.m_clipboard.marshall();


### PR DESCRIPTION
This PR cherry-picks a commit by @ofourdan from https://github.com/input-leap/input-leap/pull/1524.

------

Server::onClipboardChanged() tries to get the clipboard from the sender by calling getClipboard().

getClipboard() however may fail, and return false in that case, yet onClipboardChanged() does not actually check the return value and tries to use the clipboard.

If getClipboard() does nothing as with the EiScreen implementation, bad things can happen, such as an abort of Input Leap on an assertion failure in the marshall() call that follows.

To avoid that annoyance, check the return value from getClipboard() and bail out early (and gracefully) when it's reported as false.
