### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,11 +156,16 @@ if (UNIX)
             # no libportal release has xdp_session_connect_to_eis, so let's check for that
             # and enable the hackaround in the code
             include(CMakePushCheckState)
+            include(CheckCXXSourceCompiles)
             cmake_push_check_state(RESET)
             set(CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES};${LIBPORTAL_INCLUDE_DIRS};${GLIB2_INCLUDE_DIRS}")
             set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES};${LIBPORTAL_LINK_LIBRARIES};${GLIB2_LINK_LIBRARIES}")
             check_symbol_exists(xdp_session_connect_to_eis "libportal/portal.h" HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS)
             check_symbol_exists(xdp_input_capture_session_connect_to_eis "libportal/inputcapture.h" HAVE_LIBPORTAL_INPUTCAPTURE)
+            # check_symbol_exists can’t check for enum values
+            check_cxx_source_compiles("#include <libportal/portal.h>
+                int main() { XdpOutputType out = XDP_OUTPUT_NONE; }
+            " HAVE_LIBPORTAL_OUTPUT_NONE)
             cmake_pop_check_state()
 
             # Flatpak bits

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,15 @@ if (UNIX)
             " HAVE_LIBPORTAL_OUTPUT_NONE)
             cmake_pop_check_state()
 
+            cmake_push_check_state(RESET)
+            set(CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES};${LIBEI_INCLUDE_DIRS}")
+            set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES};${LIBEI_LINK_LIBRARIES}")
+            check_cxx_source_compiles("#include <libei/libei.h>
+                int main() { ei_device_start_emulating(nullptr, 0); }
+            " HAVE_LIBEI_SEQUENCE_NUMBER)
+            cmake_pop_check_state()
+
+
             # Flatpak bits
             install(FILES "dist/flatpak/input-leap-flatpak"
                     DESTINATION bin

--- a/src/gui/src/NewScreenWidget.cpp
+++ b/src/gui/src/NewScreenWidget.cpp
@@ -40,7 +40,15 @@ void NewScreenWidget::mousePressEvent(QMouseEvent* event)
 
     QDrag* pDrag = new QDrag(this);
     pDrag->setMimeData(pMimeData);
-    pDrag->setPixmap(*pixmap());
+    pDrag->setPixmap(
+#if QT_VERSION >= QT_VERSION_CHECK(6,6,0)
+        pixmap()
+#elif QT_VERSION >= QT_VERSION_CHECK(5,15,0)
+        pixmap(Qt::ReturnByValue)
+#else
+        *pixmap()
+#endif
+    );
     pDrag->setHotSpot(event->pos());
 
     pDrag->exec(Qt::CopyAction, Qt::CopyAction);

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -166,4 +166,6 @@ QDataStream& operator>>(QDataStream& inStream, Screen& screen)
     for (auto mod : modifiers) {
         screen.m_Modifiers.push_back(static_cast<Screen::Modifier>(mod));
     }
+
+    return inStream;
 }

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -91,19 +91,19 @@ void Screen::saveSettings(QSettings& settings) const
 
 QTextStream& Screen::writeScreensSection(QTextStream& outStream) const
 {
-    outStream << "\t" << name() << ":" << endl;
+    outStream << "\t" << name() << ":\n";
 
     for (int i = 0; i < modifiers().size(); i++) {
         auto mod = static_cast<Modifier>(i);
         if (modifier(mod) != mod) {
             outStream << "\t\t" << modifierName(mod) << " = " << modifierName(modifier(mod))
-                      << endl;
+                      << "\n";
         }
     }
 
     for (int i = 0; i < fixes().size(); i++) {
         auto fix = static_cast<Fix>(i);
-        outStream << "\t\t" << fixName(fix) << " = " << (fixes()[i] ? "true" : "false") << endl;
+        outStream << "\t\t" << fixName(fix) << " = " << (fixes()[i] ? "true" : "false") << "\n";
     }
 
     outStream << "\t\t" << "switchCorners = none ";
@@ -112,9 +112,9 @@ QTextStream& Screen::writeScreensSection(QTextStream& outStream) const
             outStream << "+" << switchCornerName(static_cast<SwitchCorner>(i)) << " ";
         }
     }
