### PR TITLE
[fix] fix server hangs on mac suspend

### DIFF
--- a/doc/newsfragments/1636_fix_hang_on_macos_suspend.bugfix
+++ b/doc/newsfragments/1636_fix_hang_on_macos_suspend.bugfix
@@ -1,0 +1,1 @@
+Fix a dead lock entered when a server screen is suspended, so that screen-resume message will work as expected.

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -263,17 +263,19 @@ EventQueueTimer* EventQueue::newOneShotTimer(double duration, const EventTarget*
 void
 EventQueue::deleteTimer(EventQueueTimer* timer)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    for (TimerQueue::iterator index = m_timerQueue.begin();
-                            index != m_timerQueue.end(); ++index) {
-        if (index->getTimer() == timer) {
-            m_timerQueue.erase(index);
-            break;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (TimerQueue::iterator index = m_timerQueue.begin();
+                                index != m_timerQueue.end(); ++index) {
+            if (index->getTimer() == timer) {
+                m_timerQueue.erase(index);
+                break;
+            }
         }
-    }
-    Timers::iterator index = m_timers.find(timer);
-    if (index != m_timers.end()) {
-        m_timers.erase(index);
+        Timers::iterator index = m_timers.find(timer);
+        if (index != m_timers.end()) {
+            m_timers.erase(index);
+        }
     }
     delete timer;
 }


### PR DESCRIPTION
This PR fix a dead lock that `EventQueue::deleteTimer` may lock its `mutex_` twice.

On my macOS 13, `input-leaps` always hangs if I close the lid when a ubuntu client is connected, and after some tries I found this bug. The 2nd `lock_guard` constructed during `delete timer` will enter a dead loop, making the whole process hang until a `kill -9` command.

This PR ensures the `mutex_` has been released before `delete timer`, so the bug disappears. Maybe a `recursive_mutex` will work better, but this PR is also enough.