### PR TITLE
Cleanup memory allocations

### DIFF
--- a/doc/newsfragments/memory-leak-during-repeated-reconnections.bugfix
+++ b/doc/newsfragments/memory-leak-during-repeated-reconnections.bugfix
@@ -1,0 +1,1 @@
+Fixed a potential memory leak that may cause server memory usage to grow during repeated reconnection attempts.

--- a/src/lib/base/UniquePtrContainer.h
+++ b/src/lib/base/UniquePtrContainer.h
@@ -38,11 +38,16 @@ public:
         data_.push_back(std::move(d));
     }
 
-    void erase(T* p)
+    std::unique_ptr<T> erase(T* p)
     {
-        data_.erase(std::remove_if(data_.begin(), data_.end(),
-                                   [p](const auto& d) { return d.get() == p; }),
-                    data_.end());
+        for (auto it = data_.begin(); it != data_.end(); ++it) {
+            if (it->get() == p) {
+                std::unique_ptr<T> ret = std::move(*it);
+                data_.erase(it);
+                return std::move(ret);
+            }
+        }
+        return {};
     }
 
     typename Container::iterator begin() { return data_.begin(); }

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -137,16 +137,17 @@ Client::connect()
         }
 
         // create the socket
-        IDataSocket* socket = m_socketFactory->create(ARCH->getAddrFamily(m_serverAddress.getAddress()),
-                                                      security_level);
+        auto socket = m_socketFactory->create(ARCH->getAddrFamily(m_serverAddress.getAddress()),
+                                              security_level);
         // filter socket messages, including a packetizing filter
-        m_stream = new PacketStreamFilter(m_events, std::unique_ptr<IDataSocket>(socket));
+        auto socket_ptr = socket.get();
+        m_stream = new PacketStreamFilter(m_events, std::move(socket));
 
         // connect
         LOG((CLOG_DEBUG1 "connecting to server"));
         setupConnecting();
         setupTimer();