-    outStream << endl;
+    outStream << "\n";
 
-    outStream << "\t\t" << "switchCornerSize = " << switchCornerSize() << endl;
+    outStream << "\t\t" << "switchCornerSize = " << switchCornerSize() << "\n";
 
     return outStream;
 }
@@ -123,10 +123,10 @@ QTextStream& Screen::writeAliasesSection(QTextStream& outStream) const
 {
     if (!aliases().isEmpty())
     {
-        outStream << "\t" << name() << ":" << endl;
+        outStream << "\t" << name() << ":\n";
 
         for (const QString& alias : aliases()) {
-            outStream << "\t\t" << alias << endl;
+            outStream << "\t\t" << alias << "\n";
         }
     }
 

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -67,8 +67,13 @@ QVariant ScreenSetupModel::data(const QModelIndex& index, int role) const
 
 Qt::ItemFlags ScreenSetupModel::flags(const QModelIndex& index) const
 {
-    if (!index.isValid() || index.row() >= m_NumRows || index.column() >= m_NumColumns)
+    if (!index.isValid() || index.row() >= m_NumRows || index.column() >= m_NumColumns) {
+#if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
+        return Qt::ItemFlags();
+#else
         return nullptr;
+#endif
+    }
 
     if (!screen(index).isNull())
         return Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled;

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -214,57 +214,57 @@ int ServerConfig::adjacentScreenIndex(int idx, int deltaColumn, int deltaRow) co
 
 QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
 {
-    outStream << "section: screens" << endl;
+    outStream << "section: screens\n";
 
     for (const Screen& s : config.screens()) {
         if (!s.isNull())
             s.writeScreensSection(outStream);
     }
 
-    outStream << "end" << endl << endl;
+    outStream << "end\n\n";
 
-    outStream << "section: aliases" << endl;
+    outStream << "section: aliases\n";
 
     for (const Screen& s : config.screens()) {
         if (!s.isNull())
             s.writeAliasesSection(outStream);
     }
 
-    outStream << "end" << endl << endl;
+    outStream << "end\n\n";
 
-    outStream << "section: links" << endl;
+    outStream << "section: links\n";
 
     for (std::size_t i = 0; i < config.screens().size(); i++)
         if (!config.screens()[i].isNull())
         {
-            outStream << "\t" << config.screens()[i].name() << ":" << endl;
+            outStream << "\t" << config.screens()[i].name() << ":\n";
 
             for (unsigned int j = 0; j < sizeof(neighbourDirs) / sizeof(neighbourDirs[0]); j++)
             {
                 int idx = config.adjacentScreenIndex(static_cast<int>(i),
                                                      neighbourDirs[j].x, neighbourDirs[j].y);
                 if (idx != -1 && !config.screens()[idx].isNull())
-                    outStream << "\t\t" << neighbourDirs[j].name << " = " << config.screens()[idx].name() << endl;
+                    outStream << "\t\t" << neighbourDirs[j].name << " = " << config.screens()[idx].name() << "\n";
             }
         }
 
-    outStream << "end" << endl << endl;
+    outStream << "end\n\n";
 
-    outStream << "section: options" << endl;
+    outStream << "section: options\n";
 
     if (config.hasHeartbeat())
-        outStream << "\t" << "heartbeat = " << config.heartbeat() << endl;
+        outStream << "\t" << "heartbeat = " << config.heartbeat() << "\n";
 
-    outStream << "\t" << "relativeMouseMoves = " << (config.relativeMouseMoves() ? "true" : "false") << endl;
-    outStream << "\t" << "screenSaverSync = " << (config.screenSaverSync() ? "true" : "false") << endl;
-    outStream << "\t" << "win32KeepForeground = " << (config.win32KeepForeground() ? "true" : "false") << endl;
-    outStream << "\t" << "clipboardSharing = " << (config.clipboardSharing() ? "true" : "false") << endl;
+    outStream << "\t" << "relativeMouseMoves = " << (config.relativeMouseMoves() ? "true" : "false") << "\n";
+    outStream << "\t" << "screenSaverSync = " << (config.screenSaverSync() ? "true" : "false") << "\n";
+    outStream << "\t" << "win32KeepForeground = " << (config.win32KeepForeground() ? "true" : "false") << "\n";
+    outStream << "\t" << "clipboardSharing = " << (config.clipboardSharing() ? "true" : "false") << "\n";
 
     if (config.hasSwitchDelay())
-        outStream << "\t" << "switchDelay = " << config.switchDelay() << endl;
+        outStream << "\t" << "switchDelay = " << config.switchDelay() << "\n";
 
     if (config.hasSwitchDoubleTap())
-        outStream << "\t" << "switchDoubleTap = " << config.switchDoubleTap() << endl;
+        outStream << "\t" << "switchDoubleTap = " << config.switchDoubleTap() << "\n";
 
     outStream << "\t" << "switchCorners = none ";
     for (int i = 0; i < config.switchCorners().size(); i++) {
@@ -273,15 +273,15 @@ QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
             outStream << "+" << config.switchCornerName(corner) << " ";
         }
     }
-    outStream << endl;
+    outStream << "\n";
 
-    outStream << "\t" << "switchCornerSize = " << config.switchCornerSize() << endl;
+    outStream << "\t" << "switchCornerSize = " << config.switchCornerSize() << "\n";
 
     for (const Hotkey& hotkey : config.hotkeys()) {
         outStream << hotkey;
     }
 
-    outStream << "end" << endl << endl;
+    outStream << "end\n\n";
 
     return outStream;
 }

--- a/src/lib/base/UniquePtrContainer.h
+++ b/src/lib/base/UniquePtrContainer.h
@@ -44,7 +44,7 @@ public:
             if (it->get() == p) {
                 std::unique_ptr<T> ret = std::move(*it);
                 data_.erase(it);
-                return std::move(ret);
+                return ret;
             }
         }
         return {};

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -168,7 +168,11 @@ void generate_pem_self_signed_cert(const std::string& path)
     }
     auto private_key_free = finally([private_key](){ EVP_PKEY_free(private_key); });
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     auto* rsa = RSA_generate_key(2048, RSA_F4, nullptr, nullptr);
+#else
+    auto* rsa = EVP_RSA_gen(2048);
+#endif
     if (!rsa) {
         throw std::runtime_error("Failed to generate RSA key");
     }

