### PR TITLE
CI: Remove `brew update` from macOS builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -92,7 +92,6 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Setup the image
         run: |
-          brew update
           brew install qt5
           brew install ninja
       - name: Run the build


### PR DESCRIPTION
This currently has a breakage, and fails to update, causing the workflow to ultimately fail, and not provide feedback on macOS builds.

This commit removes `brew update`, in an effort to fix CI checks.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
