### PR TITLE
Replace remaining `NULL` values to `nullptr` instead

### DIFF
--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -121,7 +121,7 @@ ArgParser::parseServerArgs(ServerArgs& args, int argc, const char* const* argv)
 #endif
 
         while (!a.empty()) {
-            const char *optarg = NULL;
+            const char *optarg = nullptr;
 
             if (parsePlatformArg(args, a)) {
                 continue;
@@ -176,7 +176,7 @@ ArgParser::parseClientArgs(ClientArgs& args, int argc, const char* const* argv)
 #endif
 
         while (!a.empty()) {
-            const char *optarg = NULL;
+            const char *optarg = nullptr;
 
             if (parsePlatformArg(args, a)) {
                 continue;
@@ -246,7 +246,7 @@ ArgParser::parseCarbonArg(ArgsBase& argsBase, Argv& argv)
 bool
 ArgParser::parseXWindowsArg(ArgsBase& argsBase, Argv& argv)
 {
-    const char* optarg = NULL;
+    const char* optarg = nullptr;
 
     if (argv.shift("--use-x11")) {
         // noop
@@ -345,7 +345,7 @@ ArgParser::parsePlatformArg(ArgsBase& argsBase, Argv& argv)
 bool
 ArgParser::parseGenericArgs(Argv& argv)
 {
-    const char *optarg = NULL;
+    const char *optarg = nullptr;
 
     if (argv.shift("-d", "--debug", &optarg)) {
         // change logging level

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -43,7 +43,7 @@ EiKeyState::EiKeyState(EiScreen* screen, IEventQueue* events) :
 void EiKeyState::init_default_keymap()
 {
     const struct xkb_rule_names names = {
-        NULL, NULL, NULL, NULL, NULL // Use libxkbcommon compile-time defaults/env vars
+        nullptr, nullptr, nullptr, nullptr, nullptr // Use libxkbcommon compile-time defaults/env vars
     };
 
     if (xkb_keymap_) {

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -69,7 +69,7 @@ EiScreen::EiScreen(bool is_primary, IEventQueue* events, bool use_portal) :
             portal_remote_desktop_ = new PortalRemoteDesktop(this, events_);
         }
     } else {
-        auto rc = ei_setup_backend_socket(ei_, NULL);
+        auto rc = ei_setup_backend_socket(ei_, nullptr);
         if (rc != 0) {
             LOG((CLOG_DEBUG "ei init error: %s", strerror(-rc)));
             throw std::runtime_error("Failed to init ei context");
@@ -347,7 +347,7 @@ void EiScreen::update_shape()
     for (auto it = ei_devices_.begin(); it != ei_devices_.end(); it++) {
         auto idx = 0;
         struct ei_region *r;
-        while ((r = ei_device_get_region(*it, idx++)) != NULL) {
+        while ((r = ei_device_get_region(*it, idx++)) != nullptr) {
             x_ = std::min(ei_region_get_x(r), x_);
             y_ = std::min(ei_region_get_y(r), y_);
             w_ = std::max(ei_region_get_x(r) + ei_region_get_width(r), w_);

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -29,7 +29,7 @@ PortalRemoteDesktop::PortalRemoteDesktop(EiScreen *screen,
     portal_(xdp_portal_new()),
     session_(nullptr)
 {
-    glib_main_loop_ = g_main_loop_new(NULL, true);
+    glib_main_loop_ = g_main_loop_new(nullptr, true);
     glib_thread_ = new Thread([this](){ glib_thread(); });
 
     auto init_cb = [](gpointer data) -> gboolean
@@ -49,10 +49,10 @@ PortalRemoteDesktop::~PortalRemoteDesktop()
         glib_thread_->cancel();
         glib_thread_->wait();
         delete glib_thread_;
-        glib_thread_ = NULL;
+        glib_thread_ = nullptr;
 
         g_main_loop_unref(glib_main_loop_);
-        glib_main_loop_ = NULL;
+        glib_main_loop_ = nullptr;
     }
 
     if (session_signal_id_)
@@ -105,7 +105,7 @@ void PortalRemoteDesktop::cb_session_closed(XdpSession* session)
 
 void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
 {
-    g_autoptr(GError) error = NULL;
+    g_autoptr(GError) error = nullptr;
     auto session = XDP_SESSION(object);
     auto success = xdp_session_start_finish(session, res, &error);
     if (!success) {
@@ -146,7 +146,7 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
 void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsyncResult* res)
 {
     LOG((CLOG_DEBUG "Session ready"));
-    g_autoptr(GError) error = NULL;
+    g_autoptr(GError) error = nullptr;
 
     auto session = xdp_portal_create_remote_desktop_session_finish(XDP_PORTAL(object), res, &error);
     if (!session) {

--- a/src/test/unittests/inputleap/ArgParserTests.cpp
+++ b/src/test/unittests/inputleap/ArgParserTests.cpp
@@ -48,7 +48,7 @@ TEST(ArgParserTests, isArg_hasOptarg)
     const char* argv[argc] = { "stub", "-t", "foo" };
     Argv a(argc, argv);
 
-     const char *optarg = NULL;
+     const char *optarg = nullptr;
      auto result = a.shift("-t", nullptr, &optarg);
 
      EXPECT_STREQ(result, "-t");
@@ -63,7 +63,7 @@ TEST(ArgParserTests, isArg_missingArgs_throws)
 
     EXPECT_THROW({
              try {
-                 const char *optarg = NULL;
+                 const char *optarg = nullptr;
                  a.shift("-t", nullptr, &optarg);
              } catch (XArgvParserError e) {
                  EXPECT_STREQ(e.message.c_str(), "missing argument for `-t'");


### PR DESCRIPTION
This commit replaces the remaining `NULL` values in the codebase with `nullptr`, in line with C++ recommendations.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
