### PR TITLE
lib: Don't shutdown app when debugger interrupts it

### DIFF
--- a/doc/newsfragments/debugger-app-shutdown.bugfix
+++ b/doc/newsfragments/debugger-app-shutdown.bugfix
@@ -1,0 +1,2 @@
+Fix support for debugging commpand line apps on Linux. Previously they would exit whenever debugger
+tries to interrupt them which makes debugging useless.


### PR DESCRIPTION
The accepted convention to interrupt program that gdb is attached to is by calling Ctrl+C in gdb console. This sends SIGINT which is then intercepted by gdb. However, signals in InputLeap apps are intercepted by sigwait(). This does not allow gdb to intercept them first. As a result, interrupting app via Ctrl+C causes the program to terminate as it thinks it received SIGINT.

This is worked around by checking if app is under debugger and raising SIGTRAP instead if that's the case.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
