### PR TITLE
Fix intermittent GH Actions upload errors on Windows.

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -130,7 +130,7 @@ jobs:
         name: Archive Completed Build Directory
       - uses: actions/upload-artifact@v3
         with:
-          name: Windows ${{ env.CI_ENV_BUILD_TYPE }}
+          name: Windows-2019-${{ env.CI_ENV_BUILD_TYPE }}
           path: ${{ env.CI_ENV_BUILD_TYPE }}.zip
           if-no-files-found: warn
 
@@ -160,7 +160,7 @@ jobs:
         name: Archive Completed Build Directory
       - uses: actions/upload-artifact@v3
         with:
-          name: Windows ${{ env.CI_ENV_BUILD_TYPE }}
+          name: Windows-2022-${{ env.CI_ENV_BUILD_TYPE }}
           path: ${{ env.CI_ENV_BUILD_TYPE }}.zip
       - name: Build the Installer
         run: .\build_installer.bat


### PR DESCRIPTION
This PR  adds a commit that fixes intermittent GH Actions upload errors, that so far is only happening on Windows-based runners.

It replaces #1568.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
