### PR TITLE
Ignore scroll lock mask for hotkey detection

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -37,6 +37,8 @@
 #include <cstdlib>
 #include <algorithm>
 
+#define SCROLL_LOCK_EXCLUDE_MASK 0xDFFF
+// To ignore scroll lock state for hotkeys, as it is used for alternate keyboard layout indication
 namespace inputleap {
 
 static int xi_opcode;
@@ -1455,7 +1457,7 @@ XWindowsScreen::onHotKey(XKeyEvent& xkey, bool isRepeat)
 {
 	// find the hot key id
 	HotKeyToIDMap::const_iterator i =
-		m_hotKeyToIDMap.find(HotKeyItem(xkey.keycode, xkey.state));
+		m_hotKeyToIDMap.find(HotKeyItem(xkey.keycode, xkey.state & SCROLL_LOCK_EXCLUDE_MASK));
 	if (i == m_hotKeyToIDMap.end()) {
 		return false;
 	}


### PR DESCRIPTION
Some distributions use the scroll lock mask to indicate that an alternate keyboard layout is in use, and this causes hotkeys to not get properly identified when in client screens.

No user visible change
This fixes #1528 
## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
