### PR TITLE
lib: Fix potential ODR rule violation due to EventQueueTimer

### DIFF
--- a/src/lib/base/EventQueueTimer.h
+++ b/src/lib/base/EventQueueTimer.h
@@ -1,0 +1,30 @@
+/*
+    InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) InputLeap contributors
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef INPUTLEAP_LIB_BASE_EVENT_QUEUE_TIMER_H
+#define INPUTLEAP_LIB_BASE_EVENT_QUEUE_TIMER_H
+
+namespace inputleap {
+
+class EventQueueTimer {
+public:
+    virtual ~EventQueueTimer() = default;
+};
+
+} // namespace inputleap
+
+#endif // INPUTLEAP_LIB_BASE_EVENT_QUEUE_TIMER_H

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -26,9 +26,6 @@
 namespace inputleap {
 
 class IEventQueueBuffer;
-
-// Opaque type for timer info.  This is defined by subclasses of
-// IEventQueueBuffer.
 class EventQueueTimer;
 
 //! Event queue interface

--- a/src/lib/base/SimpleEventQueueBuffer.cpp
+++ b/src/lib/base/SimpleEventQueueBuffer.cpp
@@ -16,17 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "EventQueueTimer.h"
 #include "base/SimpleEventQueueBuffer.h"
 #include "base/Stopwatch.h"
 #include "arch/Arch.h"
 
 namespace inputleap {
-
-class EventQueueTimer { };
-
-//
-// SimpleEventQueueBuffer
-//
 
 SimpleEventQueueBuffer::SimpleEventQueueBuffer()
 {

--- a/src/lib/platform/MSWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "base/EventQueueTimer.h"
 #include "platform/MSWindowsEventQueueBuffer.h"
 
 #include "arch/win32/ArchMiscWindows.h"
@@ -24,17 +25,6 @@
 #include <VersionHelpers.h>
 
 namespace inputleap {
-
-//
-// EventQueueTimer
-//
-
-class EventQueueTimer { };
-
-
-//
-// MSWindowsEventQueueBuffer
-//
 
 MSWindowsEventQueueBuffer::MSWindowsEventQueueBuffer(IEventQueue* events) :
     m_events(events)

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -16,14 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "base/EventQueueTimer.h"
 #include "platform/OSXEventQueueBuffer.h"
 
 #include "base/Event.h"
 #include "base/IEventQueue.h"
 
 namespace inputleap {
-
-class EventQueueTimer { };
 
 OSXEventQueueBuffer::OSXEventQueueBuffer(IEventQueue* events) :
     m_event(nullptr),

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <cassert>
+#include "base/EventQueueTimer.h"
 #include "platform/XWindowsEventQueueBuffer.h"
 
 #include "mt/Thread.h"
@@ -27,13 +28,6 @@
 #include <poll.h>
 
 namespace inputleap {
-
-class EventQueueTimer { };
-
-
-//
-// XWindowsEventQueueBuffer
-//
 
 XWindowsEventQueueBuffer::XWindowsEventQueueBuffer(IXWindowsImpl* impl,
         Display* display, Window window, IEventQueue* events) :

--- a/src/test/global/TestEventQueue.h
+++ b/src/test/global/TestEventQueue.h
@@ -21,8 +21,6 @@
 
 namespace inputleap {
 
-class EventQueueTimer {};
-
 class TestEventQueue : public EventQueue {
 public:
     TestEventQueue() : m_quitTimeoutTimer(nullptr) { }


### PR DESCRIPTION
Currently every platform defines its own EventQueueTimer type. This assumes that only one platform can be enabled at a time. In the future this will not necessarily be the case (Ei platform may be enabled together with XWindows). Depending on exact implementation choices this may cause ODR violations.

It's better to expose such an API that extending it in the expected way does not have chance for ODR violations. Having just one EventQueueTimer type is the simpliest solution.

## Contributor Checklist:

* [not needed] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
