### PR TITLE
Fix clang++ warning with missing override keyword

### DIFF
--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -88,7 +88,7 @@ public:
 
 protected:
     // IPlatformScreen overrides
-    virtual void handle_system_event(const Event& event);
+    virtual void handle_system_event(const Event& event) override;
     void updateButtons() override;
     IKeyState* getKeyState() const override;
 


### PR DESCRIPTION
This error was detected upon compiling with `clang++`, and happened with
the `XWindowsScreen` class, where a `virtual` method was missing the
`override` keyword.

This commit fixes the compilation warning.

Error from `clang++`:

```
[138/252] Building CXX object src/lib/platform/CMakeFiles/platform.dir/XWindowsScreen.cpp.o
In file included from /home/dzr/git.shymega.org.uk/input-leap/input-leap/src/lib/platform/XWindowsScreen.cpp:19:
/home/dzr/git.shymega.org.uk/input-leap/input-leap/src/./lib/platform/XWindowsScreen.h:91:18: warning: 'handle_system_event' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void handle_system_event(const Event& event);
                 ^
/home/dzr/git.shymega.org.uk/input-leap/input-leap/src/./lib/inputleap/IPlatformScreen.h:177:18: note: overridden virtual function is here
    virtual void handle_system_event(const Event& event) = 0;
                 ^
1 warning generated.
```

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
