### PR TITLE
fix: wake up on mac when screen locked

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -811,6 +811,8 @@ OSXScreen::enter()
 			IORegistryEntrySetCFProperty(entry, CFSTR("IORequestIdle"), kCFBooleanFalse);
 			IOObjectRelease(entry);
 		}
+		IOPMAssertionID assertionID;
+		IOPMAssertionDeclareUserActivity(CFSTR("Input Leap Wakeup Assertion"), kIOPMUserActiveLocal, &assertionID);
 
 		avoidSupression();
 	}


### PR DESCRIPTION
@shymega's note: from debauchee/barrier#1927, thank you @junbujianwpl.

I'm creating PRs from Barrier's unmerged PRs for Input Leap. This is so we can a) let the community know that there is an active fork and b) take advantage of the code contributions that Barrier simply isn't accepting. This gives us the benefit of improved codebase and bug fixes, such as this one, which happens on Mac machines.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
