### PR TITLE
clipboard: block updates when sender is not the owner

### DIFF
--- a/doc/newsfragments/1624_clipboard-sender-mismatch.bugfix
+++ b/doc/newsfragments/1624_clipboard-sender-mismatch.bugfix
@@ -1,0 +1,1 @@
+The server will now block clipboard updates from screens that do not own the clipboard, which can lead to server crashes upon switching the screen in some cases.


### PR DESCRIPTION
This blocks clipboard updates when the sender is not the clipboard owner.

This is actually being done in an assertion in onClipboardChanged, but obviously these are removed from production builds. As such, this is effectively allowing clipboard updates from any screen, no matter if it's the current screen or not, which breaks the clipboard state.  This can cause crashes of the server if the screen is moved at certain times during this process.

Note that this has a side-effect of possibly blocking clipboard updates if the screen is switched before a clipboard update is acknowledged. This delay is obviously quite short, so observing it is hopefully rare.

Fixes #1593.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
