### PR TITLE
Cleanup memory allocations

### DIFF
--- a/src/lib/inputleap/ClipboardChunk.cpp
+++ b/src/lib/inputleap/ClipboardChunk.cpp
@@ -34,12 +34,12 @@ ClipboardChunk::ClipboardChunk(size_t size)
     m_dataSize = size - CLIPBOARD_CHUNK_META_SIZE;
 }
 
-ClipboardChunk* ClipboardChunk::start(ClipboardID id, std::uint32_t sequence,
-                                      const std::string& size)
+ClipboardChunk ClipboardChunk::start(ClipboardID id, std::uint32_t sequence,
+                                     const std::string& size)
 {
     size_t sizeLength = size.size();
-    ClipboardChunk* start = new ClipboardChunk(sizeLength + CLIPBOARD_CHUNK_META_SIZE);
-    std::string& chunk = start->chunk_;
+    ClipboardChunk start(sizeLength + CLIPBOARD_CHUNK_META_SIZE);
+    std::string& chunk = start.chunk_;
 
     chunk[0] = id;
     std::memcpy (&chunk[1], &sequence, 4);
@@ -50,12 +50,12 @@ ClipboardChunk* ClipboardChunk::start(ClipboardID id, std::uint32_t sequence,
     return start;
 }
 
-ClipboardChunk* ClipboardChunk::data(ClipboardID id, std::uint32_t sequence,
-                                     const std::string& data)
+ClipboardChunk ClipboardChunk::data(ClipboardID id, std::uint32_t sequence,
+                                    const std::string& data)
 {
     size_t dataSize = data.size();
-    ClipboardChunk* chunk = new ClipboardChunk(dataSize + CLIPBOARD_CHUNK_META_SIZE);
-    std::string& chunkData = chunk->chunk_;
+    ClipboardChunk chunk(dataSize + CLIPBOARD_CHUNK_META_SIZE);
+    std::string& chunkData = chunk.chunk_;
 
     chunkData[0] = id;
     std::memcpy (&chunkData[1], &sequence, 4);
@@ -66,10 +66,10 @@ ClipboardChunk* ClipboardChunk::data(ClipboardID id, std::uint32_t sequence,
     return chunk;
 }
 
-ClipboardChunk* ClipboardChunk::end(ClipboardID id, std::uint32_t sequence)
+ClipboardChunk ClipboardChunk::end(ClipboardID id, std::uint32_t sequence)
 {
-    ClipboardChunk* end = new ClipboardChunk(CLIPBOARD_CHUNK_META_SIZE);
-    std::string& chunk = end->chunk_;
+    ClipboardChunk end(CLIPBOARD_CHUNK_META_SIZE);
+    std::string& chunk = end.chunk_;
 
     chunk[0] = id;
     std::memcpy (&chunk[1], &sequence, 4);

--- a/src/lib/inputleap/ClipboardChunk.h
+++ b/src/lib/inputleap/ClipboardChunk.h
@@ -33,9 +33,9 @@ class ClipboardChunk : public Chunk {
 public:
     ClipboardChunk(size_t size);
 
-    static ClipboardChunk* start(ClipboardID id, std::uint32_t sequence, const std::string& size);
-    static ClipboardChunk* data(ClipboardID id, std::uint32_t sequence, const std::string& data);
-    static ClipboardChunk* end(ClipboardID id, std::uint32_t sequence);
+    static ClipboardChunk start(ClipboardID id, std::uint32_t sequence, const std::string& size);
+    static ClipboardChunk data(ClipboardID id, std::uint32_t sequence, const std::string& data);
+    static ClipboardChunk end(ClipboardID id, std::uint32_t sequence);
 
     static int assemble(inputleap::IStream* stream, std::string& dataCached, ClipboardID& id,
                         std::uint32_t& sequence);

--- a/src/lib/inputleap/FileChunk.cpp
+++ b/src/lib/inputleap/FileChunk.cpp
@@ -34,11 +34,11 @@ FileChunk::FileChunk(size_t size)
     m_dataSize = size - FILE_CHUNK_META_SIZE;
 }
 
-FileChunk* FileChunk::start(const std::string& size)
+FileChunk FileChunk::start(const std::string& size)
 {
     size_t sizeLength = size.size();
-    FileChunk* start = new FileChunk(sizeLength + FILE_CHUNK_META_SIZE);
-    std::string& chunk = start->chunk_;
+    FileChunk start(sizeLength + FILE_CHUNK_META_SIZE);
+    std::string& chunk = start.chunk_;
     chunk[0] = kDataStart;
     memcpy(&chunk[1], size.c_str(), sizeLength);
     chunk[sizeLength + 1] = '\0';
@@ -46,10 +46,10 @@ FileChunk* FileChunk::start(const std::string& size)
     return start;
 }
 
-FileChunk* FileChunk::data(std::uint8_t* data, size_t dataSize)
+FileChunk FileChunk::data(std::uint8_t* data, size_t dataSize)
 {
-    FileChunk* chunk = new FileChunk(dataSize + FILE_CHUNK_META_SIZE);
-    std::string& chunkData = chunk->chunk_;
+    FileChunk chunk(dataSize + FILE_CHUNK_META_SIZE);
+    std::string& chunkData = chunk.chunk_;
     chunkData[0] = kDataChunk;
     memcpy(&chunkData[1], data, dataSize);
     chunkData[dataSize + 1] = '\0';
@@ -57,11 +57,10 @@ FileChunk* FileChunk::data(std::uint8_t* data, size_t dataSize)
     return chunk;
 }
 
-FileChunk*
-FileChunk::end()
+FileChunk FileChunk::end()
 {
-    FileChunk* end = new FileChunk(FILE_CHUNK_META_SIZE);
-    std::string& chunk = end->chunk_;
+    FileChunk end(FILE_CHUNK_META_SIZE);
+    std::string& chunk = end.chunk_;
     chunk[0] = kDataEnd;
     chunk[1] = '\0';
 

--- a/src/lib/inputleap/FileChunk.h
+++ b/src/lib/inputleap/FileChunk.h
@@ -32,9 +32,9 @@ class FileChunk : public Chunk {
 public:
     FileChunk(size_t size);
 
-    static FileChunk* start(const std::string& size);
-    static FileChunk* data(std::uint8_t* data, size_t dataSize);
-    static FileChunk* end();
+    static FileChunk start(const std::string& size);
+    static FileChunk data(std::uint8_t* data, size_t dataSize);
+    static FileChunk end();
     static int assemble(inputleap::IStream* stream, std::string& dataCached, size_t& expectedSize);
     static void send(inputleap::IStream* stream, uint8_t mark, const char* data, size_t dataSize);
 };

--- a/src/lib/inputleap/StreamChunker.cpp
+++ b/src/lib/inputleap/StreamChunker.cpp
@@ -56,10 +56,10 @@ StreamChunker::sendFile(const char* filename,
 
     // send first message (file size)
     std::string fileSize = inputleap::string::sizeTypeToString(size);
-    auto sizeMessage = FileChunk::start(fileSize);
+    auto size_message = FileChunk::start(fileSize);
 
     events->add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                      create_event_data<FileChunk>(sizeMessage));
+                      create_event_data<FileChunk>(size_message));
 
     // send chunk messages with a fixed chunk size
     size_t sentLength = 0;
@@ -119,11 +119,10 @@ StreamChunker::sendClipboard(
 {
     // send first message (data size)
     std::string dataSize = inputleap::string::sizeTypeToString(size);
-    ClipboardChunk* sizeMessage = ClipboardChunk::start(id, sequence, dataSize);
+    ClipboardChunk size_message = ClipboardChunk::start(id, sequence, dataSize);
 
     events->add_event(EventType::CLIPBOARD_SENDING, eventTarget,
-                      create_event_data<ClipboardChunk>(*sizeMessage));
-    delete sizeMessage;
+                      create_event_data<ClipboardChunk>(size_message));
 
     // send clipboard chunk with a fixed size
     size_t sentLength = 0;
@@ -138,11 +137,10 @@ StreamChunker::sendClipboard(
         }
 
         std::string chunk(data.substr(sentLength, chunkSize).c_str(), chunkSize);
-        ClipboardChunk* dataChunk = ClipboardChunk::data(id, sequence, chunk);
+        ClipboardChunk data_chunk = ClipboardChunk::data(id, sequence, chunk);
 
         events->add_event(EventType::CLIPBOARD_SENDING, eventTarget,
-                          create_event_data<ClipboardChunk>(*dataChunk));
-        delete dataChunk;
+                          create_event_data<ClipboardChunk>(data_chunk));
 
         sentLength += chunkSize;
         if (sentLength == size) {
@@ -151,11 +149,10 @@ StreamChunker::sendClipboard(
     }
 
     // send last message
-    ClipboardChunk* end = ClipboardChunk::end(id, sequence);
+    ClipboardChunk end = ClipboardChunk::end(id, sequence);
 
     events->add_event(EventType::CLIPBOARD_SENDING, eventTarget,
-                      create_event_data<ClipboardChunk>(*end));
-    delete end;
+                      create_event_data<ClipboardChunk>(end));
 
     LOG((CLOG_DEBUG "sent clipboard size=%d", sentLength));
 }

--- a/src/lib/inputleap/StreamChunker.cpp
+++ b/src/lib/inputleap/StreamChunker.cpp
@@ -56,11 +56,10 @@ StreamChunker::sendFile(const char* filename,
 
     // send first message (file size)
     std::string fileSize = inputleap::string::sizeTypeToString(size);
-    FileChunk* sizeMessage = FileChunk::start(fileSize);
+    auto sizeMessage = FileChunk::start(fileSize);
 
     events->add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                      create_event_data<FileChunk>(*sizeMessage));
-    delete sizeMessage;
+                      create_event_data<FileChunk>(sizeMessage));
 
     // send chunk messages with a fixed chunk size
     size_t sentLength = 0;
@@ -84,12 +83,11 @@ StreamChunker::sendFile(const char* filename,
         char* chunkData = new char[chunkSize];
         file.read(chunkData, chunkSize);
         std::uint8_t* data = reinterpret_cast<std::uint8_t*>(chunkData);
-        FileChunk* fileChunk = FileChunk::data(data, chunkSize);
+        FileChunk fileChunk = FileChunk::data(data, chunkSize);
         delete[] chunkData;
 
         events->add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                          create_event_data<FileChunk>(*fileChunk));
-        delete fileChunk;
+                          create_event_data<FileChunk>(fileChunk));
 
         sentLength += chunkSize;
         file.seekg (sentLength, std::ios::beg);
