### PR TITLE
Move all server->client message serialization to separate class

### DIFF
--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -897,7 +897,7 @@ void ServerProxy::handle_clipboard_sending_event(const Event& event)
 
 void ServerProxy::file_chunk_sending(const FileChunk& chunk)
 {
-    FileChunk::send(m_stream, chunk.mark_, chunk.data_);
+    ProtocolUtil::writef(m_stream, kMsgDFileTransfer, chunk.mark_, &chunk.data_);
 }
 
 void ServerProxy::sendDragInfo(std::uint32_t fileCount, const char* info, size_t size)

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -892,7 +892,9 @@ ServerProxy::dragInfoReceived()
 
 void ServerProxy::handle_clipboard_sending_event(const Event& event)
 {
-    ClipboardChunk::send(m_stream, event.get_data_as<ClipboardChunk>());
+    const auto& chunk = event.get_data_as<ClipboardChunk>();
+    ProtocolUtil::writef(m_stream, kMsgDClipboard, chunk.id_, chunk.sequence_, chunk.mark_,
+                         &chunk.data_);
 }
 
 void ServerProxy::file_chunk_sending(const FileChunk& chunk)

--- a/src/lib/inputleap/ClipboardChunk.cpp
+++ b/src/lib/inputleap/ClipboardChunk.cpp
@@ -95,27 +95,4 @@ int ClipboardChunk::assemble(inputleap::IStream* stream, std::string& dataCached
     return kError;
 }
 
-void ClipboardChunk::send(inputleap::IStream* stream, const ClipboardChunk& chunk)
-{
-    LOG((CLOG_DEBUG1 "sending clipboard chunk"));
-    switch (chunk.mark_) {
-    case kDataStart:
-        LOG((CLOG_DEBUG2 "sending clipboard chunk start: size=%s", chunk.data_.c_str()));
-        break;
-
-    case kDataChunk:
-        LOG((CLOG_DEBUG2 "sending clipboard chunk data: size=%i", chunk.data_.size()));
-        break;
-
-    case kDataEnd:
-        LOG((CLOG_DEBUG2 "sending clipboard finished"));
-        break;
-    default:
-        break;
-    }
-
-    ProtocolUtil::writef(stream, kMsgDClipboard, chunk.id_, chunk.sequence_, chunk.mark_,
-                         &chunk.data_);
-}
-
 } // namespace inputleap

--- a/src/lib/inputleap/ClipboardChunk.h
+++ b/src/lib/inputleap/ClipboardChunk.h
@@ -39,8 +39,6 @@ public:
     static int assemble(inputleap::IStream* stream, std::string& dataCached, ClipboardID& id,
                         std::uint32_t& sequence);
 
-    static void send(inputleap::IStream* stream, const ClipboardChunk& chunk);
-
     static size_t getExpectedSize() { return s_expectedSize; }
 
     std::uint8_t id_ = 0;

--- a/src/lib/inputleap/FileChunk.cpp
+++ b/src/lib/inputleap/FileChunk.cpp
@@ -118,25 +118,4 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
     return kError;
 }
 
-void FileChunk::send(inputleap::IStream* stream, std::uint8_t mark, const std::string& data)
-{
-    switch (mark) {
-    case kDataStart:
-        LOG((CLOG_DEBUG2 "sending file chunk start: size=%s", data.c_str()));
-        break;
-
-    case kDataChunk:
-        LOG((CLOG_DEBUG2 "sending file chunk: size=%i", data.size()));
-        break;
-
-    case kDataEnd:
-        LOG((CLOG_DEBUG2 "sending file finished"));
-        break;
-    default:
-        break;
-    }
-
-    ProtocolUtil::writef(stream, kMsgDFileTransfer, mark, &data);
-}
-
 } // namespace inputleap

--- a/src/lib/inputleap/FileChunk.h
+++ b/src/lib/inputleap/FileChunk.h
@@ -34,7 +34,6 @@ public:
     static FileChunk data(std::uint8_t* data, size_t dataSize);
     static FileChunk end();
     static int assemble(inputleap::IStream* stream, std::string& dataCached, size_t& expectedSize);
