### PR TITLE
Bump cmake requirement to 3.12

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,13 +35,21 @@ jobs:
     steps:
 
       - if: matrix.os == 'ubuntu:18.04'
-        name: Add repositories with newer git
+        name: Add repositories with newer git and cmake
         run: |
           apt-get update -y
-          # needed for add-apt-repository
-          apt-get install -y software-properties-common
+          # software-properties-common is needed for add-apt-repository
+          apt-get install -y software-properties-common gpg wget
           # actions/checkout@v3 wants newer git than what's in default repositories
           add-apt-repository ppa:git-core/ppa
+          # InputLeap requires at least CMake 3.12.
+          # This mirrors instructions at https://apt.kitware.com
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+            | gpg --dearmor - \
+            > /usr/share/keyrings/kitware-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' \
+            > /etc/apt/sources.list.d/kitware.list
+
       - name: Update image and install pre-reqs
         run: |
           apt-get update -y

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -34,13 +34,16 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-      - name: Update image and install pre-reqs
+      - if: matrix.os == 'ubuntu:18.04'
+        name: Add repositories with newer git
         run: |
           apt-get update -y
           # needed for add-apt-repository
           apt-get install -y software-properties-common
           # actions/checkout@v3 wants newer git than what's in default repositories
           add-apt-repository ppa:git-core/ppa
+      - name: Update image and install pre-reqs
+        run: |
           apt-get update -y
           apt-get dist-upgrade -y
           apt-get install -y \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,15 +139,7 @@ if (UNIX)
             pkg_check_modules (ICE REQUIRED ice sm)
             include_directories (${XLIB_INCLUDE_DIRS} ${ICE_INCLUDE_DIRS})
 
-            # Old cmake doesn't populate LINK_LIBRARIES.
-            # Use the "normal" libraries but this won't pick up non-standard
-            # library directories paths.
-            # Fixed in cmake 3.12, released July 2018 (commit 92ac721a44)
-            if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-                list (APPEND libs ${XLIB_LIBRARIES} ${ICE_LIBRARIES})
-            else()
-                list (APPEND libs ${XLIB_LINK_LIBRARIES} ${ICE_LINK_LIBRARIES})
-            endif()
+            list(APPEND libs ${XLIB_LINK_LIBRARIES} ${ICE_LINK_LIBRARIES})
 
             set (HAVE_X11 1)
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required(VERSION 3.12)
 project(InputLeap C CXX)
 
 option(INPUTLEAP_BUILD_GUI "Build the GUI" ON)


### PR DESCRIPTION
CMake 3.12 has been released on July 2018, more than 4 years ago.
    
Ubuntu 18:04 LTS includes CMake 3.10 and building on it will require up to date CMake from apt.kitware.org
    
Ubuntu 20.04 LTS already includes CMake 3.16.
    
Debian 9 includes CMake 3.7 and building on it will require newer CMake from Debian backports, which contains 3.16 for amd64 and 3.13 for everything else.
    
Debian 10 (released July 2019) already includes CMake 3.13.
    
Fedora does not support any release older than 13 months.
    
RHEL 7 and derivatives will need compiling cmake from source. However the bump to 3.12 does not affect this because it does not contain cmake3 anyway by default.
    
RHEL 8 or newer and their derivatives contain new enough CMake version in the AppStream repositories.