@@ -100,11 +98,10 @@ StreamChunker::sendFile(const char* filename,
     }
 
     // send last message
-    FileChunk* end = FileChunk::end();
+    FileChunk end = FileChunk::end();
 
     events->add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                      create_event_data<FileChunk>(*end));
-    delete end;
+                      create_event_data<FileChunk>(end));
 
     file.close();
 

--- a/src/test/integtests/net/NetworkTests.cpp
+++ b/src/test/integtests/net/NetworkTests.cpp
@@ -427,11 +427,10 @@ NetworkTests::sendMockData(void* eventTarget)
 {
     // send first message (file size)
     std::string size = inputleap::string::sizeTypeToString(kMockDataSize);
-    FileChunk* sizeMessage = FileChunk::start(size);
+    FileChunk size_message = FileChunk::start(size);
 
     m_events.add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                       create_event_data<FileChunk>(*sizeMessage));
-    delete sizeMessage;
+                       create_event_data<FileChunk>(size_message));
 
     // send chunk messages with incrementing chunk size
     size_t lastSize = 0;
@@ -445,10 +444,9 @@ NetworkTests::sendMockData(void* eventTarget)
         }
 
         // first byte is the chunk mark, last is \0
-        FileChunk* chunk = FileChunk::data(m_mockData, dataSize);
+        FileChunk chunk = FileChunk::data(m_mockData, dataSize);
         m_events.add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                           create_event_data<FileChunk>(*chunk));