-    static void send(inputleap::IStream* stream, uint8_t mark, const std::string& data);
 
     std::uint8_t mark_ = 0;
     std::string data_;

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -22,6 +22,7 @@
 
 namespace inputleap {
 
+class IClientConnection;
 class IStream;
 class FileChunk;
 
@@ -65,7 +66,7 @@ public:
     virtual void sendDragInfo(std::uint32_t fileCount, const char* info, size_t size) = 0;
     virtual void file_chunk_sending(const FileChunk& chunk) = 0;
     std::string getName() const override;
-    virtual inputleap::IStream* getStream() const = 0;
+    virtual IClientConnection& get_conn() const = 0;
 
 private:
     std::string m_name;

--- a/src/lib/server/ClientConnectionByStream.cpp
+++ b/src/lib/server/ClientConnectionByStream.cpp
@@ -1,0 +1,166 @@
+/*  InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) InputLeap contributors
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ClientConnectionByStream.h"
+#include "base/Log.h"
+#include "inputleap/ProtocolUtil.h"
+#include "inputleap/protocol_types.h"
+#include "io/IStream.h"
+
+namespace inputleap {
+
+ClientConnectionByStream::ClientConnectionByStream(const std::string& name,
+                                                   std::unique_ptr<IStream> stream) :
+    name_{name},
+    stream_{std::move(stream)}
+{}
+
+ClientConnectionByStream::~ClientConnectionByStream() = default;
+
+void* ClientConnectionByStream::get_event_target()
+{
+    return stream_->getEventTarget();
+}
+
+void ClientConnectionByStream::send_query_info_1_6()
+{
+    LOG((CLOG_DEBUG1 "querying client \"%s\" info", name_.c_str()));
+    ProtocolUtil::writef(stream_.get(), kMsgQInfo);
+}
+
+void ClientConnectionByStream::send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs,
+                                              std::uint32_t seq_num, KeyModifierMask mask)
+{
+    LOG((CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
+         seq_num, mask));
+    ProtocolUtil::writef(stream_.get(), kMsgCEnter, x_abs, y_abs, seq_num, mask);
+}
+
+void ClientConnectionByStream::send_leave_1_6()
+{
+    LOG((CLOG_DEBUG1 "send leave to \"%s\"", name_.c_str()));
+    ProtocolUtil::writef(stream_.get(), kMsgCLeave);
+}
+
+void ClientConnectionByStream::send_key_down_1_6(KeyID key, KeyModifierMask mask, KeyButton button)
+{
+    LOG((CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+         name_.c_str(), key, mask, button));
+    ProtocolUtil::writef(stream_.get(), kMsgDKeyDown, key, mask, button);
+}
+
+void ClientConnectionByStream::send_key_up_1_6(KeyID key, KeyModifierMask mask, KeyButton button)
+{
+    LOG((CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+         name_.c_str(), key, mask, button));
+    ProtocolUtil::writef(stream_.get(), kMsgDKeyUp, key, mask, button);
+}
+
+void ClientConnectionByStream::send_key_repeat_1_6(KeyID key, KeyModifierMask mask,
+                                                   std::int32_t count, KeyButton button)
+{
+    LOG((CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
+         name_.c_str(), key, mask, count, button));
+    ProtocolUtil::writef(stream_.get(), kMsgDKeyRepeat, key, mask, count, button);
+}
+
+void ClientConnectionByStream::send_mouse_down_1_6(ButtonID button)
+{
+    LOG((CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", name_.c_str(), button));
+    ProtocolUtil::writef(stream_.get(), kMsgDMouseDown, button);
+}
+
+void ClientConnectionByStream::send_mouse_up_1_6(ButtonID button)
+{
+    LOG((CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", name_.c_str(), button));
+    ProtocolUtil::writef(stream_.get(), kMsgDMouseUp, button);
+}
+
+void ClientConnectionByStream::send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs)
+{
+    LOG((CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs));
+    ProtocolUtil::writef(stream_.get(), kMsgDMouseMove, x_abs, y_abs);
+}
+
+void ClientConnectionByStream::send_mouse_relative_move_1_6(std::int32_t x_rel, std::int32_t y_rel)
+{
+    LOG((CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel));
+    ProtocolUtil::writef(stream_.get(), kMsgDMouseRelMove, x_rel, y_rel);
+}
+
+void ClientConnectionByStream::send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta)
+{
+    LOG((CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta));
+    ProtocolUtil::writef(stream_.get(), kMsgDMouseWheel, x_delta, y_delta);
+}
+
+void ClientConnectionByStream::send_drag_info_1_6(std::uint32_t file_count, const std::string& data)
+{
+    ProtocolUtil::writef(stream_.get(), kMsgDDragInfo, file_count, &data);
+}
+
+void ClientConnectionByStream::send_screensaver_1_6(bool on)
+{
+    LOG((CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0));
+    ProtocolUtil::writef(stream_.get(), kMsgCScreenSaver, on ? 1 : 0);
+}
+
+void ClientConnectionByStream::send_reset_options_1_6()
+{
+    LOG((CLOG_DEBUG1 "send reset options to \"%s\"", name_.c_str()));
+    ProtocolUtil::writef(stream_.get(), kMsgCResetOptions);
+}
+
+void ClientConnectionByStream::send_set_options_1_6(const OptionsList& options)
+{
+    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%d", name_.c_str(), options.size()));
+    ProtocolUtil::writef(stream_.get(), kMsgDSetOptions, &options);
+}
+
+void ClientConnectionByStream::send_info_ack_1_6()
+{
+    LOG((CLOG_DEBUG1 "send info ack to \"%s\"", name_.c_str()));
+    ProtocolUtil::writef(stream_.get(), kMsgCInfoAck);
+}
+
+void ClientConnectionByStream::send_keep_alive_1_6()
+{
+    ProtocolUtil::writef(stream_.get(), kMsgCKeepAlive);
+}
+
+void ClientConnectionByStream::send_close_1_6(const char* msg)
+{
+    LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str()));
+    ProtocolUtil::writef(stream_.get(), msg);
+}
+
+void ClientConnectionByStream::send_grab_clipboard(ClipboardID id)
+{
+    LOG((CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, name_.c_str()));
+    ProtocolUtil::writef(stream_.get(), kMsgCClipboard, id, 0);
+}
+
+void ClientConnectionByStream::flush()
+{
+    stream_->flush();
+}
+
+void ClientConnectionByStream::close()
+{
+    stream_->close();
+}
+
+} // namespace inputleap

--- a/src/lib/server/ClientConnectionByStream.cpp
+++ b/src/lib/server/ClientConnectionByStream.cpp
@@ -16,6 +16,7 @@
 
 #include "ClientConnectionByStream.h"
 #include "base/Log.h"
+#include "inputleap/FileChunk.h"
 #include "inputleap/ProtocolUtil.h"
 #include "inputleap/protocol_types.h"
 #include "io/IStream.h"
@@ -123,6 +124,11 @@ void ClientConnectionByStream::send_keep_alive_1_6()
 void ClientConnectionByStream::send_close_1_6(const char* msg)
 {
     ProtocolUtil::writef(stream_.get(), msg);
+}
+
+void ClientConnectionByStream::send_file_chunk_1_6(const FileChunk& chunk)
+{
+    ProtocolUtil::writef(stream_.get(), kMsgDFileTransfer, chunk.mark_, &chunk.data_);
 }
 
 void ClientConnectionByStream::send_grab_clipboard(ClipboardID id)

--- a/src/lib/server/ClientConnectionByStream.cpp
+++ b/src/lib/server/ClientConnectionByStream.cpp
@@ -22,9 +22,7 @@
 
 namespace inputleap {
 
-ClientConnectionByStream::ClientConnectionByStream(const std::string& name,
-                                                   std::unique_ptr<IStream> stream) :
-    name_{name},
+ClientConnectionByStream::ClientConnectionByStream(std::unique_ptr<IStream> stream) :
     stream_{std::move(stream)}
 {}
 
@@ -37,73 +35,58 @@ void* ClientConnectionByStream::get_event_target()
 
 void ClientConnectionByStream::send_query_info_1_6()
 {
-    LOG((CLOG_DEBUG1 "querying client \"%s\" info", name_.c_str()));
     ProtocolUtil::writef(stream_.get(), kMsgQInfo);
 }
 
 void ClientConnectionByStream::send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs,
                                               std::uint32_t seq_num, KeyModifierMask mask)
 {
-    LOG((CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
-         seq_num, mask));
     ProtocolUtil::writef(stream_.get(), kMsgCEnter, x_abs, y_abs, seq_num, mask);
 }
 
 void ClientConnectionByStream::send_leave_1_6()
 {
-    LOG((CLOG_DEBUG1 "send leave to \"%s\"", name_.c_str()));
     ProtocolUtil::writef(stream_.get(), kMsgCLeave);
 }
 
 void ClientConnectionByStream::send_key_down_1_6(KeyID key, KeyModifierMask mask, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
-         name_.c_str(), key, mask, button));
     ProtocolUtil::writef(stream_.get(), kMsgDKeyDown, key, mask, button);
 }
 
 void ClientConnectionByStream::send_key_up_1_6(KeyID key, KeyModifierMask mask, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
-         name_.c_str(), key, mask, button));
     ProtocolUtil::writef(stream_.get(), kMsgDKeyUp, key, mask, button);
 }
 
 void ClientConnectionByStream::send_key_repeat_1_6(KeyID key, KeyModifierMask mask,
                                                    std::int32_t count, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
-         name_.c_str(), key, mask, count, button));
     ProtocolUtil::writef(stream_.get(), kMsgDKeyRepeat, key, mask, count, button);
 }
 
 void ClientConnectionByStream::send_mouse_down_1_6(ButtonID button)
 {
-    LOG((CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", name_.c_str(), button));
     ProtocolUtil::writef(stream_.get(), kMsgDMouseDown, button);
 }
 
 void ClientConnectionByStream::send_mouse_up_1_6(ButtonID button)
 {
-    LOG((CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", name_.c_str(), button));
     ProtocolUtil::writef(stream_.get(), kMsgDMouseUp, button);
 }
 
 void ClientConnectionByStream::send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs)
 {
-    LOG((CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs));
     ProtocolUtil::writef(stream_.get(), kMsgDMouseMove, x_abs, y_abs);
 }
 
 void ClientConnectionByStream::send_mouse_relative_move_1_6(std::int32_t x_rel, std::int32_t y_rel)
 {
-    LOG((CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel));
     ProtocolUtil::writef(stream_.get(), kMsgDMouseRelMove, x_rel, y_rel);
 }
 
 void ClientConnectionByStream::send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta)
 {
-    LOG((CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta));
     ProtocolUtil::writef(stream_.get(), kMsgDMouseWheel, x_delta, y_delta);
 }
 
@@ -114,25 +97,21 @@ void ClientConnectionByStream::send_drag_info_1_6(std::uint32_t file_count, cons
 
 void ClientConnectionByStream::send_screensaver_1_6(bool on)
 {
-    LOG((CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0));
     ProtocolUtil::writef(stream_.get(), kMsgCScreenSaver, on ? 1 : 0);
 }
 
 void ClientConnectionByStream::send_reset_options_1_6()
 {
-    LOG((CLOG_DEBUG1 "send reset options to \"%s\"", name_.c_str()));
     ProtocolUtil::writef(stream_.get(), kMsgCResetOptions);
 }
 
 void ClientConnectionByStream::send_set_options_1_6(const OptionsList& options)
 {
-    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%d", name_.c_str(), options.size()));
     ProtocolUtil::writef(stream_.get(), kMsgDSetOptions, &options);
 }
 
 void ClientConnectionByStream::send_info_ack_1_6()
 {
-    LOG((CLOG_DEBUG1 "send info ack to \"%s\"", name_.c_str()));
     ProtocolUtil::writef(stream_.get(), kMsgCInfoAck);
 }
 
@@ -143,13 +122,11 @@ void ClientConnectionByStream::send_keep_alive_1_6()
 
 void ClientConnectionByStream::send_close_1_6(const char* msg)
 {
-    LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str()));
     ProtocolUtil::writef(stream_.get(), msg);
 }
 
 void ClientConnectionByStream::send_grab_clipboard(ClipboardID id)
 {
-    LOG((CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, name_.c_str()));
     ProtocolUtil::writef(stream_.get(), kMsgCClipboard, id, 0);
 }
 

--- a/src/lib/server/ClientConnectionByStream.cpp
+++ b/src/lib/server/ClientConnectionByStream.cpp
@@ -16,6 +16,7 @@
 
 #include "ClientConnectionByStream.h"
 #include "base/Log.h"
+#include "inputleap/ClipboardChunk.h"
 #include "inputleap/FileChunk.h"
 #include "inputleap/ProtocolUtil.h"
 #include "inputleap/protocol_types.h"
@@ -124,6 +125,12 @@ void ClientConnectionByStream::send_keep_alive_1_6()
 void ClientConnectionByStream::send_close_1_6(const char* msg)
 {
     ProtocolUtil::writef(stream_.get(), msg);
+}
+
+void ClientConnectionByStream::send_clipboard_chunk_1_6(const ClipboardChunk& chunk)
+{
+    ProtocolUtil::writef(stream_.get(), kMsgDClipboard, chunk.id_, chunk.sequence_, chunk.mark_,
+                         &chunk.data_);
 }
 
 void ClientConnectionByStream::send_file_chunk_1_6(const FileChunk& chunk)

--- a/src/lib/server/ClientConnectionByStream.h
+++ b/src/lib/server/ClientConnectionByStream.h
@@ -56,6 +56,7 @@ public:
     void send_keep_alive_1_6() override;
     void send_close_1_6(const char* msg) override;
 
+    void send_file_chunk_1_6(const FileChunk& chunk) override;
     void send_grab_clipboard(ClipboardID id) override;
 
     void flush() override;

--- a/src/lib/server/ClientConnectionByStream.h
+++ b/src/lib/server/ClientConnectionByStream.h
@@ -56,6 +56,7 @@ public:
     void send_keep_alive_1_6() override;
     void send_close_1_6(const char* msg) override;
 
+    void send_clipboard_chunk_1_6(const ClipboardChunk& chunk) override;
     void send_file_chunk_1_6(const FileChunk& chunk) override;
     void send_grab_clipboard(ClipboardID id) override;
 

--- a/src/lib/server/ClientConnectionByStream.h
+++ b/src/lib/server/ClientConnectionByStream.h
@@ -1,0 +1,71 @@
+/*  InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) InputLeap contributors
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef INPUTLEAP_LIB_SERVER_CLIENT_MESSAGE_BACKEND_TO_STREAM_H
+#define INPUTLEAP_LIB_SERVER_CLIENT_MESSAGE_BACKEND_TO_STREAM_H
+
+#include "IClientConnection.h"
+#include <memory>
+
+namespace inputleap {
+
+class IStream;
+
+/// Writes protocol messages to IStream instance
+class ClientConnectionByStream : public IClientConnection {
+public:
+    ClientConnectionByStream(const std::string& name, std::unique_ptr<IStream> stream);
+    ~ClientConnectionByStream() override;
+
+    IStream* get_stream() override { return stream_.get(); }
+
+    void* get_event_target() override;
+
+    void send_query_info_1_6() override;
+    void send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs, std::uint32_t seq_num,
+                        KeyModifierMask mask) override;
+    void send_leave_1_6() override;
+    void send_key_down_1_6(KeyID key, KeyModifierMask mask, KeyButton button) override;
+    void send_key_up_1_6(KeyID key, KeyModifierMask mask, KeyButton button) override;
+    void send_key_repeat_1_6(KeyID key, KeyModifierMask mask, std::int32_t count,
+                             KeyButton button) override;
+    void send_mouse_down_1_6(ButtonID button) override;
+    void send_mouse_up_1_6(ButtonID button) override;
+    void send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs) override;
+    void send_mouse_relative_move_1_6(std::int32_t x_rel, std::int32_t y_rel) override;
+    void send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta) override;
+    void send_drag_info_1_6(std::uint32_t file_count, const std::string& data) override;
+    void send_screensaver_1_6(bool on) override;
+    void send_reset_options_1_6() override;
+    void send_set_options_1_6(const OptionsList& options) override;
+    void send_info_ack_1_6() override;
+    void send_keep_alive_1_6() override;
+    void send_close_1_6(const char* msg) override;
+
+    void send_grab_clipboard(ClipboardID id) override;
+
+    void flush() override;
+    void close() override;
+
+private:
+    std::string name_;
+    std::unique_ptr<IStream> stream_;
+};
+
+} // namespace inputleap
+
+#endif // INPUTLEAP_LIB_SERVER_CLIENT_MESSAGE_BACKEND_TO_STREAM_H

--- a/src/lib/server/ClientConnectionLoggingWrapper.cpp
+++ b/src/lib/server/ClientConnectionLoggingWrapper.cpp
@@ -1,0 +1,176 @@
+/*  InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) InputLeap contributors
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ClientConnectionLoggingWrapper.h"
+#include "base/Log.h"
+#include "inputleap/ProtocolUtil.h"
+#include "inputleap/protocol_types.h"
+#include "io/IStream.h"
+
+namespace inputleap {
+
+ClientConnectionLoggingWrapper::ClientConnectionLoggingWrapper(
+        const std::string& name, std::unique_ptr<IClientConnection> conn) :
+    name_{name},
+    conn_{std::move(conn)}
+{}
+
+ClientConnectionLoggingWrapper::~ClientConnectionLoggingWrapper() = default;
+
+void* ClientConnectionLoggingWrapper::get_event_target()
+{
+    return conn_->get_event_target();
+}
+
+IStream* ClientConnectionLoggingWrapper::get_stream()
+{
+    return conn_->get_stream();
+}
+
+void ClientConnectionLoggingWrapper::send_query_info_1_6()
+{
+    LOG((CLOG_DEBUG1 "querying client \"%s\" info", name_.c_str()));
+    conn_->send_query_info_1_6();
+}
+
+void ClientConnectionLoggingWrapper::send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs,
+                                                    std::uint32_t seq_num, KeyModifierMask mask)
+{
+    LOG((CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
+         seq_num, mask));
+    conn_->send_enter_1_6(x_abs, y_abs, seq_num, mask);
+}
+
+void ClientConnectionLoggingWrapper::send_leave_1_6()
+{
+    LOG((CLOG_DEBUG1 "send leave to \"%s\"", name_.c_str()));
+    conn_->send_leave_1_6();
+}
+
+void ClientConnectionLoggingWrapper::send_key_down_1_6(KeyID key, KeyModifierMask mask,
+                                                       KeyButton button)
+{
+    LOG((CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+         name_.c_str(), key, mask, button));
+    conn_->send_key_down_1_6(key, mask, button);
+}
+
+void ClientConnectionLoggingWrapper::send_key_up_1_6(KeyID key, KeyModifierMask mask,
+                                                     KeyButton button)
+{
+    LOG((CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+         name_.c_str(), key, mask, button));
+    conn_->send_key_up_1_6(key, mask, button);
+}
+
+void ClientConnectionLoggingWrapper::send_key_repeat_1_6(KeyID key, KeyModifierMask mask,
+                                                         std::int32_t count, KeyButton button)
+{
+    LOG((CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
+         name_.c_str(), key, mask, count, button));
+    conn_->send_key_repeat_1_6(key, mask, count, button);
+}
+
+void ClientConnectionLoggingWrapper::send_mouse_down_1_6(ButtonID button)
+{
+    LOG((CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", name_.c_str(), button));
+    conn_->send_mouse_down_1_6(button);
+}
+
+void ClientConnectionLoggingWrapper::send_mouse_up_1_6(ButtonID button)
+{
+    LOG((CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", name_.c_str(), button));
+    conn_->send_mouse_up_1_6(button);
+}
+
+void ClientConnectionLoggingWrapper::send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs)
+{
+    LOG((CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs));
+    conn_->send_mouse_move_1_6(x_abs, y_abs);
+}
+
+void ClientConnectionLoggingWrapper::send_mouse_relative_move_1_6(std::int32_t x_rel,
+                                                                  std::int32_t y_rel)
+{
+    LOG((CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel));
+    conn_->send_mouse_relative_move_1_6(x_rel, y_rel);
+}
+
+void ClientConnectionLoggingWrapper::send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta)
+{
+    LOG((CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta));
+    conn_->send_mouse_wheel_1_6(x_delta, y_delta);
+}
+
+void ClientConnectionLoggingWrapper::send_drag_info_1_6(std::uint32_t file_count,
+                                                        const std::string& data)
+{
+    LOG((CLOG_DEBUG2 "send drag info to \"%s\" %d, %d", name_.c_str(), file_count, data.size()));
+    conn_->send_drag_info_1_6(file_count, data);
+}
+
+void ClientConnectionLoggingWrapper::send_screensaver_1_6(bool on)
+{
+    LOG((CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0));
+    conn_->send_screensaver_1_6(on);
+}
+
+void ClientConnectionLoggingWrapper::send_reset_options_1_6()
+{
+    LOG((CLOG_DEBUG1 "send reset options to \"%s\"", name_.c_str()));
+    conn_->send_reset_options_1_6();
+}
+
+void ClientConnectionLoggingWrapper::send_set_options_1_6(const OptionsList& options)
+{
+    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%d", name_.c_str(), options.size()));
+    conn_->send_set_options_1_6(options);
+}
+
+void ClientConnectionLoggingWrapper::send_info_ack_1_6()
+{
+    LOG((CLOG_DEBUG1 "send info ack to \"%s\"", name_.c_str()));
+    conn_->send_info_ack_1_6();
+}
+
+void ClientConnectionLoggingWrapper::send_keep_alive_1_6()
+{
+    conn_->send_keep_alive_1_6();
+}
+
+void ClientConnectionLoggingWrapper::send_close_1_6(const char* msg)
+{
+    LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str()));
+    conn_->send_close_1_6(msg);
+}
+
+void ClientConnectionLoggingWrapper::send_grab_clipboard(ClipboardID id)
+{
+    LOG((CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, name_.c_str()));
+    conn_->send_grab_clipboard(id);
+}
+
+void ClientConnectionLoggingWrapper::flush()
+{
+    conn_->flush();
+}
+
+void ClientConnectionLoggingWrapper::close()
+{
+    conn_->close();
+}
+
+} // namespace inputleap

--- a/src/lib/server/ClientConnectionLoggingWrapper.cpp
+++ b/src/lib/server/ClientConnectionLoggingWrapper.cpp
@@ -16,6 +16,7 @@
 
 #include "ClientConnectionLoggingWrapper.h"
 #include "base/Log.h"
+#include "inputleap/ClipboardChunk.h"
 #include "inputleap/FileChunk.h"
 #include "inputleap/ProtocolUtil.h"
 #include "inputleap/protocol_types.h"
@@ -156,6 +157,27 @@ void ClientConnectionLoggingWrapper::send_close_1_6(const char* msg)
 {
     LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str()));
     conn_->send_close_1_6(msg);
+}
+
+void ClientConnectionLoggingWrapper::send_clipboard_chunk_1_6(const ClipboardChunk& chunk)
+{
+    LOG((CLOG_DEBUG1 "sending clipboard chunk"));
+    switch (chunk.mark_) {
+    case kDataStart:
+        LOG((CLOG_DEBUG2 "sending clipboard chunk start: size=%s", chunk.data_.c_str()));
+        break;
+
+    case kDataChunk:
+        LOG((CLOG_DEBUG2 "sending clipboard chunk data: size=%i", chunk.data_.size()));
+        break;
+
+    case kDataEnd:
+        LOG((CLOG_DEBUG2 "sending clipboard finished"));
+        break;
+    default:
+        break;
+    }
+    conn_->send_clipboard_chunk_1_6(chunk);
 }
 
 void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)

--- a/src/lib/server/ClientConnectionLoggingWrapper.cpp
+++ b/src/lib/server/ClientConnectionLoggingWrapper.cpp
@@ -16,6 +16,7 @@
 
 #include "ClientConnectionLoggingWrapper.h"
 #include "base/Log.h"
+#include "inputleap/FileChunk.h"
 #include "inputleap/ProtocolUtil.h"
 #include "inputleap/protocol_types.h"
 #include "io/IStream.h"
@@ -155,6 +156,26 @@ void ClientConnectionLoggingWrapper::send_close_1_6(const char* msg)
 {
     LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str()));
     conn_->send_close_1_6(msg);
+}
+
+void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)
+{
+    switch (chunk.mark_) {
+    case kDataStart:
+        LOG((CLOG_DEBUG2 "sending file chunk start: size=%s", chunk.data_.c_str()));
+        break;
+
+    case kDataChunk:
+        LOG((CLOG_DEBUG2 "sending file chunk: size=%i", chunk.data_.size()));
+        break;
+
+    case kDataEnd:
+        LOG((CLOG_DEBUG2 "sending file finished"));
+        break;
+    default:
+        break;
+    }
+    conn_->send_file_chunk_1_6(chunk);
 }
 
 void ClientConnectionLoggingWrapper::send_grab_clipboard(ClipboardID id)

--- a/src/lib/server/ClientConnectionLoggingWrapper.h
+++ b/src/lib/server/ClientConnectionLoggingWrapper.h
@@ -57,6 +57,7 @@ public:
     void send_keep_alive_1_6() override;
     void send_close_1_6(const char* msg) override;
 
+    void send_clipboard_chunk_1_6(const ClipboardChunk& chunk) override;
     void send_file_chunk_1_6(const FileChunk& chunk) override;
     void send_grab_clipboard(ClipboardID id) override;
 

--- a/src/lib/server/ClientConnectionLoggingWrapper.h
+++ b/src/lib/server/ClientConnectionLoggingWrapper.h
@@ -15,8 +15,8 @@
 */
 
 
-#ifndef INPUTLEAP_LIB_SERVER_CLIENT_MESSAGE_BACKEND_TO_STREAM_H
-#define INPUTLEAP_LIB_SERVER_CLIENT_MESSAGE_BACKEND_TO_STREAM_H
+#ifndef INPUTLEAP_LIB_SERVER_CLIENT_CONNECTION_LOGGING_WRAPPER_H
+#define INPUTLEAP_LIB_SERVER_CLIENT_CONNECTION_LOGGING_WRAPPER_H
 
 #include "IClientConnection.h"
 #include <memory>
@@ -25,13 +25,14 @@ namespace inputleap {
 
 class IStream;
 
-/// Writes protocol messages to IStream instance
-class ClientConnectionByStream : public IClientConnection {
+/// Wraps a IClientConnection and logs messages received from and sent to it.
+class ClientConnectionLoggingWrapper : public IClientConnection {
 public:
-    ClientConnectionByStream(std::unique_ptr<IStream> stream);
-    ~ClientConnectionByStream() override;
+    ClientConnectionLoggingWrapper(const std::string& name,
+                                   std::unique_ptr<IClientConnection> conn);
+    ~ClientConnectionLoggingWrapper() override;
 
-    IStream* get_stream() override { return stream_.get(); }
+    IStream* get_stream() override;
 
     void* get_event_target() override;
 
@@ -62,9 +63,10 @@ public:
     void close() override;
 
 private:
-    std::unique_ptr<IStream> stream_;
+    std::string name_;
+    std::unique_ptr<IClientConnection> conn_;
 };
 
 } // namespace inputleap
 
-#endif // INPUTLEAP_LIB_SERVER_CLIENT_MESSAGE_BACKEND_TO_STREAM_H
+#endif // INPUTLEAP_LIB_SERVER_CLIENT_CONNECTION_LOGGING_WRAPPER_H

--- a/src/lib/server/ClientConnectionLoggingWrapper.h
+++ b/src/lib/server/ClientConnectionLoggingWrapper.h
@@ -57,6 +57,7 @@ public:
     void send_keep_alive_1_6() override;
     void send_close_1_6(const char* msg) override;
 
+    void send_file_chunk_1_6(const FileChunk& chunk) override;
     void send_grab_clipboard(ClipboardID id) override;
 
     void flush() override;

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -17,17 +17,14 @@
  */
 
 #include "server/ClientProxy.h"
-
-#include "inputleap/ProtocolUtil.h"
-#include "io/IStream.h"
-#include "base/Log.h"
+#include "IClientConnection.h"
 #include "base/EventQueue.h"
 
 namespace inputleap {
 
-ClientProxy::ClientProxy(const std::string& name, std::unique_ptr<IStream> stream) :
+ClientProxy::ClientProxy(const std::string& name, std::unique_ptr<IClientConnection> backend) :
     BaseClientProxy(name),
-    stream_{std::move(stream)}
+    conn_{std::move(backend)}
 {
 }
 
@@ -36,11 +33,8 @@ ClientProxy::~ClientProxy() = default;
 void
 ClientProxy::close(const char* msg)
 {
-    LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, getName().c_str()));
-    ProtocolUtil::writef(getStream(), msg);
-
     // force the close to be sent before we return
-    getStream()->flush();
+    get_conn().flush();
 }
 
 void*

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -25,19 +25,14 @@
 
 namespace inputleap {
 
-class IStream;
-
 //! Generic proxy for client
 class ClientProxy : public BaseClientProxy {
 public:
     /*!
     \c name is the name of the client.
     */
-    ClientProxy(const std::string& name, std::unique_ptr<IStream> stream);
+    ClientProxy(const std::string& name, std::unique_ptr<IClientConnection> backend);
     ~ClientProxy();
-
-    //! @name manipulators
-    //@{
 
     //! Disconnect
     /*!
@@ -45,23 +40,14 @@ public:
     */
     void close(const char* msg);
 
-    //@}
-    //! @name accessors
-    //@{
-
-    //! Get stream
-    /*!
-    Returns the original stream passed to the c'tor.
-    */
-    IStream* getStream() const override { return stream_.get(); }
-
-    //@}
+    /// Returns original IClientProtocolWriter passed to ctor
+    IClientConnection& get_conn() const override { return *conn_; }
 
     // IScreen
     void* getEventTarget() const override;
 
 private:
-    std::unique_ptr<IStream> stream_;
+    std::unique_ptr<IClientConnection> conn_;
 };
 
 } // namespace inputleap

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -383,7 +383,7 @@ void ClientProxy1_6::sendDragInfo(std::uint32_t fileCount, const char* info, siz
 
 void ClientProxy1_6::file_chunk_sending(const FileChunk& chunk)
 {
-    FileChunk::send(getStream(), chunk.mark_, chunk.data_);
+    get_conn().send_file_chunk_1_6(chunk);
 }
 
 void ClientProxy1_6::screensaver(bool on)

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -266,7 +266,7 @@ void ClientProxy1_6::handle_flatline()
 
 void ClientProxy1_6::handle_clipboard_sending_event(const Event& event)
 {
-    ClipboardChunk::send(getStream(), event.get_data_as<ClipboardChunk>());
+    get_conn().send_clipboard_chunk_1_6(event.get_data_as<ClipboardChunk>());
 }
 
 bool ClientProxy1_6::getClipboard(ClipboardID id, IClipboard* clipboard) const

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "server/ClientProxy1_6.h"
+#include "ClientConnectionByStream.h"
 
 #include "inputleap/ProtocolUtil.h"
 #include "inputleap/ClipboardChunk.h"
@@ -32,9 +33,10 @@
 
 namespace inputleap {
 
-ClientProxy1_6::ClientProxy1_6(const std::string& name, std::unique_ptr<IStream> stream,
+ClientProxy1_6::ClientProxy1_6(const std::string& name,
+                               std::unique_ptr<IClientConnection> backend,
                                Server* server, IEventQueue* events) :
-    ClientProxy(name, std::move(stream)),
+    ClientProxy(name, std::move(backend)),
     m_heartbeatTimer(nullptr),
     m_parser(&ClientProxy1_6::parseHandshakeMessage),
     m_events(events),
@@ -43,15 +45,15 @@ ClientProxy1_6::ClientProxy1_6(const std::string& name, std::unique_ptr<IStream>
     m_server{server}
 {
     // install event handlers
-    m_events->add_handler(EventType::STREAM_INPUT_READY, getStream()->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_READY, get_conn().get_event_target(),
                           [this](const auto& e){ handle_data(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, getStream()->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, get_conn().get_event_target(),
                           [this](const auto& e){ handle_write_error(); });
-    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, getStream()->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, get_conn().get_event_target(),
                           [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, getStream()->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, get_conn().get_event_target(),
                           [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, getStream()->getEventTarget(),
+    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, get_conn().get_event_target(),
                           [this](const auto& e){ handle_write_error(); });
     m_events->add_handler(EventType::FILE_KEEPALIVE, this,
                           [this](const auto& e){ keepAlive(); });
@@ -62,8 +64,7 @@ ClientProxy1_6::ClientProxy1_6(const std::string& name, std::unique_ptr<IStream>
 
     setHeartbeatRate(kHeartRate, kHeartRate * kHeartBeatsUntilDeath);
 
-    LOG((CLOG_DEBUG1 "querying client \"%s\" info", getName().c_str()));
-    ProtocolUtil::writef(getStream(), kMsgQInfo);
+    get_conn().send_query_info_1_6();
 
     setHeartbeatRate(kKeepAliveRate, kKeepAliveRate * kKeepAlivesUntilDeath);
 }
@@ -73,21 +74,26 @@ ClientProxy1_6::~ClientProxy1_6()
     removeHandlers();
 }
 
+IStream* ClientProxy1_6::getStream() const
+{
+    return get_conn().get_stream();
+}
+
 void ClientProxy1_6::disconnect()
 {
     removeHandlers();
-    getStream()->close();
+    get_conn().close();
     m_events->add_event(EventType::CLIENT_PROXY_DISCONNECTED, getEventTarget());
 }
 
 void ClientProxy1_6::removeHandlers()
 {
     // uninstall event handlers
-    m_events->removeHandler(EventType::STREAM_INPUT_READY, getStream()->getEventTarget());
-    m_events->removeHandler(EventType::STREAM_OUTPUT_ERROR, getStream()->getEventTarget());
-    m_events->removeHandler(EventType::STREAM_INPUT_SHUTDOWN, getStream()->getEventTarget());
-    m_events->removeHandler(EventType::STREAM_OUTPUT_SHUTDOWN, getStream()->getEventTarget());
-    m_events->removeHandler(EventType::STREAM_INPUT_FORMAT_ERROR, getStream()->getEventTarget());
+    m_events->removeHandler(EventType::STREAM_INPUT_READY, get_conn().get_event_target());
+    m_events->removeHandler(EventType::STREAM_OUTPUT_ERROR, get_conn().get_event_target());
+    m_events->removeHandler(EventType::STREAM_INPUT_SHUTDOWN, get_conn().get_event_target());
+    m_events->removeHandler(EventType::STREAM_OUTPUT_SHUTDOWN, get_conn().get_event_target());
+    m_events->removeHandler(EventType::STREAM_INPUT_FORMAT_ERROR, get_conn().get_event_target());
     m_events->removeHandler(EventType::FILE_KEEPALIVE, this);
     m_events->removeHandler(EventType::CLIPBOARD_SENDING, this);
     m_events->removeHandler(EventType::TIMER, this);
@@ -288,16 +294,12 @@ void ClientProxy1_6::getCursorPos(std::int32_t& x, std::int32_t& y) const
 void ClientProxy1_6::enter(std::int32_t xAbs, std::int32_t yAbs, std::uint32_t seqNum,
                            KeyModifierMask mask, bool)
 {
-    LOG((CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", getName().c_str(), xAbs, yAbs, seqNum, mask));
-    ProtocolUtil::writef(getStream(), kMsgCEnter,
-                                xAbs, yAbs, seqNum, mask);
+    get_conn().send_enter_1_6(xAbs, yAbs, seqNum, mask);
 }
 
 bool ClientProxy1_6::leave()
 {
-    LOG((CLOG_DEBUG1 "send leave to \"%s\"", getName().c_str()));
-    ProtocolUtil::writef(getStream(), kMsgCLeave);
-
+    get_conn().send_leave_1_6();
     // we can never prevent the user from leaving
     return true;
 }
@@ -321,8 +323,7 @@ void ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
 
 void ClientProxy1_6::grabClipboard(ClipboardID id)
 {
-    LOG((CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, getName().c_str()));
-    ProtocolUtil::writef(getStream(), kMsgCClipboard, id, 0);
+    get_conn().send_grab_clipboard(id);
 
     // this clipboard is now dirty
     m_clipboard[id].m_dirty = true;
@@ -335,60 +336,49 @@ void ClientProxy1_6::setClipboardDirty(ClipboardID id, bool dirty)
 
 void ClientProxy1_6::keyDown(KeyID key, KeyModifierMask mask, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
-         getName().c_str(), key, mask, button));
-    ProtocolUtil::writef(getStream(), kMsgDKeyDown, key, mask, button);
+    get_conn().send_key_down_1_6(key, mask, button);
 }
 
 void ClientProxy1_6::keyRepeat(KeyID key, KeyModifierMask mask, std::int32_t count,
                                KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
-         getName().c_str(), key, mask, count, button));
-    ProtocolUtil::writef(getStream(), kMsgDKeyRepeat, key, mask, count, button);
+    get_conn().send_key_repeat_1_6(key, mask, count, button);
 }
 
 void ClientProxy1_6::keyUp(KeyID key, KeyModifierMask mask, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
-         getName().c_str(), key, mask, button));
-    ProtocolUtil::writef(getStream(), kMsgDKeyUp, key, mask, button);
+    get_conn().send_key_up_1_6(key, mask, button);
 }
 
 void ClientProxy1_6::mouseDown(ButtonID button)
 {
-    LOG((CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", getName().c_str(), button));
-    ProtocolUtil::writef(getStream(), kMsgDMouseDown, button);
+    get_conn().send_mouse_down_1_6(button);
 }
 
 void ClientProxy1_6::mouseUp(ButtonID button)
 {
-    LOG((CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", getName().c_str(), button));
-    ProtocolUtil::writef(getStream(), kMsgDMouseUp, button);
+    get_conn().send_mouse_up_1_6(button);
 }
 
 void ClientProxy1_6::mouseMove(std::int32_t xAbs, std::int32_t yAbs)
 {
-    LOG((CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", getName().c_str(), xAbs, yAbs));
-    ProtocolUtil::writef(getStream(), kMsgDMouseMove, xAbs, yAbs);
+    get_conn().send_mouse_move_1_6(xAbs, yAbs);
 }
 
 void ClientProxy1_6::mouseRelativeMove(std::int32_t xRel, std::int32_t yRel)
 {
-    LOG((CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", getName().c_str(), xRel, yRel));
-    ProtocolUtil::writef(getStream(), kMsgDMouseRelMove, xRel, yRel);
+    get_conn().send_mouse_relative_move_1_6(xRel, yRel);
 }
 
 void ClientProxy1_6::mouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 {
-    LOG((CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", getName().c_str(), xDelta, yDelta));
-    ProtocolUtil::writef(getStream(), kMsgDMouseWheel, xDelta, yDelta);
+    get_conn().send_mouse_wheel_1_6(xDelta, yDelta);
 }
 
 void ClientProxy1_6::sendDragInfo(std::uint32_t fileCount, const char* info, size_t size)
 {
     std::string data(info, size);
-    ProtocolUtil::writef(getStream(), kMsgDDragInfo, fileCount, &data);
+    get_conn().send_drag_info_1_6(fileCount, data);
 }
 
 void ClientProxy1_6::file_chunk_sending(const FileChunk& chunk)
@@ -398,15 +388,12 @@ void ClientProxy1_6::file_chunk_sending(const FileChunk& chunk)
 
 void ClientProxy1_6::screensaver(bool on)
 {
-    LOG((CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", getName().c_str(), on ? 1 : 0));
-    ProtocolUtil::writef(getStream(), kMsgCScreenSaver, on ? 1 : 0);
+    get_conn().send_screensaver_1_6(on);
 }
 
 void ClientProxy1_6::resetOptions()
 {
-    LOG((CLOG_DEBUG1 "send reset options to \"%s\"", getName().c_str()));
-    ProtocolUtil::writef(getStream(), kMsgCResetOptions);
-
+    get_conn().send_reset_options_1_6();
     // reset heart rate and death
     resetHeartbeatRate();
     removeHeartbeatTimer();
@@ -415,8 +402,7 @@ void ClientProxy1_6::resetOptions()
 
 void ClientProxy1_6::setOptions(const OptionsList& options)
 {
-    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%d", getName().c_str(), options.size()));
-    ProtocolUtil::writef(getStream(), kMsgDSetOptions, &options);
+    get_conn().send_set_options_1_6(options);
 
     // check options
     for (std::uint32_t i = 0, n = static_cast<std::uint32_t>(options.size()); i < n; i += 2) {
@@ -460,8 +446,7 @@ bool ClientProxy1_6::recvInfo()
     m_info.m_my = my;
 
     // acknowledge receipt
-    LOG((CLOG_DEBUG1 "send info ack to \"%s\"", getName().c_str()));
-    ProtocolUtil::writef(getStream(), kMsgCInfoAck);
+    get_conn().send_info_ack_1_6();
     return true;
 }
 
@@ -522,7 +507,7 @@ bool ClientProxy1_6::recvGrabClipboard()
 
 void ClientProxy1_6::keepAlive()
 {
-    ProtocolUtil::writef(getStream(), kMsgCKeepAlive);
+    get_conn().send_keep_alive_1_6();
 }
 
 void ClientProxy1_6::fileChunkReceived()

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -28,15 +28,18 @@ class Event;
 class EventQueueTimer;
 class IEventQueue;
 class Server;
+class IStream;
 
 //! Proxy for client implementing protocol version 1.0
 class ClientProxy1_6 : public ClientProxy {
 public:
-    ClientProxy1_6(const std::string& name, std::unique_ptr<IStream> stream, Server* server,
-                   IEventQueue* events);
+    ClientProxy1_6(const std::string& name, std::unique_ptr<IClientConnection> backend,
+                   Server* server, IEventQueue* events);
     ~ClientProxy1_6() override;
 
     Server* getServer() { return m_server; }
+
+    IStream* getStream() const;
 
     // IScreen
     bool getClipboard(ClipboardID id, IClipboard*) const override;

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "server/ClientProxyUnknown.h"
-
+#include "ClientConnectionByStream.h"
 #include "server/Server.h"
 #include "server/ClientProxy1_6.h"
 #include "inputleap/protocol_types.h"
@@ -173,7 +173,9 @@ void ClientProxyUnknown::handle_data()
         if (major == 1) {
             switch (minor) {
             case 6:
-                m_proxy = new ClientProxy1_6(name, std::move(stream_), m_server, m_events);
+                m_proxy = new ClientProxy1_6(
+                            name, std::make_unique<ClientConnectionByStream>(name, std::move(stream_)),
+                            m_server, m_events);
                 break;
             default:
                 break;

--- a/src/lib/server/IClientConnection.h
+++ b/src/lib/server/IClientConnection.h
@@ -1,0 +1,68 @@
+/*  InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) InputLeap contributors
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef INPUTLEAP_LIB_SERVER_ICLIENT_CONNECTION_H
+#define INPUTLEAP_LIB_SERVER_ICLIENT_CONNECTION_H
+
+#include "inputleap/clipboard_types.h"
+#include "inputleap/key_types.h"
+#include "inputleap/mouse_types.h"
+#include "inputleap/option_types.h"
+#include <string>
+
+namespace inputleap {
+
+class IStream;
+
+/// A low-level interface to write protocol messages
+class IClientConnection {
+public:
+    virtual ~IClientConnection() = default;
+
+    virtual void* get_event_target() = 0;
+
+    virtual IStream* get_stream() = 0;
+
+    virtual void send_query_info_1_6() = 0;
+    virtual void send_leave_1_6() = 0;
+    virtual void send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs, std::uint32_t seq_num,
+                                KeyModifierMask mask) = 0;
+    virtual void send_key_down_1_6(KeyID key, KeyModifierMask mask, KeyButton button) = 0;
+    virtual void send_key_up_1_6(KeyID key, KeyModifierMask mask, KeyButton button) = 0;
+    virtual void send_key_repeat_1_6(KeyID key, KeyModifierMask mask, std::int32_t count,
+                                     KeyButton button) = 0;
+    virtual void send_mouse_down_1_6(ButtonID button) = 0;
+    virtual void send_mouse_up_1_6(ButtonID button) = 0;
+    virtual void send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs) = 0;
+    virtual void send_mouse_relative_move_1_6(std::int32_t x_rel, std::int32_t y_rel) = 0;
+    virtual void send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta) = 0;
+    virtual void send_drag_info_1_6(std::uint32_t file_count, const std::string& data) = 0;
+    virtual void send_screensaver_1_6(bool on) = 0;
+    virtual void send_reset_options_1_6() = 0;
+    virtual void send_set_options_1_6(const OptionsList& options) = 0;
+    virtual void send_info_ack_1_6() = 0;
+    virtual void send_keep_alive_1_6() = 0;
+    virtual void send_close_1_6(const char* msg) = 0;
+
+    virtual void send_grab_clipboard(ClipboardID id) = 0;
+
+    virtual void flush() = 0;
+    virtual void close() = 0;
+};
+
+} // namespace inputleap
+
+#endif // INPUTLEAP_LIB_SERVER_ICLIENT_CONNECTION_H

--- a/src/lib/server/IClientConnection.h
+++ b/src/lib/server/IClientConnection.h
@@ -25,6 +25,7 @@
 
 namespace inputleap {
 
+class ClipboardChunk;
 class IStream;
 class FileChunk;
 
@@ -58,6 +59,7 @@ public:
     virtual void send_keep_alive_1_6() = 0;
     virtual void send_close_1_6(const char* msg) = 0;
 
+    virtual void send_clipboard_chunk_1_6(const ClipboardChunk& chunk) = 0;
     virtual void send_file_chunk_1_6(const FileChunk& chunk) = 0;
     virtual void send_grab_clipboard(ClipboardID id) = 0;
 

--- a/src/lib/server/IClientConnection.h
+++ b/src/lib/server/IClientConnection.h
@@ -26,6 +26,7 @@
 namespace inputleap {
 
 class IStream;
+class FileChunk;
 
 /// A low-level interface to write protocol messages
 class IClientConnection {
@@ -57,6 +58,7 @@ public:
     virtual void send_keep_alive_1_6() = 0;
     virtual void send_close_1_6(const char* msg) = 0;
 
+    virtual void send_file_chunk_1_6(const FileChunk& chunk) = 0;
     virtual void send_grab_clipboard(ClipboardID id) = 0;
 
     virtual void flush() = 0;

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -24,6 +24,7 @@
 namespace inputleap {
 
 class Screen;
+class IStream;
 
 //! Primary screen as pseudo-client
 /*!
@@ -145,8 +146,11 @@ public:
     void sendDragInfo(std::uint32_t fileCount, const char* info, size_t size) override;
     void file_chunk_sending(const FileChunk& chunk) override;
 
-    virtual inputleap::IStream*
-    getStream() const override { return nullptr; }
+    virtual IClientConnection& get_conn() const override
+    {
+        throw std::invalid_argument("Unsupported");
+    }
+
     bool isPrimary() const override{ return true; }
 private:
     inputleap::Screen* m_screen;


### PR DESCRIPTION
This interface will allow to mock data connection in the future and more properly test lower level connection bits. Additionally, code is slightly cleaner now because all logging has been moved to yet other wrapper class.