### PR TITLE
azure-pipelines: Install ninja on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
     vmImage: $(imageName)
   steps:
     - script: sudo apt-get update -y
-    - script: sudo apt-get install -y libxtst-dev libxinerama-dev libxrandr-dev libice-dev libsm-dev qtdeclarative5-dev qttools5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev
+    - script: sudo apt-get install -y ninja-build libxtst-dev libxinerama-dev libxrandr-dev libice-dev libsm-dev qtdeclarative5-dev qttools5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev
       displayName: Install Dependencies
     - script: sh -x ./clean_build.sh
       displayName: Clean Build


### PR DESCRIPTION
Apparently ninja is not installed on azure pipelines Linux builds, which causes them to finish slower because ninja does not parallelize make builds.