### PR TITLE
This commit makes the Matrix strategy continue running even on failure

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,6 +30,7 @@ jobs:
     container: ${{ matrix.os }}
     strategy:
       matrix:
+        fail-fast: false
         os: ["ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -127,6 +128,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        fail-fast: false
         os: [macos-11, macos-12]
 
     env:


### PR DESCRIPTION
For example, the libei builds currently fail, but prevent other Ubuntu jobs from running. This commit will allow them to run.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