--- a/src/lib/net/TCPSocketFactory.cpp
+++ b/src/lib/net/TCPSocketFactory.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<IDataSocket>
         auto secure_socket = std::make_unique<SecureSocket>(m_events, m_socketMultiplexer, family,
                                                             security_level);
         secure_socket->initSsl(false);
-        return std::move(secure_socket);
+        return secure_socket;
     } else {
         return std::make_unique<TCPSocket>(m_events, m_socketMultiplexer, family);
     }

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -43,7 +43,7 @@ EiKeyState::EiKeyState(EiScreen* screen, IEventQueue* events) :
 void EiKeyState::init_default_keymap()
 {
     const struct xkb_rule_names names = {
-        NULL, // Use libxkbcommon compile-time defaults/env vars
+        NULL, NULL, NULL, NULL, NULL // Use libxkbcommon compile-time defaults/env vars
     };
 
     if (xkb_keymap_) {

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -617,6 +617,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
                 throw std::runtime_error("Oops, EIS didn't like us");
             case EI_EVENT_DEVICE_PAUSED:
                 LOG((CLOG_DEBUG "device %s is paused", ei_device_get_name(device)));
+                break;
             case EI_EVENT_DEVICE_RESUMED:
                 LOG((CLOG_DEBUG "device %s is resumed", ei_device_get_name(device)));
                 break;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -245,6 +245,17 @@ void EiScreen::enter()
 {
     is_on_screen_ = true;
     if (!is_primary_) {
+#if HAVE_LIBEI_SEQUENCE_NUMBER
+        if (ei_pointer_) {
+            ei_device_start_emulating(ei_pointer_, 0);
+        }
+        if (ei_keyboard_) {
+            ei_device_start_emulating(ei_keyboard_, 0);
+        }
+        if (ei_abs_) {
+            ei_device_start_emulating(ei_abs_, 0);
+        }
+#else
         if (ei_pointer_) {
             ei_device_start_emulating(ei_pointer_);
         }
@@ -254,6 +265,7 @@ void EiScreen::enter()
         if (ei_abs_) {
             ei_device_start_emulating(ei_abs_);
         }
+#endif
     }
 #if HAVE_LIBPORTAL_INPUTCAPTURE
     else {

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -25,8 +25,8 @@ namespace inputleap {
 PortalRemoteDesktop::PortalRemoteDesktop(EiScreen *screen,
                                          IEventQueue* events) :
     screen_(screen),
-    portal_(xdp_portal_new()),
     events_(events),
+    portal_(xdp_portal_new()),
     session_(nullptr)
 {
     glib_main_loop_ = g_main_loop_new(NULL, true);

--- a/src/lib/platform/PortalRemoteDesktop.h
+++ b/src/lib/platform/PortalRemoteDesktop.h
@@ -25,6 +25,12 @@
 #include <glib.h>
 #include <libportal/portal.h>
 
+#if !HAVE_LIBPORTAL_OUTPUT_NONE
+// Added in libportal ad82a74 Jun 2022, not yet released in libportal 0.6
+// should be used as a patch on ≤ 0.6, and non-git
+#define XDP_OUTPUT_NONE (XdpOutputType)0
+#endif
+
 namespace inputleap {
 
 class PortalRemoteDesktop {


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 

----

These are code improvements only, mostly upgrading from deprecated code, so no user-visible change.

1. 4628a7c8b98064f58a5f4dc64cc5680adb12e68a fixes building against the last libportal release (currently CI builds against master, which has caused issues when done with libei)
2. 3557fb55297b011c51fc42a9174a3f880d5d6523 fixes building against the latest libei (i.e. master), which will inevitably be needed at some point
3. 0497e17ba9b18e0cf941733ae56281bdc7fd15a3 is a bug fix, a return statement was missing
4. 6edd9363ac4444b2305585af568e30333b8a46bf a5ff6ced6b797340287cf39aedbd0e10d22696be b4cb8339d4712627f92b53b663b5aad35cb584f4 are 3 different Qt deprecations. Useful to start fixing code before upgrading to Qt 6, this will allow to minimize changes.
7. 9e72ce97414e824946e733f2172ba3eb5f74618b fixes the recommended way of creating an RSA key, the current used way is deprecated since 0.9.8 (latest stable is 3.0 and introduces this new shorthand function, it’s also LTS until Sept. 2026).
8. c88ec801181c4106535bc27db585f275a92d4819 removes 2 `std::move()` calls that are redundant or prevent compiler optimisations.

All deprecation fixes are done in a way that does not break current builds or change library requirements.

The remaining fixes were in the libei-only part of the code:

9. 8e4cf4957d0ea706c57ad328c4850793c9654441 fix initialisation order. Slightly nitpicky but since I was fixing warnings anyway, I might as well.
10. 86fd01ae913ed1b64814d3f53faccc45308d7441 a `break` was missing between device paused and device resumed events, which would cause both events to be logged on a pause event.
11. 07be35f1a62967c909149301cfb0e01ade4e742e Initialise a struct correctly. If using reclaimed memory (which typically happens on the stack) the pointers in the incorrectly initialised struct will contain garbage and risk causing segfaults.


If you compile with warning flags after this PR, the only remaining warnings are unused parameters, i.e. `-Wall -Wextra -Wno-unused-parameter` will output no warnings.