-        socket->connect(m_serverAddress);
+        socket_ptr->connect(m_serverAddress);
     }
     catch (XBase& e) {
         cleanupTimer();

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -65,7 +65,6 @@ Client::Client(IEventQueue* events, const std::string& name, const NetworkAddres
     m_events(events),
     m_sendFileThread(nullptr),
     m_writeToDropDirThread(nullptr),
-    m_socket(nullptr),
     m_useSecureNetwork(args.m_enableCrypto),
     m_args(args),
     m_enableClipboard(true)
@@ -140,8 +139,6 @@ Client::connect()
         // create the socket
         IDataSocket* socket = m_socketFactory->create(ARCH->getAddrFamily(m_serverAddress.getAddress()),
                                                       security_level);
-        m_socket = dynamic_cast<TCPSocket*>(socket);
-
         // filter socket messages, including a packetizing filter
         m_stream = socket;
         m_stream = new PacketStreamFilter(m_events, m_stream, true);

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -140,8 +140,7 @@ Client::connect()
         IDataSocket* socket = m_socketFactory->create(ARCH->getAddrFamily(m_serverAddress.getAddress()),
                                                       security_level);
         // filter socket messages, including a packetizing filter
-        m_stream = socket;
-        m_stream = new PacketStreamFilter(m_events, m_stream, true);
+        m_stream = new PacketStreamFilter(m_events, std::unique_ptr<IDataSocket>(socket));
 
         // connect
         LOG((CLOG_DEBUG1 "connecting to server"));

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -217,7 +217,6 @@ private:
     std::string m_dragFileExt;
     Thread* m_sendFileThread;
     Thread* m_writeToDropDirThread;
-    TCPSocket* m_socket;
     bool m_useSecureNetwork;
     ClientArgs m_args;
     bool m_enableClipboard;

--- a/src/lib/inputleap/PacketStreamFilter.cpp
+++ b/src/lib/inputleap/PacketStreamFilter.cpp
@@ -25,8 +25,8 @@
 
 namespace inputleap {
 
-PacketStreamFilter::PacketStreamFilter(IEventQueue* events, inputleap::IStream* stream, bool adoptStream) :
-    StreamFilter(events, stream, adoptStream),
+PacketStreamFilter::PacketStreamFilter(IEventQueue* events, std::unique_ptr<IStream> stream) :
+    StreamFilter(events, std::move(stream)),
     m_size(0),
     m_inputShutdown(false),
     m_events(events)

--- a/src/lib/inputleap/PacketStreamFilter.h
+++ b/src/lib/inputleap/PacketStreamFilter.h
@@ -33,7 +33,7 @@ Filters a stream to read and write packets.
 */
 class PacketStreamFilter : public StreamFilter {
 public:
-    PacketStreamFilter(IEventQueue* events, inputleap::IStream* stream, bool adoptStream = true);
+    PacketStreamFilter(IEventQueue* events, std::unique_ptr<IStream> stream);
     ~PacketStreamFilter() override;
 
     // IStream overrides

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -648,7 +648,7 @@ ServerApp::openClientListener(const NetworkAddress& address)
 
     ClientListener* listen = new ClientListener(
         address,
-        new TCPSocketFactory(m_events, getSocketMultiplexer()),
+        std::make_unique<TCPSocketFactory>(m_events, getSocketMultiplexer()),
         m_events, security_level);
 
     m_events->add_handler(EventType::CLIENT_LISTENER_CONNECTED, listen,

--- a/src/lib/io/StreamFilter.cpp
+++ b/src/lib/io/StreamFilter.cpp
@@ -21,23 +21,19 @@
 
 namespace inputleap {
 
-StreamFilter::StreamFilter(IEventQueue* events, IStream* stream, bool adoptStream) :
-    m_stream(stream),
-    m_adopted(adoptStream),
+StreamFilter::StreamFilter(IEventQueue* events, std::unique_ptr<IStream> stream) :
+    stream_(std::move(stream)),
     m_events(events)
 {
     // replace handlers for m_stream
-    m_events->removeHandlers(m_stream->getEventTarget());
-    m_events->add_handler(EventType::UNKNOWN, m_stream->getEventTarget(),
+    m_events->removeHandlers(stream_->getEventTarget());
+    m_events->add_handler(EventType::UNKNOWN, stream_->getEventTarget(),
                           [this](const auto& e){ handle_upstream_event(e); });
 }
 
 StreamFilter::~StreamFilter()
 {
-    m_events->removeHandler(EventType::UNKNOWN, m_stream->getEventTarget());
-    if (m_adopted) {
-        delete m_stream;
-    }
+    m_events->removeHandler(EventType::UNKNOWN, stream_->getEventTarget());
 }
 
 void
@@ -89,12 +85,6 @@ StreamFilter::isReady() const
 std::uint32_t StreamFilter::getSize() const
 {
     return getStream()->getSize();
-}
-
-inputleap::IStream*
-StreamFilter::getStream() const
-{
-    return m_stream;
 }
 
 void

--- a/src/lib/io/StreamFilter.h
+++ b/src/lib/io/StreamFilter.h
@@ -20,6 +20,7 @@
 
 #include "io/IStream.h"
 #include "base/IEventQueue.h"
+#include <memory>
 
 namespace inputleap {
 
@@ -35,7 +36,7 @@ public:
     this object takes ownership of the stream and will delete it in the
     d'tor.
     */
-    StreamFilter(IEventQueue* events, IStream* stream, bool adoptStream = true);
+    StreamFilter(IEventQueue* events, std::unique_ptr<IStream> stream);
     ~StreamFilter() override;
 
     // IStream overrides
@@ -55,7 +56,7 @@ public:
     /*!
     Returns the stream passed to the c'tor.
     */
-    inputleap::IStream* getStream() const;
+    inputleap::IStream* getStream() const { return stream_.get(); }
 
 protected:
     //! Handle events from source stream
@@ -69,8 +70,7 @@ private:
     void handle_upstream_event(const Event&);
 
 private:
-    inputleap::IStream* m_stream;
-    bool m_adopted;
+    std::unique_ptr<IStream> stream_;
     IEventQueue* m_events;
 };
 

--- a/src/lib/net/ISocketFactory.h
+++ b/src/lib/net/ISocketFactory.h
@@ -20,6 +20,7 @@
 
 #include "arch/IArchNetwork.h"
 #include "net/ConnectionSecurityLevel.h"
+#include <memory>
 
 namespace inputleap {
 
@@ -35,18 +36,15 @@ class ISocketFactory {
 public:
     virtual ~ISocketFactory() { }
 
-    //! @name accessors
-    //@{
-
     //! Create data socket
-    virtual IDataSocket* create(IArchNetwork::EAddressFamily family,
-                                ConnectionSecurityLevel security_level) const = 0;
+    virtual std::unique_ptr<IDataSocket>
+        create(IArchNetwork::EAddressFamily family,
+               ConnectionSecurityLevel security_level) const = 0;
 
     //! Create listen socket
-    virtual IListenSocket* createListen(IArchNetwork::EAddressFamily family,
-                                        ConnectionSecurityLevel security_level) const = 0;
-
-    //@}
+    virtual std::unique_ptr<IListenSocket>
+        create_listen(IArchNetwork::EAddressFamily family,
+                      ConnectionSecurityLevel security_level) const = 0;
 };
 
 } // namespace inputleap

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -83,9 +83,6 @@ SecureSocket::~SecureSocket()
     removeJob();
     freeSSLResources();
 
-    // removing sleep() because I have no idea why you would want to do it
-    // ... smells of trying to cover up a bug you don't understand
-    //inputleap::this_thread_sleep(1);
     delete m_ssl;
 }
 

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -49,15 +49,14 @@ enum {
 };
 
 struct Ssl {
-    SSL_CTX*    m_context;
-    SSL*        m_ssl;
+    SSL_CTX* m_context = nullptr;
+    SSL* m_ssl = nullptr;
 };
 
 SecureSocket::SecureSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer,
                            IArchNetwork::EAddressFamily family,
                            ConnectionSecurityLevel security_level) :
     TCPSocket(events, socketMultiplexer, family),
-    m_ssl(nullptr),
     m_secureReady(false),
     m_fatal(false),
     security_level_{security_level}
@@ -67,7 +66,6 @@ SecureSocket::SecureSocket(IEventQueue* events, SocketMultiplexer* socketMultipl
 SecureSocket::SecureSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer,
                            ArchSocket socket, ConnectionSecurityLevel security_level) :
     TCPSocket(events, socketMultiplexer, socket),
-    m_ssl(nullptr),
     m_secureReady(false),
     m_fatal(false),
     security_level_{security_level}
@@ -82,8 +80,6 @@ SecureSocket::~SecureSocket()
     // will do this, too, but the double-call is harmless
     removeJob();
     freeSSLResources();
-
-    delete m_ssl;
 }
 
 void
@@ -316,10 +312,7 @@ SecureSocket::initSsl(bool server)
 {
     std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
 
-    m_ssl = new Ssl();
-    m_ssl->m_context = nullptr;
-    m_ssl->m_ssl = nullptr;
-
+    m_ssl = std::make_unique<Ssl>();
     initContext(server);
 }
 

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -69,7 +69,7 @@ private:
     int secureAccept(int s);
     int secureConnect(int s);
 
-    void checkResult(int n, int& retry); // may only be called with m_ssl_mutex_ acquired.
+    void checkResult(int n, int& retry); // may only be called with ssl_mutex_ acquired.
 
     void showError(const std::string& reason);
     std::string getError();
@@ -95,7 +95,7 @@ private:
     // by it.
     std::mutex ssl_mutex_;
 
-    Ssl* m_ssl;
+    std::unique_ptr<Ssl> m_ssl;
     bool m_secureReady;
     bool m_fatal;
     ConnectionSecurityLevel security_level_ = ConnectionSecurityLevel::ENCRYPTED;

--- a/src/lib/net/TCPSocketFactory.cpp
+++ b/src/lib/net/TCPSocketFactory.cpp
@@ -38,32 +38,30 @@ TCPSocketFactory::~TCPSocketFactory()
     // do nothing
 }
 
-IDataSocket* TCPSocketFactory::create(IArchNetwork::EAddressFamily family,
-                                      ConnectionSecurityLevel security_level) const
+std::unique_ptr<IDataSocket>
+    TCPSocketFactory::create(IArchNetwork::EAddressFamily family,
+                             ConnectionSecurityLevel security_level) const
 {
     if (security_level != ConnectionSecurityLevel::PLAINTEXT) {
-        SecureSocket* secureSocket = new SecureSocket(m_events, m_socketMultiplexer, family,
-                                                      security_level);
-        secureSocket->initSsl (false);
-        return secureSocket;
-    }
-    else {
-        return new TCPSocket(m_events, m_socketMultiplexer, family);
+        auto secure_socket = std::make_unique<SecureSocket>(m_events, m_socketMultiplexer, family,
+                                                            security_level);
+        secure_socket->initSsl(false);
+        return std::move(secure_socket);
+    } else {
+        return std::make_unique<TCPSocket>(m_events, m_socketMultiplexer, family);
     }
 }
 
-IListenSocket* TCPSocketFactory::createListen(IArchNetwork::EAddressFamily family,
-                                              ConnectionSecurityLevel security_level) const
+std::unique_ptr<IListenSocket>
+    TCPSocketFactory::create_listen(IArchNetwork::EAddressFamily family,
+                                    ConnectionSecurityLevel security_level) const
 {
-    IListenSocket* socket = nullptr;
     if (security_level != ConnectionSecurityLevel::PLAINTEXT) {
-        socket = new SecureListenSocket(m_events, m_socketMultiplexer, family, security_level);
+        return std::make_unique<SecureListenSocket>(m_events, m_socketMultiplexer, family,
+                                                    security_level);
+    } else {
+        return std::make_unique<TCPListenSocket>(m_events, m_socketMultiplexer, family);
     }
-    else {
-        socket = new TCPListenSocket(m_events, m_socketMultiplexer, family);
-    }
-
-    return socket;
 }
 
 } // namespace inputleap

--- a/src/lib/net/TCPSocketFactory.h
+++ b/src/lib/net/TCPSocketFactory.h
@@ -33,11 +33,13 @@ public:
     virtual ~TCPSocketFactory();
 
     // ISocketFactory overrides
-    IDataSocket* create(IArchNetwork::EAddressFamily family,
-                                ConnectionSecurityLevel security_level) const override;
+    std::unique_ptr<IDataSocket>
+        create(IArchNetwork::EAddressFamily family,
+               ConnectionSecurityLevel security_level) const override;
 
-    IListenSocket* createListen(IArchNetwork::EAddressFamily family,
-                                        ConnectionSecurityLevel security_level) const override;
+    std::unique_ptr<IListenSocket>
+        create_listen(IArchNetwork::EAddressFamily family,
+                      ConnectionSecurityLevel security_level) const override;
 
 private:
     IEventQueue* m_events;

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -201,6 +201,7 @@ void ClientListener::handle_client_disconnected(ClientProxy* client)
             m_waitingClients.erase(i);
             m_events->removeHandler(EventType::CLIENT_PROXY_DISCONNECTED, client);
 
+            // FIXME: there are multiple dangling pointers in handlers left for the socket
             delete client;
             break;
         }

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -143,11 +143,12 @@ ClientListener::handle_client_accepted(IDataSocket* socket)
     LOG((CLOG_NOTE "accepted client connection"));
 
     // filter socket messages, including a packetizing filter
-    inputleap::IStream* stream = new PacketStreamFilter(m_events, socket, false);
+    auto stream = std::make_unique<PacketStreamFilter>(m_events, socket, false);
     assert(m_server != nullptr);
 
     // create proxy for unknown client
-    ClientProxyUnknown* client = new ClientProxyUnknown(stream, 30.0, m_server, m_events);
+    ClientProxyUnknown* client = new ClientProxyUnknown(std::move(stream), 30.0, m_server,
+                                                        m_events);
 
     m_newClients.insert(client);
 

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -71,7 +71,7 @@ public:
 private:
     // client connection event handlers
     void handle_client_connecting();
-    void handle_client_accepted(IDataSocket* socket);
+    void handle_client_accepted(IDataSocket* socket_ptr);
     void handle_unknown_client(ClientProxyUnknown* client);
     void handle_client_disconnected(ClientProxy* client);
 

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -83,7 +83,7 @@ private:
     typedef std::set<ClientProxyUnknown*> NewClients;
     typedef std::deque<ClientProxy*> WaitingClients;
 
-    IListenSocket* m_listen;
+    std::unique_ptr<IListenSocket> listen_;
     std::unique_ptr<ISocketFactory> socket_factory_;
     NewClients m_newClients;
     WaitingClients m_waitingClients;

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -41,7 +41,8 @@ class IDataSocket;
 class ClientListener {
 public:
     // The factories are adopted.
-    ClientListener(const NetworkAddress&, ISocketFactory*, IEventQueue* events,
+    ClientListener(const NetworkAddress&,
+                   std::unique_ptr<ISocketFactory> socket_factory, IEventQueue* events,
                    ConnectionSecurityLevel security_level);
     ~ClientListener();
 
@@ -83,7 +84,7 @@ private:
     typedef std::deque<ClientProxy*> WaitingClients;
 
     IListenSocket* m_listen;
-    ISocketFactory* m_socketFactory;
+    std::unique_ptr<ISocketFactory> socket_factory_;
     NewClients m_newClients;
     WaitingClients m_waitingClients;
     Server* m_server;

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -25,16 +25,13 @@
 
 namespace inputleap {
 
-ClientProxy::ClientProxy(const std::string& name, IStream* stream) :
+ClientProxy::ClientProxy(const std::string& name, std::unique_ptr<IStream> stream) :
     BaseClientProxy(name),
-    m_stream(stream)
+    stream_{std::move(stream)}
 {
 }
 
-ClientProxy::~ClientProxy()
-{
-    delete m_stream;
-}
+ClientProxy::~ClientProxy() = default;
 
 void
 ClientProxy::close(const char* msg)
@@ -44,12 +41,6 @@ ClientProxy::close(const char* msg)
 
     // force the close to be sent before we return
     getStream()->flush();
-}
-
-inputleap::IStream*
-ClientProxy::getStream() const
-{
-    return m_stream;
 }
 
 void*

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -21,6 +21,7 @@
 #include "server/BaseClientProxy.h"
 #include "base/Event.h"
 #include "base/EventTypes.h"
+#include <memory>
 
 namespace inputleap {
 
@@ -32,7 +33,7 @@ public:
     /*!
     \c name is the name of the client.
     */
-    ClientProxy(const std::string& name, IStream* adoptedStream);
+    ClientProxy(const std::string& name, std::unique_ptr<IStream> stream);
     ~ClientProxy();
 
     //! @name manipulators
@@ -52,7 +53,7 @@ public:
     /*!
     Returns the original stream passed to the c'tor.
     */
-    IStream* getStream() const override;
+    IStream* getStream() const override { return stream_.get(); }
 
     //@}
 
@@ -60,7 +61,7 @@ public:
     void* getEventTarget() const override;
 
 private:
-    IStream* m_stream;
+    std::unique_ptr<IStream> stream_;
 };
 
 } // namespace inputleap

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -32,9 +32,9 @@
 
 namespace inputleap {
 
-ClientProxy1_6::ClientProxy1_6(const std::string& name, inputleap::IStream* stream, Server* server,
-                               IEventQueue* events) :
-    ClientProxy(name, stream),
+ClientProxy1_6::ClientProxy1_6(const std::string& name, std::unique_ptr<IStream> stream,
+                               Server* server, IEventQueue* events) :
+    ClientProxy(name, std::move(stream)),
     m_heartbeatTimer(nullptr),
     m_parser(&ClientProxy1_6::parseHandshakeMessage),
     m_events(events),
@@ -43,15 +43,15 @@ ClientProxy1_6::ClientProxy1_6(const std::string& name, inputleap::IStream* stre
     m_server{server}
 {
     // install event handlers
-    m_events->add_handler(EventType::STREAM_INPUT_READY, stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_READY, getStream()->getEventTarget(),
                           [this](const auto& e){ handle_data(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, getStream()->getEventTarget(),
                           [this](const auto& e){ handle_write_error(); });
-    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, getStream()->getEventTarget(),
                           [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, getStream()->getEventTarget(),
                           [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, getStream()->getEventTarget(),
                           [this](const auto& e){ handle_write_error(); });
     m_events->add_handler(EventType::FILE_KEEPALIVE, this,
                           [this](const auto& e){ keepAlive(); });

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -32,7 +32,7 @@ class Server;
 //! Proxy for client implementing protocol version 1.0
 class ClientProxy1_6 : public ClientProxy {
 public:
-    ClientProxy1_6(const std::string& name, inputleap::IStream* stream, Server* server,
+    ClientProxy1_6(const std::string& name, std::unique_ptr<IStream> stream, Server* server,
                    IEventQueue* events);
     ~ClientProxy1_6() override;
 

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -173,7 +173,7 @@ void ClientProxyUnknown::handle_data()
         if (major == 1) {
             switch (minor) {
             case 6:
-                m_proxy = new ClientProxy1_6(name, stream_.get(), m_server, m_events);
+                m_proxy = new ClientProxy1_6(name, std::move(stream_), m_server, m_events);
                 break;
             default:
                 break;
@@ -185,9 +185,7 @@ void ClientProxyUnknown::handle_data()
             throw XIncompatibleClient(major, minor);
         }
 
-        // the proxy is created and now proxy now owns the stream
         LOG((CLOG_DEBUG1 "created proxy for client \"%s\" version %d.%d", name.c_str(), major, minor));
-        stream_.reset();
 
         // wait until the proxy signals that it's ready or has disconnected
         addProxyHandlers();

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -30,8 +30,9 @@
 
 namespace inputleap {
 
-ClientProxyUnknown::ClientProxyUnknown(inputleap::IStream* stream, double timeout, Server* server, IEventQueue* events) :
-    m_stream(stream),
+ClientProxyUnknown::ClientProxyUnknown(std::unique_ptr<inputleap::IStream> stream,
+                                       double timeout, Server* server, IEventQueue* events) :
+    stream_(std::move(stream)),
     m_proxy(nullptr),
     m_ready(false),
     m_server(server),
@@ -44,16 +45,13 @@ ClientProxyUnknown::ClientProxyUnknown(inputleap::IStream* stream, double timeou
     addStreamHandlers();
 
     LOG((CLOG_DEBUG1 "saying hello"));
-    ProtocolUtil::writef(m_stream, kMsgHello,
-                            kProtocolMajorVersion,
-                            kProtocolMinorVersion);
+    ProtocolUtil::writef(stream_.get(), kMsgHello, kProtocolMajorVersion, kProtocolMinorVersion);
 }
 
 ClientProxyUnknown::~ClientProxyUnknown()
 {
     removeHandlers();
     removeTimer();
-    delete m_stream;
     delete m_proxy;
 }
 
@@ -93,16 +91,16 @@ ClientProxyUnknown::sendFailure()
 void
 ClientProxyUnknown::addStreamHandlers()
 {
-    assert(m_stream != nullptr);
-    m_events->add_handler(EventType::STREAM_INPUT_READY, m_stream->getEventTarget(),
+    assert(stream_.get() != nullptr);
+    m_events->add_handler(EventType::STREAM_INPUT_READY, stream_->getEventTarget(),
                           [this](const auto& e){ handle_data(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, m_stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, stream_->getEventTarget(),
                           [this](const auto& e){ handle_write_error(); });
-    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, m_stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, stream_->getEventTarget(),
                           [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, m_stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, stream_->getEventTarget(),
                           [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, m_stream->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, stream_->getEventTarget(),
                           [this](const auto& e){ handle_write_error(); });
 }
 
@@ -119,12 +117,12 @@ ClientProxyUnknown::addProxyHandlers()
 void
 ClientProxyUnknown::removeHandlers()
 {
-    if (m_stream != nullptr) {
-        m_events->removeHandler(EventType::STREAM_INPUT_READY, m_stream->getEventTarget());
-        m_events->removeHandler(EventType::STREAM_OUTPUT_ERROR, m_stream->getEventTarget());
-        m_events->removeHandler(EventType::STREAM_INPUT_SHUTDOWN, m_stream->getEventTarget());
-        m_events->removeHandler(EventType::STREAM_INPUT_FORMAT_ERROR, m_stream->getEventTarget());
-        m_events->removeHandler(EventType::STREAM_OUTPUT_SHUTDOWN, m_stream->getEventTarget());
+    if (stream_) {
+        m_events->removeHandler(EventType::STREAM_INPUT_READY, stream_->getEventTarget());
+        m_events->removeHandler(EventType::STREAM_OUTPUT_ERROR, stream_->getEventTarget());
+        m_events->removeHandler(EventType::STREAM_INPUT_SHUTDOWN, stream_->getEventTarget());
+        m_events->removeHandler(EventType::STREAM_INPUT_FORMAT_ERROR, stream_->getEventTarget());
+        m_events->removeHandler(EventType::STREAM_OUTPUT_SHUTDOWN, stream_->getEventTarget());
     }
     if (m_proxy != nullptr) {
         m_events->removeHandler(EventType::CLIENT_PROXY_READY, m_proxy);
@@ -149,7 +147,7 @@ void ClientProxyUnknown::handle_data()
     std::string name("<unknown>");
     try {
         // limit the maximum length of the hello
-        std::uint32_t n = m_stream->getSize();
+        std::uint32_t n = stream_->getSize();
         if (n > kMaxHelloLength) {
             LOG((CLOG_DEBUG1 "hello reply too long"));
             throw XBadClient();
@@ -157,8 +155,7 @@ void ClientProxyUnknown::handle_data()
 
         // parse the reply to hello
         std::int16_t major, minor;
-        if (!ProtocolUtil::readf(m_stream, kMsgHelloBack,
-                                    &major, &minor, &name)) {
+        if (!ProtocolUtil::readf(stream_.get(), kMsgHelloBack, &major, &minor, &name)) {
             throw XBadClient();
         }
 
@@ -176,7 +173,7 @@ void ClientProxyUnknown::handle_data()
         if (major == 1) {
             switch (minor) {
             case 6:
-                m_proxy = new ClientProxy1_6(name, m_stream, m_server, m_events);
+                m_proxy = new ClientProxy1_6(name, stream_.get(), m_server, m_events);
                 break;
             default:
                 break;
@@ -190,7 +187,7 @@ void ClientProxyUnknown::handle_data()
 
         // the proxy is created and now proxy now owns the stream
         LOG((CLOG_DEBUG1 "created proxy for client \"%s\" version %d.%d", name.c_str(), major, minor));
-        m_stream = nullptr;
+        stream_.reset();
 
         // wait until the proxy signals that it's ready or has disconnected
         addProxyHandlers();
@@ -199,14 +196,13 @@ void ClientProxyUnknown::handle_data()
     catch (XIncompatibleClient& e) {
         // client is incompatible
         LOG((CLOG_WARN "client \"%s\" has incompatible version %d.%d)", name.c_str(), e.getMajor(), e.getMinor()));
-        ProtocolUtil::writef(m_stream,
-                            kMsgEIncompatible,
-                            kProtocolMajorVersion, kProtocolMinorVersion);
+        ProtocolUtil::writef(stream_.get(), kMsgEIncompatible,
+                             kProtocolMajorVersion, kProtocolMinorVersion);
     }
     catch (XBadClient&) {
         // client not behaving
         LOG((CLOG_WARN "protocol error from client \"%s\"", name.c_str()));
-        ProtocolUtil::writef(m_stream, kMsgEBad);
+        ProtocolUtil::writef(stream_.get(), kMsgEBad);
     }
     catch (XBase& e) {
         // misc error

--- a/src/lib/server/ClientProxyUnknown.h
+++ b/src/lib/server/ClientProxyUnknown.h
@@ -20,6 +20,7 @@
 
 #include "base/Event.h"
 #include "base/EventTypes.h"
+#include <memory>
 
 namespace inputleap {
 
@@ -31,7 +32,8 @@ class IEventQueue;
 
 class ClientProxyUnknown {
 public:
-    ClientProxyUnknown(inputleap::IStream* stream, double timeout, Server* server, IEventQueue* events);
+    ClientProxyUnknown(std::unique_ptr<IStream> stream, double timeout, Server* server,
+                       IEventQueue* events);
     ~ClientProxyUnknown();
 
     //! @name manipulators
@@ -46,7 +48,7 @@ public:
     ClientProxy* orphanClientProxy();
 
     //! Get the stream
-    inputleap::IStream* getStream() { return m_stream; }
+    inputleap::IStream* getStream() { return stream_.get(); }
 
     //@}
 
@@ -64,7 +66,7 @@ private:
     void handle_ready();
 
 private:
-    inputleap::IStream* m_stream;
+    std::unique_ptr<inputleap::IStream> stream_;
     EventQueueTimer* m_timer;
     ClientProxy* m_proxy;
     bool m_ready;

--- a/src/test/integtests/net/NetworkTests.cpp
+++ b/src/test/integtests/net/NetworkTests.cpp
@@ -113,8 +113,9 @@ TEST_F(NetworkTests, sendToClient_mockData)
 
     // server
     SocketMultiplexer serverSocketMultiplexer;
-    TCPSocketFactory* serverSocketFactory = new TCPSocketFactory(&m_events, &serverSocketMultiplexer);
-    ClientListener listener(serverAddress, serverSocketFactory, &m_events,
+    ClientListener listener(serverAddress,
+                            std::make_unique<TCPSocketFactory>(&m_events, &serverSocketMultiplexer),
+                            &m_events,
                             ConnectionSecurityLevel::PLAINTEXT);
     NiceMock<MockScreen> serverScreen;
     NiceMock<MockPrimaryClient> primaryClient;
@@ -174,9 +175,9 @@ TEST_F(NetworkTests, sendToClient_mockFile)
 
     // server
     SocketMultiplexer serverSocketMultiplexer;
-    TCPSocketFactory* serverSocketFactory = new TCPSocketFactory(&m_events, &serverSocketMultiplexer);
-    ClientListener listener(serverAddress, serverSocketFactory, &m_events,
-                            ConnectionSecurityLevel::PLAINTEXT);
+    ClientListener listener(serverAddress,
+                            std::make_unique<TCPSocketFactory>(&m_events, &serverSocketMultiplexer),
+                            &m_events, ConnectionSecurityLevel::PLAINTEXT);
     NiceMock<MockScreen> serverScreen;
     NiceMock<MockPrimaryClient> primaryClient;
     NiceMock<MockConfig> serverConfig;
@@ -234,9 +235,9 @@ TEST_F(NetworkTests, sendToServer_mockData)
 
     // server
     SocketMultiplexer serverSocketMultiplexer;
-    TCPSocketFactory* serverSocketFactory = new TCPSocketFactory(&m_events, &serverSocketMultiplexer);
-    ClientListener listener(serverAddress, serverSocketFactory, &m_events,
-                            ConnectionSecurityLevel::PLAINTEXT);
+    ClientListener listener(serverAddress,
+                            std::make_unique<TCPSocketFactory>(&m_events, &serverSocketMultiplexer),
+                            &m_events, ConnectionSecurityLevel::PLAINTEXT);
     NiceMock<MockScreen> serverScreen;
     NiceMock<MockPrimaryClient> primaryClient;
     NiceMock<MockConfig> serverConfig;
@@ -294,9 +295,9 @@ TEST_F(NetworkTests, sendToServer_mockFile)
 
     // server
     SocketMultiplexer serverSocketMultiplexer;
-    TCPSocketFactory* serverSocketFactory = new TCPSocketFactory(&m_events, &serverSocketMultiplexer);
-    ClientListener listener(serverAddress, serverSocketFactory, &m_events,
-                            ConnectionSecurityLevel::PLAINTEXT);
+    ClientListener listener(serverAddress,
+                            std::make_unique<TCPSocketFactory>(&m_events, &serverSocketMultiplexer),
+                            &m_events, ConnectionSecurityLevel::PLAINTEXT);
     NiceMock<MockScreen> serverScreen;
     NiceMock<MockPrimaryClient> primaryClient;
     NiceMock<MockConfig> serverConfig;


### PR DESCRIPTION
This PR cleans up memory allocations by adding more uses of automatic memory management via std::unique_ptr.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
