### PR TITLE
Use --parallel for building in clean_build.sh

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -39,5 +39,5 @@ mkdir ${B_BUILD_DIR}
 cd ${B_BUILD_DIR}
 echo "Starting Input Leap $B_BUILD_TYPE build in '${B_BUILD_DIR}'..."
 "$B_CMAKE" $B_CMAKE_FLAGS ..
-"$B_CMAKE" --build .
+"$B_CMAKE" --build . --parallel
 echo "Build completed successfully"


### PR DESCRIPTION
Forced parallelism has been dropped in commit b477be79e9c. However, it was probably a mistake to do, because not everyone installs ninja by default. Any user who forgets that will get a slow build which is not optimal. Since minimum version of CMake is now 3.12, enabling parallelism is just a single flag.
