### PR TITLE
base: Remove IEventQueueBuffor newTimer and deleteTimer APIs

### DIFF
--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -228,7 +228,7 @@ EventQueueTimer* EventQueue::newTimer(double duration, const EventTarget* target
 {
     assert(duration > 0.0);
 
-    EventQueueTimer* timer = buffer_->newTimer(duration, false);
+    EventQueueTimer* timer = new EventQueueTimer;
     if (target == nullptr) {
         target = timer;
     }
@@ -246,7 +246,7 @@ EventQueueTimer* EventQueue::newOneShotTimer(double duration, const EventTarget*
 {
     assert(duration > 0.0);
 
-    EventQueueTimer* timer = buffer_->newTimer(duration, true);
+    EventQueueTimer* timer = new EventQueueTimer;
     if (target == nullptr) {
         target = timer;
     }
@@ -275,7 +275,7 @@ EventQueue::deleteTimer(EventQueueTimer* timer)
     if (index != m_timers.end()) {
         m_timers.erase(index);
     }
-    buffer_->deleteTimer(timer);
+    delete timer;
 }
 
 void EventQueue::add_handler(EventType type, const EventTarget* target, const EventHandler& handler)

--- a/src/lib/base/IEventQueueBuffer.h
+++ b/src/lib/base/IEventQueueBuffer.h
@@ -74,31 +74,12 @@ public:
     virtual bool addEvent(std::uint32_t dataID) = 0;
 
     //@}
-    //! @name accessors
-    //@{
 
     //! Check if event queue buffer is empty
     /*!
     Return true iff the event queue buffer  is empty.
     */
     virtual bool isEmpty() const = 0;
-
-    //! Create a timer object
-    /*!
-    Create and return a timer object.  The object is opaque and is
-    used only by the buffer but it must be a valid object (i.e.
-    not nullptr).
-    */
-    virtual EventQueueTimer*
-                        newTimer(double duration, bool oneShot) const = 0;
-
-    //! Destroy a timer object
-    /*!
-    Destroy a timer object previously returned by \c newTimer().
-    */
-    virtual void deleteTimer(EventQueueTimer*) const = 0;
-
-    //@}
 };
 
 } // namespace inputleap

--- a/src/lib/base/SimpleEventQueueBuffer.cpp
+++ b/src/lib/base/SimpleEventQueueBuffer.cpp
@@ -79,16 +79,4 @@ SimpleEventQueueBuffer::isEmpty() const
     return !m_queueReady;
 }
 
-EventQueueTimer*
-SimpleEventQueueBuffer::newTimer(double, bool) const
-{
-    return new EventQueueTimer;
-}
-
-void
-SimpleEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
-{
-    delete timer;
-}
-
 } // namespace inputleap

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -40,8 +40,6 @@ public:
     Type getEvent(Event& event, std::uint32_t& dataID) override;
     bool addEvent(std::uint32_t dataID) override;
     bool isEmpty() const override;
-    EventQueueTimer* newTimer(double duration, bool oneShot) const override;
-    void deleteTimer(EventQueueTimer*) const override;
 
 private:
     typedef std::deque<std::uint32_t> EventDeque;

--- a/src/lib/platform/MSWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "base/EventQueueTimer.h"
 #include "platform/MSWindowsEventQueueBuffer.h"
 
 #include "arch/win32/ArchMiscWindows.h"
@@ -129,18 +128,6 @@ bool
 MSWindowsEventQueueBuffer::isEmpty() const
 {
     return (HIWORD(GetQueueStatus(m_os_supported_message_types)) == 0);
-}
-
-EventQueueTimer*
-MSWindowsEventQueueBuffer::newTimer(double, bool) const
-{
-    return new EventQueueTimer;
-}
-
-void
-MSWindowsEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
-{
-    delete timer;
 }
 
 } // namespace inputleap

--- a/src/lib/platform/MSWindowsEventQueueBuffer.h
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.h
@@ -38,8 +38,6 @@ public:
     virtual Type getEvent(Event& event, std::uint32_t& dataID);
     virtual bool addEvent(std::uint32_t dataID);
     virtual bool isEmpty() const;
-    virtual EventQueueTimer* newTimer(double duration, bool oneShot) const;
-    virtual void deleteTimer(EventQueueTimer*) const;
 
 private:
     DWORD m_thread;

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "base/EventQueueTimer.h"
 #include "platform/OSXEventQueueBuffer.h"
 
 #include "base/Event.h"
@@ -119,18 +118,6 @@ OSXEventQueueBuffer::isEmpty() const
     EventRef event;
     OSStatus status = ReceiveNextEvent(0, nullptr, 0.0, false, &event);
     return (status == eventLoopTimedOutErr);
-}
-
-EventQueueTimer*
-OSXEventQueueBuffer::newTimer(double, bool) const
-{
-    return new EventQueueTimer;
-}
-
-void
-OSXEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
-{
-    delete timer;
 }
 
 } // namespace inputleap

--- a/src/lib/platform/OSXEventQueueBuffer.h
+++ b/src/lib/platform/OSXEventQueueBuffer.h
@@ -37,8 +37,6 @@ public:
     virtual Type getEvent(Event& event, std::uint32_t& dataID);
     virtual bool addEvent(std::uint32_t dataID);
     virtual bool isEmpty() const;
-    virtual EventQueueTimer* newTimer(double duration, bool oneShot) const;
-    virtual void deleteTimer(EventQueueTimer*) const;
 
 private:
     EventRef m_event;

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <cassert>
-#include "base/EventQueueTimer.h"
 #include "platform/XWindowsEventQueueBuffer.h"
 
 #include "mt/Thread.h"
@@ -207,18 +206,6 @@ XWindowsEventQueueBuffer::isEmpty() const
 {
     std::lock_guard<std::mutex> lock(mutex_);
     return (m_impl->XPending(m_display) == 0 );
-}
-
-EventQueueTimer*
-XWindowsEventQueueBuffer::newTimer(double, bool) const
-{
-    return new EventQueueTimer;
-}
-
-void
-XWindowsEventQueueBuffer::deleteTimer(EventQueueTimer* timer) const
-{
-    delete timer;
 }
 
 void

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -43,8 +43,6 @@ public:
     Type getEvent(Event& event, std::uint32_t& dataID) override;
     bool addEvent(std::uint32_t dataID) override;
     bool isEmpty() const override;
-    EventQueueTimer* newTimer(double duration, bool oneShot) const override;
-    void deleteTimer(EventQueueTimer*) const override;
 
 private:
     void flush();


### PR DESCRIPTION
In the current implementation timers are not platform-specific. On all currently supported platforms timer costrution and destruction is simple new and delete, so it does not make sense having this customization point.
