### PR TITLE
Fixes X11 clipboard issues, adds size limit for clipboard transfers, added webp/tiff/png/jpg

### DIFF
--- a/doc/newsfragments/clipboard-sharing-size-limit.feature
+++ b/doc/newsfragments/clipboard-sharing-size-limit.feature
@@ -1,0 +1,1 @@
+Adds a new clipboard sharing size limiter to prevent transferring clipboards past a default value in bytes.

--- a/doc/newsfragments/fix-x11-clipboard.bugfix
+++ b/doc/newsfragments/fix-x11-clipboard.bugfix
@@ -1,0 +1,1 @@
+fixes issue with X11 clipboard sharing images as text targets or in other targetsthan the one it should have.

--- a/doc/newsfragments/x11-new-converters.feature
+++ b/doc/newsfragments/x11-new-converters.feature
@@ -1,0 +1,1 @@
+adds new converters for X11 to support copy pasting png/tiff/jpg/webp formats.

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -52,6 +52,7 @@ ServerConfig::ServerConfig(QSettings* settings, int numColumns, int numRows ,
     m_IgnoreAutoConfigClient(false),
     m_EnableDragAndDrop(false),
     m_ClipboardSharing(true),
+    m_ClipboardSharingSize(defaultClipboardSharingSize()),
     m_pMainWindow(mainWindow)
 {
     Q_ASSERT(m_pSettings);
@@ -119,6 +120,7 @@ void ServerConfig::saveSettings()
     settings().setValue("ignoreAutoConfigClient", ignoreAutoConfigClient());
     settings().setValue("enableDragAndDrop", enableDragAndDrop());
     settings().setValue("clipboardSharing", clipboardSharing());
+    settings().setValue("clipboardSharingSize", (int)clipboardSharingSize());
 
     writeSettings<bool>(settings(), switchCorners(), "switchCorner");
 
@@ -164,6 +166,8 @@ void ServerConfig::loadSettings()
     setIgnoreAutoConfigClient(settings().value("ignoreAutoConfigClient").toBool());
     setEnableDragAndDrop(settings().value("enableDragAndDrop", true).toBool());
     setClipboardSharing(settings().value("clipboardSharing", true).toBool());
+    setClipboardSharingSize(settings().value("clipboardSharingSize",
+        (int) ServerConfig::defaultClipboardSharingSize()).toULongLong());
 
     readSettings<bool>(settings(), switchCorners(), "switchCorner", false,
                        static_cast<int>(SwitchCorner::Count));
@@ -412,4 +416,19 @@ void::ServerConfig::addToFirstEmptyGrid(const QString &clientName)
             break;
         }
     }
+}
+
+size_t ServerConfig::defaultClipboardSharingSize() {
+    return 100 * 1000 * 1000; // 100 MB
+}
+
+size_t ServerConfig::setClipboardSharingSize(size_t size) {
+    if (size) {
+        setClipboardSharing(true);
+    } else {
+        setClipboardSharing(false);
+    }
+    using std::swap;
+    swap (size, m_ClipboardSharingSize);
+    return size;
 }

--- a/src/gui/src/ServerConfig.h
+++ b/src/gui/src/ServerConfig.h
@@ -63,6 +63,8 @@ class ServerConfig : public BaseConfig
         bool ignoreAutoConfigClient() const { return m_IgnoreAutoConfigClient; }
         bool enableDragAndDrop() const { return m_EnableDragAndDrop; }
         bool clipboardSharing() const { return m_ClipboardSharing; }
+        size_t clipboardSharingSize() const { return m_ClipboardSharingSize; }
+        static size_t defaultClipboardSharingSize();
 
         void saveSettings();
         void loadSettings();
@@ -92,6 +94,7 @@ class ServerConfig : public BaseConfig
         void setIgnoreAutoConfigClient(bool on) { m_IgnoreAutoConfigClient = on; }
         void setEnableDragAndDrop(bool on) { m_EnableDragAndDrop = on; }
         void setClipboardSharing(bool on) { m_ClipboardSharing = on; }
+        size_t setClipboardSharingSize(size_t size);
         QList<bool>& switchCorners() { return m_SwitchCorners; }
         std::vector<Hotkey>& hotkeys() { return m_Hotkeys; }
 
@@ -125,6 +128,7 @@ class ServerConfig : public BaseConfig
         bool m_IgnoreAutoConfigClient;
         bool m_EnableDragAndDrop;
         bool m_ClipboardSharing;
