### PR TITLE
Bump libei version from 0.3 to 0.4.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -81,12 +81,12 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - if: matrix.os == 'ubuntu:22.04'
-        name: build libei from git tag (0.3)
+        name: build libei from git tag (0.4.1)
         run: |
             apt-get install -y python3-pip
             pip3 install meson
             apt-get install -y libsystemd-dev protobuf-compiler protobuf-c-compiler libprotobuf-c-dev meson git ca-certificates python3-pytest python3-attr python3-dbusmock
-            git clone --depth 1 --branch 0.3 https://gitlab.freedesktop.org/libinput/libei
+            git clone --depth 1 --branch 0.4.1 https://gitlab.freedesktop.org/libinput/libei
             cd libei
             meson -Dprefix=/usr _libei_builddir
             ninja -C _libei_builddir install


### PR DESCRIPTION
It was mentioned that libei *does* work with Input Leap on libei (0.4.1), but not from mainline.

So, in the interests of keeping things up-to-date, I'm bumping the clone tag to 0.4.1.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
