### PR TITLE
Revert #1433 (blocking off-screen clipboard updates)

### DIFF
--- a/doc/newsfragments/1640_revert-1434.bugfix
+++ b/doc/newsfragments/1640_revert-1434.bugfix
@@ -1,0 +1,1 @@
+[#1433](https://github.com/input-leap/input-leap/issues/1433) has been reverted as it creates issues in some situations where a clipboard update is attempted off-screen, as mentioned in [#1624](https://github.com/input-leap/input-leap/pull/1624).

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1183,10 +1183,6 @@ void Server::handle_clipboard_grabbed(const Event& event, BaseClientProxy* grabb
 	if (m_clientSet.count(grabber) == 0) {
 		return;
 	}
-  // ignore grab event from non-active client, which happens if their clipboard is updated in background
-	if (grabber != m_active) {
-		return;
-	}
     const auto& info = event.get_data_as<IScreen::ClipboardInfo>();
 
 	// ignore grab if sequence number is old.  always allow primary


### PR DESCRIPTION
This reverts #1433.

Based on discussion in #1624 it seems like this would be better denoted as intended behavior and if a truly shared clipboard was not desired, that clipboard sharing should be disabled.

Blocking off-screen updates truly is a complex process and there are other parts of the stack that need to be fixed as well (see aforementioned issue). If this is a feature that is desired, a larger update will be needed, and likely should also be introduced as an optional feature.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