+        size_t m_ClipboardSharingSize;
         MainWindow* m_pMainWindow;
 };
 

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -59,6 +59,8 @@ ServerConfigDialog::ServerConfigDialog(QWidget* parent, ServerConfig& config, co
     m_pCheckBoxEnableDragAndDrop->setChecked(serverConfig().enableDragAndDrop());
 
     m_pCheckBoxEnableClipboard->setChecked(serverConfig().clipboardSharing());
+    m_pSpinBoxClipboardSizeLimit->setValue(serverConfig().clipboardSharingSize());
+    m_pSpinBoxClipboardSizeLimit->setEnabled(serverConfig().clipboardSharing());
 
     for (const Hotkey& hotkey : serverConfig().hotkeys()) {
         m_pListHotkeys->addItem(hotkey.text());
@@ -110,6 +112,7 @@ void ServerConfigDialog::accept()
     serverConfig().setIgnoreAutoConfigClient(m_pCheckBoxIgnoreAutoConfigClient->isChecked());
     serverConfig().setEnableDragAndDrop(m_pCheckBoxEnableDragAndDrop->isChecked());
     serverConfig().setClipboardSharing(m_pCheckBoxEnableClipboard->isChecked());
+    serverConfig().setClipboardSharingSize(m_pSpinBoxClipboardSizeLimit->value());
 
     // now that the dialog has been accepted, copy the new server config to the original one,
     // which is a reference to the one in MainWindow.

--- a/src/gui/src/ServerConfigDialogBase.ui
+++ b/src/gui/src/ServerConfigDialogBase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>795</width>
-    <height>534</height>
+    <width>816</width>
+    <height>545</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="m_pTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="m_pTabScreens">
       <attribute name="title">
@@ -422,6 +422,57 @@ Double click on a screen to edit its settings.</string>
           <string>&amp;Options</string>
          </property>
          <layout class="QGridLayout">
+          <item row="7" column="0">
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string/>
+            </property>
+            <widget class="QLabel" name="m_pLabelSharingSize">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>201</width>
+               <height>21</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>Max Clipboard sharing size</string>
+             </property>
+            </widget>
+            <widget class="QSpinBox" name="m_pSpinBoxClipboardSizeLimit">
+             <property name="geometry">
+              <rect>
+               <x>250</x>
+               <y>0</y>
+               <width>131</width>
+               <height>20</height>
+              </rect>
+             </property>
+             <property name="toolTip">
+              <string>Clipboard sharing size in bytes</string>
+             </property>
+             <property name="toolTipDuration">
+              <number>-3</number>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="minimum">
+              <number>1000000</number>
+             </property>
+             <property name="maximum">
+              <number>100000000</number>
+             </property>
+             <property name="singleStep">
+              <number>1000</number>
+             </property>
+             <property name="value">
+              <number>3000000</number>
+             </property>
+            </widget>
+           </widget>
+          </item>
           <item row="3" column="0">
            <widget class="QCheckBox" name="m_pCheckBoxWin32KeepForeground">
             <property name="enabled">
@@ -432,23 +483,10 @@ Double click on a screen to edit its settings.</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="m_pCheckBoxRelativeMouseMoves">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="m_pCheckBoxEnableDragAndDrop">
             <property name="text">
-             <string>Use &amp;relative mouse moves</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="m_pCheckBoxScreenSaverSync">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>S&amp;ynchronize screen savers</string>
+             <string>Enable drag and drop file transfers</string>
             </property>
            </widget>
           </item>
@@ -505,7 +543,44 @@ Double click on a screen to edit its settings.</string>
             </item>
            </layout>
           </item>
-          <item row="7" column="0">
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="m_pCheckBoxEnableClipboard">
+            <property name="text">
+             <string>Enable clipboard sharing</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="m_pCheckBoxIgnoreAutoConfigClient">
+            <property name="text">
+             <string>Ignore auto config clients</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="m_pCheckBoxScreenSaverSync">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>S&amp;ynchronize screen savers</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="m_pCheckBoxRelativeMouseMoves">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Use &amp;relative mouse moves</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
            <spacer>
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -517,30 +592,6 @@ Double click on a screen to edit its settings.</string>
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="5" column="0">
-           <widget class="QCheckBox" name="m_pCheckBoxEnableDragAndDrop">
-            <property name="text">
-             <string>Enable drag and drop file transfers</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QCheckBox" name="m_pCheckBoxIgnoreAutoConfigClient">
-            <property name="text">
-             <string>Ignore auto config clients</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QCheckBox" name="m_pCheckBoxEnableClipboard">
-            <property name="text">
-             <string>Enable clipboard sharing</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>

--- a/src/gui/src/SettingsDialogBase.ui
+++ b/src/gui/src/SettingsDialogBase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
-    <height>428</height>
+    <width>616</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -93,7 +93,7 @@
          <string>Specify when the InputLeap service should run at an elevated privilege level</string>
         </property>
         <property name="currentIndex">
-         <number>0</number>
+         <number>2</number>
         </property>
         <item>
          <property name="text">

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -69,7 +69,8 @@ Client::Client(IEventQueue* events, const std::string& name, const NetworkAddres
     m_writeToDropDirThread(nullptr),
     m_useSecureNetwork(args.m_enableCrypto),
     m_args(args),
-    m_enableClipboard(true)
+    m_enableClipboard(true),
+    m_maximumClipboardSize(INT_MAX)
 {
     assert(m_socketFactory != nullptr);
     assert(m_screen != nullptr);
@@ -347,7 +348,18 @@ Client::setOptions(const OptionsList& options)
             m_enableClipboard = *index;
 
             break;
+        } else if (id == kOptionClipboardSharingSize) {
+            index++;
+            if (index != options.end()) {
+				m_maximumClipboardSize = *index;
+            }
         }
+    }
+
+    if (m_enableClipboard && !m_maximumClipboardSize) {
+        m_enableClipboard = false;
+        LOG((CLOG_NOTE "clipboard sharing is disabled because the server "
+                       "set the maximum clipboard size to 0"));
     }
 
     m_screen->setOptions(options);
@@ -384,6 +396,12 @@ Client::sendClipboard(ClipboardID id)
 
         // marshall the data
         std::string data = clipboard.marshall();
+        if (data.size() >= m_maximumClipboardSize) {
+            LOG((CLOG_NOTE "Skipping clipboard transfer because the clipboard"
+                " contents exceeds the %i MB size limit set by the server",
+                m_maximumClipboardSize));
+            return;
+        }
 
         // save and send data if different or not yet sent
         if (!m_sentClipboard[id] || data != m_dataClipboard[id]) {
@@ -593,7 +611,7 @@ void Client::handle_shape_changed()
 
 void Client::handle_clipboard_grabbed(const Event& event)
 {
-    if (!m_enableClipboard) {
+    if (!m_enableClipboard || (m_maximumClipboardSize == 0)) {
         return;
     }
 

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -216,6 +216,7 @@ private:
     bool m_useSecureNetwork;
     ClientArgs m_args;
     bool m_enableClipboard;
+    size_t m_maximumClipboardSize;
 };
 
 } // namespace inputleap

--- a/src/lib/inputleap/IClipboard.h
+++ b/src/lib/inputleap/IClipboard.h
@@ -62,6 +62,10 @@ public:
         kText,            //!< Text format, UTF-8, newline is LF
         kHTML,            //!< HTML format, HTML fragment, UTF-8, newline is LF
         kBitmap,        //!< Bitmap format, BMP 24/32bpp, BI_RGB
+        kPNG,             //!< PNG format
+        kJpeg,            //!< JPEG format
+        kTiff,            //!< TIFF format
+        kWebp,            //!< WEBP format
         kNumFormats        //!< The number of clipboard formats
     };
 

--- a/src/lib/inputleap/option_types.h
+++ b/src/lib/inputleap/option_types.h
@@ -68,6 +68,7 @@ static const OptionID    kOptionScreenPreserveFocus        = OPTION_CODE("SFOC")
 static const OptionID    kOptionRelativeMouseMoves        = OPTION_CODE("MDLT");
 static const OptionID    kOptionWin32KeepForeground        = OPTION_CODE("_KFW");
 static const OptionID    kOptionClipboardSharing            = OPTION_CODE("CLPS");
+static const OptionID    kOptionClipboardSharingSize        = OPTION_CODE("CLSZ");
 //@}
 
 //! @name Screen switch corner enumeration

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -552,14 +552,6 @@ XWindowsClipboard::icccmFillCache()
         // available rather than checking TARGETS.  i've seen clipboard
         // owners that don't report all the targets they support.
         target = converter->getAtom();
-        #if 0
-        for (std::uint32_t i = 0; i < numTargets; ++i) {
-            if (converter->getAtom() == targets[i]) {
-                target = targets[i];
-                break;
-            }
-        }
-        #endif
         if (target == None) {
             continue;
         }

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -23,6 +23,10 @@
 #include "platform/XWindowsClipboardUTF8Converter.h"
 #include "platform/XWindowsClipboardHTMLConverter.h"
 #include "platform/XWindowsClipboardBMPConverter.h"
+#include "platform/XWindowsClipboardJPGConverter.h"
+#include "platform/XWindowsClipboardPNGConverter.h"
+#include "platform/XWindowsClipboardTIFConverter.h"
+#include "platform/XWindowsClipboardWEBPConverter.h"
 #include "platform/XWindowsUtil.h"
 #include "mt/Thread.h"
 #include "arch/Arch.h"
@@ -82,11 +86,15 @@ XWindowsClipboard::XWindowsClipboard(IXWindowsImpl* impl, Display* display,
     }
 
     // add converters, most desired first
+    m_converters.push_back(new XWindowsClipboardPNGConverter(m_display));
+    m_converters.push_back(new XWindowsClipboardWEBPConverter(m_display));
+    m_converters.push_back(new XWindowsClipboardJPGConverter(m_display));
+    m_converters.push_back(new XWindowsClipboardTIFConverter(m_display));
+    m_converters.push_back(new XWindowsClipboardBMPConverter(m_display));
     m_converters.push_back(new XWindowsClipboardHTMLConverter(m_display,
                                 "text/html"));
     m_converters.push_back(new XWindowsClipboardHTMLConverter(m_display,
                                 "application/x-moz-nativehtml"));
-    m_converters.push_back(new XWindowsClipboardBMPConverter(m_display));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
                                 "text/plain;charset=UTF-8"));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
