### PR TITLE
Cleanup memory allocations

### DIFF
--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -80,8 +80,7 @@ EventQueue::loop()
     }
 }
 
-void
-EventQueue::adoptBuffer(IEventQueueBuffer* buffer)
+void EventQueue::set_buffer(std::unique_ptr<IEventQueueBuffer> buffer)
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
@@ -102,8 +101,8 @@ EventQueue::adoptBuffer(IEventQueueBuffer* buffer)
     m_oldEventIDs.clear();
 
     // use new buffer
-    buffer_.reset(buffer);
-    if (buffer_ == nullptr) {
+    buffer_ = std::move(buffer);
+    if (!buffer_) {
         buffer_ = std::make_unique<SimpleEventQueueBuffer>();
     }
 }

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -46,7 +46,7 @@ public:
 
     // IEventQueue overrides
     void loop() override;
-    void adoptBuffer(IEventQueueBuffer*) override;
+    void set_buffer(std::unique_ptr<IEventQueueBuffer> buffer) override;
     bool getEvent(Event& event, double timeout = -1.0) override;
     bool dispatchEvent(const Event& event) override;
     void add_event(Event&& event) override;

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -22,6 +22,7 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace inputleap {
@@ -54,12 +55,10 @@ public:
     */
     virtual void loop() = 0;
 
-    //! Set the buffer
-    /*!
-    Replace the current event queue buffer.  Any queued events are
-    discarded.  The queue takes ownership of the buffer.
+    /** Replace the current event queue buffer.  Any queued events are discarded.
+        The queue takes ownership of the buffer.
     */
-    virtual void adoptBuffer(IEventQueueBuffer*) = 0;
+    virtual void set_buffer(std::unique_ptr<IEventQueueBuffer>) = 0;
 
     //! Remove event from queue
     /*!

--- a/src/lib/inputleap/App.cpp
+++ b/src/lib/inputleap/App.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "inputleap/App.h"
+#include "Screen.h"
 
 #include "base/Log.h"
 #include "common/Version.h"
@@ -290,8 +291,7 @@ MinimalApp::foregroundStartup(int argc, char** argv)
     return 0;
 }
 
-inputleap::Screen*
-MinimalApp::createScreen()
+std::unique_ptr<Screen> MinimalApp::create_screen()
 {
     return nullptr;
 }

--- a/src/lib/inputleap/App.h
+++ b/src/lib/inputleap/App.h
@@ -132,7 +132,7 @@ public:
     void startNode() override;
     int mainLoop() override;
     int foregroundStartup(int argc, char** argv) override;
-    inputleap::Screen* createScreen() override;
+    std::unique_ptr<Screen> create_screen() override;
     void loadConfig() override;
     bool loadConfig(const std::string& pathname) override;
     const char* daemonInfo() const override;

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -421,7 +421,7 @@ ClientApp::mainLoop()
     appUtil().startNode();
 
     // init ipc client after node start, since create a new screen wipes out
-    // the event queue (the screen ctors call adoptBuffer).
+    // the event queue (the screen ctors call set_buffer).
     if (argsBase().m_enableIpc) {
         initIpcClient();
     }

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -162,17 +162,17 @@ inputleap::Screen*
 ClientApp::createScreen()
 {
 #if WINAPI_MSWINDOWS
-    return new inputleap::Screen(new MSWindowsScreen(
+    return new inputleap::Screen(std::make_unique<MSWindowsScreen>(
         false, args().m_noHooks, args().m_stopOnDeskSwitch, m_events), m_events);
 #endif
 #if WINAPI_XWINDOWS
-    return new inputleap::Screen(new XWindowsScreen(
+    return new inputleap::Screen(std::make_unique<XWindowsScreen>(
         new XWindowsImpl(),
         args().m_display, false,
         args().m_yscroll, m_events), m_events);
 #endif
 #if WINAPI_CARBON
-    return new inputleap::Screen(new OSXScreen(m_events, false), m_events);
+    return new inputleap::Screen(std::make_unique<OSXScreen>(m_events, false), m_events);
 #endif
     throw std::runtime_error("Failed to create screen, this shouldn't happen");
 }

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -158,21 +158,20 @@ ClientApp::daemonInfo() const
 #endif
 }
 
-inputleap::Screen*
-ClientApp::createScreen()
+std::unique_ptr<Screen> ClientApp::create_screen()
 {
 #if WINAPI_MSWINDOWS
-    return new inputleap::Screen(std::make_unique<MSWindowsScreen>(
+    return std::make_unique<Screen>(std::make_unique<MSWindowsScreen>(
         false, args().m_noHooks, args().m_stopOnDeskSwitch, m_events), m_events);
 #endif
 #if WINAPI_XWINDOWS
-    return new inputleap::Screen(std::make_unique<XWindowsScreen>(
+    return std::make_unique<Screen>(std::make_unique<XWindowsScreen>(
         new XWindowsImpl(),
         args().m_display, false,
         args().m_yscroll, m_events), m_events);
 #endif
 #if WINAPI_CARBON
-    return new inputleap::Screen(std::make_unique<OSXScreen>(m_events, false), m_events);
+    return std::make_unique<Screen>(std::make_unique<OSXScreen>(m_events, false), m_events);
 #endif
     throw std::runtime_error("Failed to create screen, this shouldn't happen");
 }
@@ -231,10 +230,9 @@ void ClientApp::handle_screen_error()
 }
 
 
-inputleap::Screen*
-ClientApp::openClientScreen()
+std::unique_ptr<Screen> ClientApp::open_client_screen()
 {
-    inputleap::Screen* screen = createScreen();
+    auto screen = create_screen();
     if (!argsBase().m_dropTarget.empty()) {
         screen->setDropTarget(argsBase().m_dropTarget);
     }
@@ -243,18 +241,6 @@ ClientApp::openClientScreen()
                           [this](const auto& e){ handle_screen_error(); });
     return screen;
 }
-
-
-void
-ClientApp::closeClientScreen(inputleap::Screen* screen)
-{
-    if (screen != nullptr) {
-        m_events->remove_handler(EventType::SCREEN_ERROR,
-            screen->get_event_target());
-        delete screen;
-    }
-}
-
 
 void
 ClientApp::handle_client_restart(const Event&, EventQueueTimer* timer)
@@ -373,13 +359,12 @@ bool
 ClientApp::startClient()
 {
     double retryTime;
-    inputleap::Screen* clientScreen = nullptr;
+    std::unique_ptr<Screen> client_screen;
     try {
-        if (m_clientScreen == nullptr) {
-            clientScreen = openClientScreen();
-            m_client     = openClient(args().m_name,
-                *m_serverAddress, clientScreen);
-            m_clientScreen  = clientScreen;
+        if (!m_clientScreen) {
+            client_screen = open_client_screen();
+            m_client = openClient(args().m_name, *m_serverAddress, client_screen.get());
+            m_clientScreen = std::move(client_screen);
             LOG((CLOG_NOTE "started client"));
         }
 
@@ -390,18 +375,18 @@ ClientApp::startClient()
     }
     catch (XScreenUnavailable& e) {
         LOG((CLOG_WARN "secondary screen unavailable: %s", e.what()));
-        closeClientScreen(clientScreen);
         updateStatus(std::string("secondary screen unavailable: ") + e.what());
+        m_clientScreen.reset();
         retryTime = e.getRetryTime();
     }
     catch (XScreenOpenFailure& e) {
         LOG((CLOG_CRIT "failed to start client: %s", e.what()));
-        closeClientScreen(clientScreen);
+        m_clientScreen.reset();
         return false;
     }
     catch (XBase& e) {
         LOG((CLOG_CRIT "failed to start client: %s", e.what()));
-        closeClientScreen(clientScreen);
+        m_clientScreen.reset();
         return false;
     }
 
@@ -420,9 +405,8 @@ void
 ClientApp::stopClient()
 {
     closeClient(m_client);
-    closeClientScreen(m_clientScreen);
     m_client = nullptr;
-    m_clientScreen = nullptr;
+    m_clientScreen.reset();
 }
 
 

--- a/src/lib/inputleap/ClientApp.h
+++ b/src/lib/inputleap/ClientApp.h
@@ -52,14 +52,13 @@ public:
     int foregroundStartup(int argc, char** argv) override;
     int standardStartup(int argc, char** argv) override;
     int runInner(int argc, char** argv, ILogOutputter* outputter, StartupFunc startup) override;
-    inputleap::Screen* createScreen() override;
+    std::unique_ptr<Screen> create_screen() override;
     void updateStatus();
     void updateStatus(const std::string& msg);
     void resetRestartTimeout();
     double nextRestartTimeout();
     void handle_screen_error();
-    inputleap::Screen* openClientScreen();
-    void closeClientScreen(inputleap::Screen* screen);
+    std::unique_ptr<Screen> open_client_screen();
     void handle_client_restart(const Event& event, EventQueueTimer* timer);
     void scheduleClientRestart(double retryTime);
     void handle_client_connected();
@@ -79,7 +78,7 @@ public:
 
 private:
     Client* m_client;
-    inputleap::Screen* m_clientScreen;
+    std::unique_ptr<inputleap::Screen> m_clientScreen;
     NetworkAddress* m_serverAddress;
 };
 

--- a/src/lib/inputleap/IApp.h
+++ b/src/lib/inputleap/IApp.h
@@ -20,6 +20,7 @@
 
 #include "Fwd.h"
 #include "base/Fwd.h"
+#include <memory>
 
 namespace inputleap {
 
@@ -42,7 +43,7 @@ public:
     virtual void initApp(int argc, const char** argv) = 0;
     virtual const char* daemonName() const = 0;
     virtual int foregroundStartup(int argc, char** argv) = 0;
-    virtual inputleap::Screen* createScreen() = 0;
+    virtual std::unique_ptr<Screen> create_screen() = 0;
     virtual IEventQueue* getEvents() const = 0;
 };
 

--- a/src/lib/inputleap/IKeyState.cpp
+++ b/src/lib/inputleap/IKeyState.cpp
@@ -24,11 +24,6 @@
 
 namespace inputleap {
 
-IKeyState::IKeyState(IEventQueue* events)
-{
-    (void) events;
-}
-
 IKeyState::KeyInfo IKeyState::KeyInfo::create(KeyID id, KeyModifierMask mask, KeyButton button,
                                               std::int32_t count,
                                               const std::set<std::string>& destinations)

--- a/src/lib/inputleap/IKeyState.h
+++ b/src/lib/inputleap/IKeyState.h
@@ -35,8 +35,6 @@ class IKeyState {
 public:
     virtual ~IKeyState() { }
 
-    IKeyState(IEventQueue* events);
-
     enum {
         kNumButtons = 0x200
     };

--- a/src/lib/inputleap/IPlatformScreen.h
+++ b/src/lib/inputleap/IPlatformScreen.h
@@ -41,8 +41,6 @@ public:
     //! @name manipulators
     //@{
 
-    IPlatformScreen(IEventQueue* events) : IKeyState(events) { }
-
     //! Enable screen
     /*!
     Enable the screen, preparing it to report system and user events.

--- a/src/lib/inputleap/KeyState.cpp
+++ b/src/lib/inputleap/KeyState.cpp
@@ -386,7 +386,6 @@ static const KeyID s_numpadTable[] = {
 //
 
 KeyState::KeyState(IEventQueue* events) :
-    IKeyState(events),
     m_keyMapPtr(new inputleap::KeyMap()),
     m_keyMap(*m_keyMapPtr),
     m_mask(0),
@@ -396,7 +395,6 @@ KeyState::KeyState(IEventQueue* events) :
 }
 
 KeyState::KeyState(IEventQueue* events, inputleap::KeyMap& keyMap) :
-    IKeyState(events),
     m_keyMapPtr(nullptr),
     m_keyMap(keyMap),
     m_mask(0),

--- a/src/lib/inputleap/PlatformScreen.cpp
+++ b/src/lib/inputleap/PlatformScreen.cpp
@@ -22,8 +22,7 @@
 
 namespace inputleap {
 
-PlatformScreen::PlatformScreen(IEventQueue* events) :
-    IPlatformScreen(events),
+PlatformScreen::PlatformScreen() :
     m_draggingStarted(false),
     m_fakeDraggingStarted(false)
 {

--- a/src/lib/inputleap/PlatformScreen.h
+++ b/src/lib/inputleap/PlatformScreen.h
@@ -33,7 +33,7 @@ subclasses to implement the rest.
 */
 class PlatformScreen : public IPlatformScreen, public EventTarget {
 public:
-    PlatformScreen(IEventQueue* events);
+    PlatformScreen();
     ~PlatformScreen() override;
 
     // IKeyState overrides

--- a/src/lib/inputleap/Screen.cpp
+++ b/src/lib/inputleap/Screen.cpp
@@ -25,13 +25,9 @@
 
 namespace inputleap {
 
-//
-// Screen
-//
-
-Screen::Screen(IPlatformScreen* platformScreen, IEventQueue* events) :
-    m_screen(platformScreen),
-    m_isPrimary(platformScreen->isPrimary()),
+Screen::Screen(std::unique_ptr<IPlatformScreen> platform_screen, IEventQueue* events) :
+    m_screen(std::move(platform_screen)),
+    m_isPrimary(m_screen->isPrimary()),
     m_enabled(false),
     m_entered(m_isPrimary),
     m_screenSaverSync(true),
@@ -40,8 +36,6 @@ Screen::Screen(IPlatformScreen* platformScreen, IEventQueue* events) :
     m_mock(false),
     m_enableDragDrop(false)
 {
-    assert(m_screen != nullptr);
-
     // reset options
     resetOptions();
 
@@ -59,7 +53,6 @@ Screen::~Screen()
     }
     assert(!m_enabled);
     assert(m_entered == m_isPrimary);
-    delete m_screen;
     LOG((CLOG_DEBUG "closed display"));
 }
 

--- a/src/lib/inputleap/Screen.h
+++ b/src/lib/inputleap/Screen.h
@@ -22,6 +22,7 @@
 #include "inputleap/DragInformation.h"
 #include "inputleap/clipboard_types.h"
 #include "inputleap/IScreen.h"
+#include "inputleap/IPlatformScreen.h"
 #include "inputleap/key_types.h"
 #include "inputleap/mouse_types.h"
 #include "inputleap/option_types.h"

--- a/src/lib/inputleap/Screen.h
+++ b/src/lib/inputleap/Screen.h
@@ -26,6 +26,7 @@
 #include "inputleap/mouse_types.h"
 #include "inputleap/option_types.h"
 #include "base/Fwd.h"
+#include <memory>
 
 namespace inputleap {
 
@@ -36,7 +37,7 @@ primary or secondary screen.
 */
 class Screen : public IScreen {
 public:
-    Screen(IPlatformScreen* platformScreen, IEventQueue* events);
+    Screen(std::unique_ptr<IPlatformScreen> platform_screen, IEventQueue* events);
     virtual ~Screen();
 
 #ifdef INPUTLEAP_TEST_ENV
@@ -298,7 +299,7 @@ public:
                   std::int32_t& height) const override;
     void getCursorPos(std::int32_t& x, std::int32_t& y) const override;
 
-    IPlatformScreen* getPlatformScreen() { return m_screen; }
+    IPlatformScreen* getPlatformScreen() { return m_screen.get(); }
 
 protected:
     void enablePrimary();
@@ -313,7 +314,7 @@ protected:
 
 private:
     // our platform dependent screen
-    IPlatformScreen* m_screen;
+    std::unique_ptr<IPlatformScreen> m_screen;
 
     // true if screen is being used as a primary screen, false otherwise
     bool m_isPrimary;

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -591,16 +591,16 @@ inputleap::Screen*
 ServerApp::createScreen()
 {
 #if WINAPI_MSWINDOWS
-    return new inputleap::Screen(new MSWindowsScreen(
+    return new inputleap::Screen(std::make_unique<MSWindowsScreen>(
         true, args().m_noHooks, args().m_stopOnDeskSwitch, m_events), m_events);
 #endif
 #if WINAPI_XWINDOWS
-    return new inputleap::Screen(new XWindowsScreen(
+    return new inputleap::Screen(std::make_unique<XWindowsScreen>(
         new XWindowsImpl(),
         args().m_display, true, 0, m_events), m_events);
 #endif
 #if WINAPI_CARBON
-    return new inputleap::Screen(new OSXScreen(m_events, true), m_events);
+    return new inputleap::Screen(std::make_unique<OSXScreen>(m_events, true), m_events);
 #endif
     throw std::runtime_error("Failed to create screen, this shouldn't happen");
 }

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -715,7 +715,7 @@ ServerApp::mainLoop()
     appUtil().startNode();
 
     // init ipc client after node start, since create a new screen wipes out
-    // the event queue (the screen ctors call adoptBuffer).
+    // the event queue (the screen ctors call set_buffer).
     if (argsBase().m_enableIpc) {
         initIpcClient();
     }

--- a/src/lib/inputleap/ServerApp.h
+++ b/src/lib/inputleap/ServerApp.h
@@ -90,7 +90,7 @@ public:
     void handle_suspend();
     void handle_resume();
     ClientListener* openClientListener(const NetworkAddress& address);
-    Server* openServer(Config& config, PrimaryClient* primaryClient);
+    std::unique_ptr<Server> open_server(Config& config, PrimaryClient* primaryClient);
     void handle_no_clients();
     bool startServer();
     int mainLoop() override;
@@ -101,9 +101,9 @@ public:
 
     static ServerApp& instance() { return static_cast<ServerApp&>(App::instance()); }
 
-    Server* getServerPtr() { return m_server; }
+    Server* getServerPtr() { return server_.get(); }
 
-    Server* m_server;
+    std::unique_ptr<Server> server_;
     EServerState m_serverState;
     std::unique_ptr<Screen> server_screen_;
     PrimaryClient* m_primaryClient;

--- a/src/lib/inputleap/ServerApp.h
+++ b/src/lib/inputleap/ServerApp.h
@@ -83,8 +83,8 @@ public:
     void cleanupServer();
     bool initServer();
     void handle_retry();
-    inputleap::Screen* openServerScreen();
-    inputleap::Screen* createScreen() override;
+    std::unique_ptr<Screen> open_server_screen();
+    std::unique_ptr<Screen> create_screen() override;
     PrimaryClient* openPrimaryClient(const std::string& name, inputleap::Screen* screen);
     void handle_screen_error();
     void handle_suspend();
@@ -105,7 +105,7 @@ public:
 
     Server* m_server;
     EServerState m_serverState;
-    inputleap::Screen* m_serverScreen;
+    std::unique_ptr<Screen> server_screen_;
     PrimaryClient* m_primaryClient;
     ClientListener* m_listener;
     EventQueueTimer* m_timer;

--- a/src/lib/inputleap/win32/DaemonApp.cpp
+++ b/src/lib/inputleap/win32/DaemonApp.cpp
@@ -197,7 +197,7 @@ DaemonApp::mainLoop(bool daemonized)
         m_ipcServer->listen();
 
         // install the platform event queue to handle service stop events.
-        m_events->adoptBuffer(new MSWindowsEventQueueBuffer(m_events));
+        m_events->set_buffer(std::make_unique<MSWindowsEventQueueBuffer>(m_events));
 
         std::string command = ARCH->setting("Command");
         bool elevate = ARCH->setting("Elevate") == "1";

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -161,7 +161,7 @@ MSWindowsScreen::MSWindowsScreen(
                           [this](const auto& e){ handle_system_event(e); });
 
     // install the platform event queue
-    m_events->adoptBuffer(new MSWindowsEventQueueBuffer(m_events));
+    m_events->set_buffer(std::make_unique<MSWindowsEventQueueBuffer>(m_events));
 }
 
 MSWindowsScreen::~MSWindowsScreen()
@@ -169,7 +169,7 @@ MSWindowsScreen::~MSWindowsScreen()
     assert(s_screen != nullptr);
 
     disable();
-    m_events->adoptBuffer(nullptr);
+    m_events->set_buffer(nullptr);
     m_events->remove_handler(EventType::SYSTEM, m_events->getSystemTarget());
     delete m_keyState;
     delete m_desks;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -91,7 +91,6 @@ MSWindowsScreen::MSWindowsScreen(
     bool noHooks,
     bool stopOnDeskSwitch,
     IEventQueue* events) :
-    PlatformScreen(events),
     m_isPrimary(isPrimary),
     m_noHooks(noHooks),
     m_isOnScreen(m_isPrimary),

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -165,13 +165,13 @@ OSXScreen::OSXScreen(IEventQueue* events, bool isPrimary, bool autoShowHideCurso
                           [this](const auto& e){ handle_system_event(e); });
 
 	// install the platform event queue
-	m_events->adoptBuffer(new OSXEventQueueBuffer(m_events));
+    m_events->set_buffer(std::make_unique<OSXEventQueueBuffer>(m_events));
 }
 
 OSXScreen::~OSXScreen()
 {
 	disable();
-    m_events->adoptBuffer(nullptr);
+    m_events->set_buffer(nullptr);
     m_events->remove_handler(EventType::SYSTEM, m_events->getSystemTarget());
 
 	if (m_pmWatchThread) {

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -68,7 +68,6 @@ bool					OSXScreen::s_testedForGHOM = false;
 bool					OSXScreen::s_hasGHOM	    = false;
 
 OSXScreen::OSXScreen(IEventQueue* events, bool isPrimary, bool autoShowHideCursor) :
-	PlatformScreen(events),
 	m_isPrimary(isPrimary),
 	m_isOnScreen(m_isPrimary),
 	m_cursorPosValid(false),

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -64,7 +64,6 @@ XWindowsScreen::XWindowsScreen(
 		bool isPrimary,
 		int mouseScrollDelta,
 		IEventQueue* events) :
-    PlatformScreen(events),
     m_isPrimary(isPrimary),
     m_mouseScrollDelta(mouseScrollDelta),
     m_x_accumulatedScroll(0),

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -153,8 +153,8 @@ XWindowsScreen::XWindowsScreen(
                           [this](const auto& e){ handle_system_event(e); });
 
 	// install the platform event queue
-    m_events->adoptBuffer(new XWindowsEventQueueBuffer(m_impl,
-		m_display, m_window, m_events));
+    m_events->set_buffer(std::make_unique<XWindowsEventQueueBuffer>(m_impl, m_display,
+                                                                    m_window, m_events));
 }
 
 XWindowsScreen::~XWindowsScreen()
@@ -162,7 +162,7 @@ XWindowsScreen::~XWindowsScreen()
     assert(s_screen != nullptr);
     assert(m_display != nullptr);
 
-    m_events->adoptBuffer(nullptr);
+    m_events->set_buffer(nullptr);
     m_events->remove_handler(EventType::SYSTEM, m_events->getSystemTarget());
 	for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
 		delete m_clipboard[id];
@@ -1689,7 +1689,7 @@ void
 XWindowsScreen::onError()
 {
 	// prevent further access to the X display
-    m_events->adoptBuffer(nullptr);
+    m_events->set_buffer(nullptr);
 	m_screensaver->destroy();
     m_screensaver = nullptr;
     m_display = nullptr;

--- a/src/test/integtests/platform/XWindowsScreenTests.cpp
+++ b/src/test/integtests/platform/XWindowsScreenTests.cpp
@@ -35,7 +35,7 @@ TEST(CXWindowsScreenTests, fakeMouseMove_nonPrimary_getCursorPosValuesCorrect)
 
     MockEventQueue eventQueue;
     EXPECT_CALL(eventQueue, add_handler(_, _, _)).Times(2);
-    EXPECT_CALL(eventQueue, adoptBuffer(_)).Times(2);
+    EXPECT_CALL(eventQueue, set_buffer(_)).Times(2);
     EXPECT_CALL(eventQueue, remove_handler(_, _)).Times(2);
     XWindowsScreen screen(new XWindowsImpl(), displayName, false, 0, &eventQueue);
 

--- a/src/test/mock/inputleap/MockApp.h
+++ b/src/test/mock/inputleap/MockApp.h
@@ -20,6 +20,7 @@
 #define INPUTLEAP_TEST_ENV
 
 #include "inputleap/App.h"
+#include "inputleap/Screen.h"
 
 #include <gmock/gmock.h>
 
@@ -42,7 +43,7 @@ public:
     MOCK_METHOD0(startNode, void());
     MOCK_METHOD0(mainLoop, int());
     MOCK_METHOD2(foregroundStartup, int(int, char**));
-    MOCK_METHOD0(createScreen, inputleap::Screen*());
+    MOCK_METHOD0(create_screen, std::unique_ptr<Screen>());
 };
 
 } // namespace inputleap

--- a/src/test/mock/inputleap/MockEventQueue.h
+++ b/src/test/mock/inputleap/MockEventQueue.h
@@ -19,8 +19,9 @@
 #pragma once
 
 #include "base/IEventQueue.h"
-
+#include "base/IEventQueueBuffer.h"
 #include <gmock/gmock.h>
+#include <memory>
 
 namespace inputleap {
 
@@ -31,7 +32,7 @@ public:
     MOCK_METHOD2(newOneShotTimer, EventQueueTimer*(double, const EventTarget*));
     MOCK_METHOD2(newTimer, EventQueueTimer*(double, const EventTarget*));
     MOCK_METHOD2(getEvent, bool(Event&, double));
-    MOCK_METHOD1(adoptBuffer, void(IEventQueueBuffer*));
+    MOCK_METHOD1(set_buffer, void(std::unique_ptr<IEventQueueBuffer>));
     MOCK_METHOD1(remove_handlers, void(const EventTarget*));
     MOCK_METHOD1(registerType, EventType(const char*));
     MOCK_CONST_METHOD0(isEmpty, bool());


### PR DESCRIPTION
This PR cleans up memory allocations by adding more uses of automatic memory management via std::unique_ptr.