### PR TITLE
lib: Fix incorrect order of timer destruction

### DIFF
--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -238,8 +238,8 @@ void
 ClientApp::handle_client_restart(const Event&, EventQueueTimer* timer)
 {
     // discard old timer
-    m_events->deleteTimer(timer);
     m_events->remove_handler(EventType::TIMER, timer);
+    m_events->deleteTimer(timer);
 
     // reconnect
     startClient();


### PR DESCRIPTION
Since ad7946ec23 all event targets are non-trivial types which depend on the data stored in the target for correct unregistration. This means that the object must still be valid when passing it to EventQueue::remove_handler(), otherwise the behavior is unpredictable.