@@ -544,31 +552,53 @@ XWindowsClipboard::icccmFillCache()
         // available rather than checking TARGETS.  i've seen clipboard
         // owners that don't report all the targets they support.
         target = converter->getAtom();
-        /*
+        #if 0
         for (std::uint32_t i = 0; i < numTargets; ++i) {
             if (converter->getAtom() == targets[i]) {
                 target = targets[i];
                 break;
             }
         }
-        */
+        #endif
         if (target == None) {
             continue;
         }
 
         // get the data
         Atom actualTarget;
+        IClipboard::EFormat format = converter->getFormat();
         std::string targetData;
         if (!icccmGetSelection(target, &actualTarget, &targetData)) {
             LOG((CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            m_added[format] = false;
             continue;
         }
 
-        // add to clipboard and note we've done it
-        IClipboard::EFormat format = converter->getFormat();
-        m_data[format]  = converter->toIClipboard(targetData);
-        m_added[format] = true;
-        LOG((CLOG_DEBUG "added format %d for target %s (%u %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+        if (actualTarget != target) {
+            LOG((CLOG_DEBUG1 "  target %s not same as actual target %s",
+                XWindowsUtil::atomToString(m_display, target).c_str(),
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+            m_added[format] = false;
+            continue;
+        }
+
+        if (targetData.empty()) {
+            m_added[format] = false;
+            LOG((CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)", 
+                XWindowsUtil::atomToString(m_display, target).c_str(),
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+             continue;
+        }
+
+        if (!converter->toIClipboard(targetData).empty()) {
+            // add to clipboard and note we've done it
+            m_data[format]  = converter->toIClipboard(targetData);
+            m_added[format] = true;
+            LOG((CLOG_DEBUG "  added format %d for target %s (%u %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+        } else {
+            LOG((CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            m_added[format] = false;
+        }
     }
 }
 
@@ -798,18 +828,39 @@ XWindowsClipboard::motifFillCache()
 
         // get the data (finally)
         Atom actualTarget;
+        IClipboard::EFormat format = converter->getFormat();
         std::string targetData;
         if (!motifGetSelection(&motifFormat, &actualTarget, &targetData)) {
             LOG((CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            m_added[format] = false;
+            continue;
+        }
+            
+        if (actualTarget != target) {
+            LOG((CLOG_DEBUG1 "  target %s not same as actual target %s",
+                XWindowsUtil::atomToString(m_display, target).c_str(),
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+            m_added[format] = false;
+            continue;
+        }    
+        
+        if (targetData.empty()) {
+            m_added[format] = false;
+            LOG((CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)", 
+                XWindowsUtil::atomToString(m_display, target).c_str(),
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
             continue;
         }
 
-        // add to clipboard and note we've done it
-        IClipboard::EFormat clipboard_format = converter->getFormat();
-        m_data[clipboard_format]  = converter->toIClipboard(targetData);
-        m_added[clipboard_format] = true;
-        LOG((CLOG_DEBUG "added format %d for target %s", clipboard_format,
-             XWindowsUtil::atomToString(m_display, target).c_str()));
+        if (!converter->toIClipboard(targetData).empty()) {
+            // add to clipboard and note we've done it
+            m_data[format]  = converter->toIClipboard(targetData);
+            m_added[format] = true;
+            LOG((CLOG_DEBUG "  added format %d for target %s (%u %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+        } else {
+            LOG((CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            m_added[format] = false;
+        }
     }
 }
 

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
@@ -61,6 +61,10 @@ XWindowsClipboardAnyBitmapConverter::getDataSize() const
 
 std::string XWindowsClipboardAnyBitmapConverter::fromIClipboard(const std::string& bmp) const
 {
+    if (bmp.empty()) {
+        return {};
+    }
+
     // fill BMP info header with native-endian data
     CBMPInfoHeader infoHeader;
     const std::uint8_t* rawBMPInfoHeader = reinterpret_cast<const std::uint8_t*>(bmp.data());
@@ -98,6 +102,10 @@ std::string XWindowsClipboardAnyBitmapConverter::fromIClipboard(const std::strin
 
 std::string XWindowsClipboardAnyBitmapConverter::toIClipboard(const std::string& image) const
 {
+    if (image.empty()) {
+        return {};
+    }
+
     // convert to raw BMP data
     std::uint32_t w, h, depth;
     std::string rawBMP = doToIClipboard(image, w, h, depth);

--- a/src/lib/platform/XWindowsClipboardBMPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.cpp
@@ -63,6 +63,10 @@ XWindowsClipboardBMPConverter::getDataSize() const
 
 std::string XWindowsClipboardBMPConverter::fromIClipboard(const std::string& bmp) const
 {
+    if (bmp.empty()) {
+        return {};
+    }
+
     // create BMP image
     std::uint8_t header[14];
     std::uint8_t* dst = header;
@@ -77,6 +81,10 @@ std::string XWindowsClipboardBMPConverter::fromIClipboard(const std::string& bmp
 
 std::string XWindowsClipboardBMPConverter::toIClipboard(const std::string& bmp) const
 {
+    if (bmp.empty()) {
+        return {};
+    }
+
     // make sure data is big enough for a BMP file
     if (bmp.size() <= 14 + 40) {
         return {};

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
@@ -59,6 +59,10 @@ std::string XWindowsClipboardHTMLConverter::fromIClipboard(const std::string& da
 
 std::string XWindowsClipboardHTMLConverter::toIClipboard(const std::string& data) const
 {
+    if (data.empty()) {
+        return {};
+    }
+
     // Older Firefox [1] and possibly other applications use UTF-16 for text/html - handle both
     // [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1497580
     if (Unicode::isUTF8(data)) {

--- a/src/lib/platform/XWindowsClipboardJPGConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardJPGConverter.cpp
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardJPGConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardJPGConverter.cpp
@@ -1,0 +1,78 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform/XWindowsClipboardJPGConverter.h"
+
+namespace inputleap {
+
+//
+// XWindowsClipboardJPGConverter
+//
+
+XWindowsClipboardJPGConverter::XWindowsClipboardJPGConverter(
+                Display* display) :
+    m_atom(XInternAtom(display, "image/jpeg", False))
+{
+    // do nothing
+}
+
+XWindowsClipboardJPGConverter::~XWindowsClipboardJPGConverter()
+{
+    // do nothing
+}
+
+IClipboard::EFormat
+XWindowsClipboardJPGConverter::getFormat() const
+{
+    return IClipboard::kJpeg;
+}
+
+Atom
+XWindowsClipboardJPGConverter::getAtom() const
+{
+    return m_atom;
+}
+
+int
+XWindowsClipboardJPGConverter::getDataSize() const
+{
+    return 8;
+}
+
+std::string XWindowsClipboardJPGConverter::fromIClipboard(const std::string& jpegdata) const
+{
+    return jpegdata;
+}
+
+std::string XWindowsClipboardJPGConverter::toIClipboard(const std::string& jpegdata) const
+{
+    if (jpegdata.empty()) {
+        return {};
+    }
+    
+    // check JPG file header
+    const std::uint8_t* rawJPGHeader = reinterpret_cast<const std::uint8_t*>(jpegdata.data());
+    
+    if (rawJPGHeader[0] == 0xFF && rawJPGHeader[1] == 0xD8 && rawJPGHeader[2] == 0xFF) {
+        return jpegdata;
+    }
+
+    return {};
+}
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardJPGConverter.h
+++ b/src/lib/platform/XWindowsClipboardJPGConverter.h
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardJPGConverter.h
+++ b/src/lib/platform/XWindowsClipboardJPGConverter.h
@@ -1,0 +1,43 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform/XWindowsClipboard.h"
+
+namespace inputleap {
+
+//! Convert to/from some text encoding
+class XWindowsClipboardJPGConverter :
+                public IXWindowsClipboardConverter {
+public:
+    XWindowsClipboardJPGConverter(Display* display);
+    ~XWindowsClipboardJPGConverter() override;
+
+    // IXWindowsClipboardConverter overrides
+    IClipboard::EFormat getFormat() const override;
+    Atom getAtom() const override;
+    int getDataSize() const override;
+    std::string fromIClipboard(const std::string&) const override;
+    std::string toIClipboard(const std::string&) const override;
+
+private:
+    Atom m_atom;
+};
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardPNGConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardPNGConverter.cpp
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardPNGConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardPNGConverter.cpp
@@ -1,0 +1,78 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform/XWindowsClipboardPNGConverter.h"
+
+namespace inputleap {
+
+//
+// XWindowsClipboardPNGConverter
+//
+
+XWindowsClipboardPNGConverter::XWindowsClipboardPNGConverter(
+                Display* display) :
+    m_atom(XInternAtom(display, "image/png", False))
+{
+    // do nothing
+}
+
+XWindowsClipboardPNGConverter::~XWindowsClipboardPNGConverter()
+{
+    // do nothing
+}
+
+IClipboard::EFormat
+XWindowsClipboardPNGConverter::getFormat() const
+{
+    return IClipboard::kPNG;
+}
+
+Atom
+XWindowsClipboardPNGConverter::getAtom() const
+{
+    return m_atom;
+}
+
+int
+XWindowsClipboardPNGConverter::getDataSize() const
+{
+    return 8;
+}
+
+std::string XWindowsClipboardPNGConverter::fromIClipboard(const std::string& pngdata) const
+{
+    return pngdata;
+}
+
+std::string XWindowsClipboardPNGConverter::toIClipboard(const std::string& pngdata) const
+{
+    if (pngdata.empty()) {
+        return {};
+    }
+
+    // check PNG file header
+    const std::uint8_t* rawPNGHeader = reinterpret_cast<const std::uint8_t*>(pngdata.data());
+
+    if (rawPNGHeader[0] == 0x89 && rawPNGHeader[1] == 0x50 && rawPNGHeader[2] == 0x4e && rawPNGHeader[3] == 0x47) {
+        return pngdata;
+    }
+
+    return {};
+}
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardPNGConverter.h
+++ b/src/lib/platform/XWindowsClipboardPNGConverter.h
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardPNGConverter.h
+++ b/src/lib/platform/XWindowsClipboardPNGConverter.h
@@ -1,0 +1,43 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform/XWindowsClipboard.h"
+
+namespace inputleap {
+
+//! Convert to/from some text encoding
+class XWindowsClipboardPNGConverter :
+                public IXWindowsClipboardConverter {
+public:
+    XWindowsClipboardPNGConverter(Display* display);
+    ~XWindowsClipboardPNGConverter() override;
+
+    // IXWindowsClipboardConverter overrides
+    IClipboard::EFormat getFormat() const override;
+    Atom getAtom() const override;
+    int getDataSize() const override;
+    std::string fromIClipboard(const std::string&) const override;
+    std::string toIClipboard(const std::string&) const override;
+
+private:
+    Atom m_atom;
+};
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardTIFConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTIFConverter.cpp
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardTIFConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTIFConverter.cpp
@@ -1,0 +1,84 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform/XWindowsClipboardTIFConverter.h"
+
+namespace inputleap {
+
+//
+// XWindowsClipboardTIFConverter
+//
+
+XWindowsClipboardTIFConverter::XWindowsClipboardTIFConverter(
+                Display* display) :
+    m_atom(XInternAtom(display, "image/tiff", False))
+{
+    // do nothing
+}
+
+XWindowsClipboardTIFConverter::~XWindowsClipboardTIFConverter()
+{
+    // do nothing
+}
+
+IClipboard::EFormat
+XWindowsClipboardTIFConverter::getFormat() const
+{
+    return IClipboard::kTiff;
+}
+
+Atom
+XWindowsClipboardTIFConverter::getAtom() const
+{
+    return m_atom;
+}
+
+int
+XWindowsClipboardTIFConverter::getDataSize() const
+{
+    return 8;
+}
+
+std::string XWindowsClipboardTIFConverter::fromIClipboard(const std::string& tiffdata) const
+{
+    return tiffdata;
+}
+
+std::string XWindowsClipboardTIFConverter::toIClipboard(const std::string& tiffdata) const
+{
+    if (tiffdata.empty()) {
+        return {};
+    }
+
+    // check TIFF file header, verify if Big or Little Endian
+    const std::uint8_t* rawTIFHeader = reinterpret_cast<const std::uint8_t*>(tiffdata.data());
+
+    // Prepare Tiff (BE)
+    if (rawTIFHeader[0] == 0x49 && rawTIFHeader[1] == 0x49 && rawTIFHeader[2] == 0x2a && rawTIFHeader[3] == 0x00) {
+        return tiffdata;
+    }
+
+    // Prepare Tiff (LE)
+    if (rawTIFHeader[0] == 0x4D && rawTIFHeader[1] == 0x4D && rawTIFHeader[2] == 0x00 && rawTIFHeader[3] == 0x2a) {
+        return tiffdata;
+    }
+
+    return {};
+}
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardTIFConverter.h
+++ b/src/lib/platform/XWindowsClipboardTIFConverter.h
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardTIFConverter.h
+++ b/src/lib/platform/XWindowsClipboardTIFConverter.h
@@ -1,0 +1,43 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform/XWindowsClipboard.h"
+
+namespace inputleap {
+
+//! Convert to/from some text encoding
+class XWindowsClipboardTIFConverter :
+                public IXWindowsClipboardConverter {
+public:
+    XWindowsClipboardTIFConverter(Display* display);
+    ~XWindowsClipboardTIFConverter() override;
+
+    // IXWindowsClipboardConverter overrides
+    IClipboard::EFormat getFormat() const override;
+    Atom getAtom() const override;
+    int getDataSize() const override;
+    std::string fromIClipboard(const std::string&) const override;
+    std::string toIClipboard(const std::string&) const override;
+
+private:
+    Atom m_atom;
+};
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTextConverter.cpp
@@ -59,6 +59,10 @@ std::string XWindowsClipboardTextConverter::fromIClipboard(const std::string& da
 
 std::string XWindowsClipboardTextConverter::toIClipboard(const std::string& data) const
 {
+    if (data.empty()) {
+        return {};
+    }
+
     // convert to UTF-8
     bool errors;
     std::string utf8 = Unicode::textToUTF8(data, &errors);

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
@@ -59,6 +59,10 @@ std::string XWindowsClipboardUCS2Converter::fromIClipboard(const std::string& da
 
 std::string XWindowsClipboardUCS2Converter::toIClipboard(const std::string& data) const
 {
+    if (data.empty()) {
+        return {};
+    }
+
     return Unicode::UCS2ToUTF8(data);
 }
 

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
@@ -57,6 +57,10 @@ std::string XWindowsClipboardUTF8Converter::fromIClipboard(const std::string& da
 
 std::string XWindowsClipboardUTF8Converter::toIClipboard(const std::string& data) const
 {
+    if (data.empty()) {
+        return {};
+    }
+
     return data;
 }
 

--- a/src/lib/platform/XWindowsClipboardWEBPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardWEBPConverter.cpp
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardWEBPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardWEBPConverter.cpp
@@ -1,0 +1,79 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform/XWindowsClipboardWEBPConverter.h"
+
+namespace inputleap {
+
+//
+// XWindowsClipboardWEBPConverter
+//
+
+XWindowsClipboardWEBPConverter::XWindowsClipboardWEBPConverter(
+                Display* display) :
+    m_atom(XInternAtom(display, "image/webp", False))
+{
+    // do nothing
+}
+
+XWindowsClipboardWEBPConverter::~XWindowsClipboardWEBPConverter()
+{
+    // do nothing
+}
+
+IClipboard::EFormat
+XWindowsClipboardWEBPConverter::getFormat() const
+{
+    return IClipboard::kWebp;
+}
+
+Atom
+XWindowsClipboardWEBPConverter::getAtom() const
+{
+    return m_atom;
+}
+
+int
+XWindowsClipboardWEBPConverter::getDataSize() const
+{
+    return 8;
+}
+
+std::string XWindowsClipboardWEBPConverter::fromIClipboard(const std::string& webpdata) const
+{
+    return webpdata;
+}
+
+std::string XWindowsClipboardWEBPConverter::toIClipboard(const std::string& webpdata) const
+{
+    if (webpdata.empty()) {
+        return {};
+    }
+
+    // check WEBPF file header, veirfy if Big or Little Endian
+    const std::uint8_t* rawWEBPHeader = reinterpret_cast<const std::uint8_t*>(webpdata.data());
+
+    if (rawWEBPHeader[0] == 'R' && rawWEBPHeader[1] == 'I' && rawWEBPHeader[2] == 'F' && rawWEBPHeader[3] == 'F' &&
+        rawWEBPHeader[8] == 'W' && rawWEBPHeader[9] == 'E' && rawWEBPHeader[10] == 'B' && rawWEBPHeader[11] == 'P' ) {
+        return webpdata;
+    }
+
+    return {};
+}
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsClipboardWEBPConverter.h
+++ b/src/lib/platform/XWindowsClipboardWEBPConverter.h
@@ -1,5 +1,6 @@
 /*
- * barrier -- mouse and keyboard sharing utility
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023 Draekko
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
  *

--- a/src/lib/platform/XWindowsClipboardWEBPConverter.h
+++ b/src/lib/platform/XWindowsClipboardWEBPConverter.h
@@ -1,0 +1,43 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2012-2016 Symless Ltd.
+ * Copyright (C) 2004 Chris Schoeneman
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform/XWindowsClipboard.h"
+
+namespace inputleap {
+
+//! Convert to/from some text encoding
+class XWindowsClipboardWEBPConverter :
+                public IXWindowsClipboardConverter {
+public:
+    XWindowsClipboardWEBPConverter(Display* display);
+    ~XWindowsClipboardWEBPConverter() override;
+
+    // IXWindowsClipboardConverter overrides
+    IClipboard::EFormat getFormat() const override;
+    Atom getAtom() const override;
+    int getDataSize() const override;
+    std::string fromIClipboard(const std::string&) const override;
+    std::string toIClipboard(const std::string&) const override;
+
+private:
+    Atom m_atom;
+};
+
+} // namespace inputleap

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1811,9 +1811,11 @@ XWindowsUtil::ErrorLock::internalHandler(Display* display, XErrorEvent* event)
 }
 
 void
-XWindowsUtil::ErrorLock::ignoreHandler(Display*, XErrorEvent* e, void*)
+XWindowsUtil::ErrorLock::ignoreHandler(Display* display, XErrorEvent* e, void*)
 {
-    LOG((CLOG_DEBUG1 "ignoring X error: %d", e->error_code));
+    char errtxt[1024];
+    XGetErrorText(display, e->error_code, errtxt, 1023);
+    LOG((CLOG_DEBUG1 "ignoring X error: %d - %.1023s", e->error_code, errtxt));
 }
 
 void

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -739,6 +739,9 @@ Config::readSectionOptions(ConfigReadContext& s)
 		else if (name == "clipboardSharing") {
 			addOption("", kOptionClipboardSharing, s.parseBoolean(value));
 		}
+		else if (name == "clipboardSharingSize") {
+			addOption("", kOptionClipboardSharingSize, s.parseInt(value));
+		}
 
 		else {
 			handled = false;
@@ -1349,6 +1352,9 @@ Config::getOptionName(OptionID id)
 	if (id == kOptionClipboardSharing) {
 		return "clipboardSharing";
 	}
+	if (id == kOptionClipboardSharingSize) {
+		return "clipboardSharingSize";
+	}
 	return nullptr;
 }
 
@@ -1365,7 +1371,8 @@ std::string Config::getOptionValue(OptionID id, OptionValue value)
 		id == kOptionRelativeMouseMoves ||
 		id == kOptionWin32KeepForeground ||
 		id == kOptionScreenPreserveFocus ||
-		id == kOptionClipboardSharing) {
+		id == kOptionClipboardSharing ||
+		id == kOptionClipboardSharingSize) {
 		return (value != 0) ? "true" : "false";
 	}
 	if (id == kOptionModifierMapForShift ||

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -476,6 +476,7 @@ private:
     std::string m_dragFileExt;
     bool m_ignoreFileTransfer;
     bool m_enableClipboard;
+    size_t m_maximumClipboardSize;
 
     Thread* m_sendDragInfoThread;
     bool m_waitDragInfoThread;


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 

The patch was originally made for barrier (a PR was made for it as well) but i only noticed today that it's no longer maintained so adapted the patched code to input-leaf

This fixes X11 to X11 clipboard issues, prevents images from leaking to text targets and other image targets other than the one its intended for. Adds size limits if someone wants to limit clipboard transfers. Adds converters for WEBP, TIFF, PNG, JPG image formats. 

PNG is needed to properly transfer images copy pasted from apps or desktop or from gimp on one machine to the next under X11, added the other formats since it was virtually the same code for them as PNG. The size limit option for the clipboard was mentioned in the barrier wiki but there was no corresponding code, this PR adds the option.

Should not interfere with other platforms but I don't have a Mac or Windows machine for dev support so someone will need to add those there they want it as well. To clarify, only the X11 converters for PNG/WEBP/TIFF/JPG need to be created for the other platforms, the memory limit option for clipboard transfers should work across platforms.

