### PR TITLE
Add link to wiki in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ the same machine.
 Note that if the keyboard's Scroll Lock is active then this will prevent the
 mouse from switching screens.
 
+To find information about configuring Input Leap look at the
+[wiki](https://github.com/input-leap/input-leap/wiki)
+
 ### Contact & support
 
 Please be aware that the *only* way to draw our attention to a bug is to create


### PR DESCRIPTION
Makes it easier for an end-user to find the documentation for Input Leap

In the past I wasted a good 20 minutes trying to find detailed documentation for input leap/barrier inside the repository. A note in the readme would have helped me find the documentation in the wiki much sooner (usually I ignore wikis on GitHub because they're often very sparse).

By the way thanks for forking and carrying on the mantle of Synergy/Barrier! I'm really excited to follow along with this project.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
