### PR TITLE
macOS: add support for right side modifier keys

### DIFF
--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -51,7 +51,7 @@ public:
     Determines which modifier keys have changed and updates the modifier
     state and sends key events as appropriate.
     */
-    void handleModifierKeys(const EventTarget* target,
+    void handleModifierKeys(const EventTarget* target, std::uint32_t virtualKey,
                             KeyModifierMask oldMask, KeyModifierMask newMask);
 
     //@}

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -1193,7 +1193,7 @@ OSXScreen::onKey(CGEventRef event)
 		// get old and new modifier state
 		KeyModifierMask oldMask = getActiveModifiers();
 		KeyModifierMask newMask = m_keyState->mapModifiersFromOSX(macMask);
-        m_keyState->handleModifierKeys(get_event_target(), oldMask, newMask);
+        m_keyState->handleModifierKeys(get_event_target(), virtualKey, oldMask, newMask);
 
 		// if the current set of modifiers exactly matches a modifiers-only
 		// hot key then generate a hot key down event.

--- a/src/lib/platform/OSXUchrKeyResource.cpp
+++ b/src/lib/platform/OSXUchrKeyResource.cpp
@@ -97,8 +97,7 @@ OSXUchrKeyResource::isValid() const
 
 std::uint32_t OSXUchrKeyResource::getNumModifierCombinations() const
 {
-    // only 32 (not 256) because the righthanded modifier bits are ignored
-    return 32;
+    return 256;
 }
 
 std::uint32_t OSXUchrKeyResource::getNumTables() const


### PR DESCRIPTION
Notes:
 * Tested with FreeBSD server & macOS client
 * Function `handleModifierKeys()` is untested; I was unable to trigger a breakpoint in it. Maybe it's only hit when running a server?
 
 There's still something a bit off in the logic when handling multiple simultaneous modifier key presses: Pressing Alt_R-Shift_L works, but pressing Shift_L-Alt_R causes latter to get interpreted with incorrect keycode. I'm not sure if I have time/energy left to address it, but I'll try.
Edit: This seems to be an unrelated XWindow server side issue.
Edit2: It's not a bug, just what happens when shift modifier is applied to alt_r with my current configuration