-        delete chunk;
+                           create_event_data<FileChunk>(chunk));
 
         sentLength += dataSize;
         lastSize = dataSize;
@@ -460,10 +458,9 @@ NetworkTests::sendMockData(void* eventTarget)
     }
 
     // send last message
-    FileChunk* transferFinished = FileChunk::end();
+    FileChunk transferFinished = FileChunk::end();
     m_events.add_event(EventType::FILE_CHUNK_SENDING, eventTarget,
-                       create_event_data<FileChunk>(*transferFinished));
-    delete transferFinished;
+                       create_event_data<FileChunk>(transferFinished));
 }
 
 std::uint8_t* newMockData(size_t size)

--- a/src/test/unittests/inputleap/ClipboardChunkTests.cpp
+++ b/src/test/unittests/inputleap/ClipboardChunkTests.cpp
@@ -27,16 +27,14 @@ TEST(ClipboardChunkTests, start_formatStartChunk)
     ClipboardID id = 0;
     std::uint32_t sequence = 0;
     std::string mockDataSize = "10";
-    ClipboardChunk* chunk = ClipboardChunk::start(id, sequence, mockDataSize);
+    ClipboardChunk chunk = ClipboardChunk::start(id, sequence, mockDataSize);
 
-    EXPECT_EQ(id, chunk->chunk_[0]);
-    EXPECT_EQ(sequence, static_cast<std::uint32_t>(chunk->chunk_[1]));
-    EXPECT_EQ(kDataStart, chunk->chunk_[5]);
-    EXPECT_EQ('1', chunk->chunk_[6]);
-    EXPECT_EQ('0', chunk->chunk_[7]);
-    EXPECT_EQ('\0', chunk->chunk_[8]);
-
-    delete chunk;
+    EXPECT_EQ(id, chunk.chunk_[0]);
+    EXPECT_EQ(sequence, static_cast<std::uint32_t>(chunk.chunk_[1]));
+    EXPECT_EQ(kDataStart, chunk.chunk_[5]);
+    EXPECT_EQ('1', chunk.chunk_[6]);
+    EXPECT_EQ('0', chunk.chunk_[7]);
+    EXPECT_EQ('\0', chunk.chunk_[8]);
 }
 
 TEST(ClipboardChunkTests, data_formatDataChunk)
