### PR TITLE
Fix conflicting artifact names

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -130,7 +130,7 @@ jobs:
         name: Archive Completed Build Directory
       - uses: actions/upload-artifact@v3
         with:
-          name: Windows ${{ env.CI_ENV_BUILD_TYPE }}
+          name: ${{ runner.os }}-${{ env.CI_ENV_BUILD_TYPE }}
           path: ${{ env.CI_ENV_BUILD_TYPE }}.zip
           if-no-files-found: warn
 
@@ -160,7 +160,7 @@ jobs:
         name: Archive Completed Build Directory
       - uses: actions/upload-artifact@v3
         with:
-          name: Windows ${{ env.CI_ENV_BUILD_TYPE }}
+          name: ${{ runner.os }}-${{ env.CI_ENV_BUILD_TYPE }}
           path: ${{ env.CI_ENV_BUILD_TYPE }}.zip
       - name: Build the Installer
         run: .\build_installer.bat


### PR DESCRIPTION
This PR fixes the artefact upload error from Azure (HTTP 503), causing the check to fail.

We now upload the ZIP artefact in the format of `windows-{ver}-Release`. This makes the artefact name *unique*.

The fix is inspired by: https://github.com/actions/upload-artifact/issues/171#issuecomment-1007504385

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