@@ -44,37 +42,33 @@ TEST(ClipboardChunkTests, data_formatDataChunk)
     ClipboardID id = 0;
     std::uint32_t sequence = 1;
     std::string mockData = "mock data";
-    ClipboardChunk* chunk = ClipboardChunk::data(id, sequence, mockData);
+    ClipboardChunk chunk = ClipboardChunk::data(id, sequence, mockData);
 
-    EXPECT_EQ(id, chunk->chunk_[0]);
-    EXPECT_EQ(sequence, static_cast<std::uint32_t>(chunk->chunk_[1]));
-    EXPECT_EQ(kDataChunk, chunk->chunk_[5]);
-    EXPECT_EQ('m', chunk->chunk_[6]);
-    EXPECT_EQ('o', chunk->chunk_[7]);
-    EXPECT_EQ('c', chunk->chunk_[8]);
-    EXPECT_EQ('k', chunk->chunk_[9]);
-    EXPECT_EQ(' ', chunk->chunk_[10]);
-    EXPECT_EQ('d', chunk->chunk_[11]);
-    EXPECT_EQ('a', chunk->chunk_[12]);
-    EXPECT_EQ('t', chunk->chunk_[13]);
-    EXPECT_EQ('a', chunk->chunk_[14]);
-    EXPECT_EQ('\0', chunk->chunk_[15]);
-
-    delete chunk;
+    EXPECT_EQ(id, chunk.chunk_[0]);
+    EXPECT_EQ(sequence, static_cast<std::uint32_t>(chunk.chunk_[1]));
+    EXPECT_EQ(kDataChunk, chunk.chunk_[5]);
+    EXPECT_EQ('m', chunk.chunk_[6]);
+    EXPECT_EQ('o', chunk.chunk_[7]);
+    EXPECT_EQ('c', chunk.chunk_[8]);
+    EXPECT_EQ('k', chunk.chunk_[9]);
+    EXPECT_EQ(' ', chunk.chunk_[10]);
+    EXPECT_EQ('d', chunk.chunk_[11]);
+    EXPECT_EQ('a', chunk.chunk_[12]);
+    EXPECT_EQ('t', chunk.chunk_[13]);
+    EXPECT_EQ('a', chunk.chunk_[14]);
+    EXPECT_EQ('\0', chunk.chunk_[15]);
 }
 
 TEST(ClipboardChunkTests, end_formatDataChunk)
 {
     ClipboardID id = 1;
     std::uint32_t sequence = 1;
-    ClipboardChunk* chunk = ClipboardChunk::end(id, sequence);
+    ClipboardChunk chunk = ClipboardChunk::end(id, sequence);
 
-    EXPECT_EQ(id, chunk->chunk_[0]);
-    EXPECT_EQ(sequence, static_cast<std::uint32_t>(chunk->chunk_[1]));
-    EXPECT_EQ(kDataEnd, chunk->chunk_[5]);
-    EXPECT_EQ('\0', chunk->chunk_[6]);
-
-    delete chunk;
+    EXPECT_EQ(id, chunk.chunk_[0]);
+    EXPECT_EQ(sequence, static_cast<std::uint32_t>(chunk.chunk_[1]));
+    EXPECT_EQ(kDataEnd, chunk.chunk_[5]);
+    EXPECT_EQ('\0', chunk.chunk_[6]);
 }
 
 } // namespace inputleap


### PR DESCRIPTION
This PR cleans up memory allocations by adding more uses of automatic memory management via std::unique_ptr.