### PR TITLE
ei: adjust to API changes in libei 1.0.0rc1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -81,14 +81,14 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - if: matrix.os == 'ubuntu:22.04'
-        name: build libei from git tag (0.5)
+        name: build libei from git tag (0.99.1)
         run: |
             apt-get install -y python3-pip
             pip3 install meson
             apt-get install -y libsystemd-dev meson git ca-certificates python3-pytest python3-attr python3-dbusmock python3-structlog python3-jinja2
-            git clone --depth 1 --branch 0.5 https://gitlab.freedesktop.org/libinput/libei
+            git clone --depth 1 --branch 0.99.1 https://gitlab.freedesktop.org/libinput/libei
             cd libei
-            meson -Dprefix=/usr -Dtests=false _libei_builddir
+            meson -Dprefix=/usr -Dtests=disabled -Dliboeffis=disabled -Ddocumentation=[] _libei_builddir
             ninja -C _libei_builddir install
             cd ..
             rm -rf libei

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if (UNIX)
         endif()
 
         if (INPUTLEAP_BUILD_LIBEI)
-            pkg_check_modules(LIBEI REQUIRED "libei>=0.5")
+            pkg_check_modules(LIBEI REQUIRED "libei-1.0 >= 0.99.1")
             pkg_check_modules(LIBXKBCOMMON REQUIRED xkbcommon)
             pkg_check_modules(GLIB2 REQUIRED glib-2.0 gio-2.0)
             pkg_check_modules(LIBPORTAL REQUIRED libportal)


### PR DESCRIPTION
libei has a libei-1.0 pkconfig file now, so let's update to that. The rest of the APIs are fairly straightforward renames with the exception of the new BUTTON and SCROLL capabilities (previously part of POINTER/POINTER_ABSOLUTE).

Technically it's possible for an EIS implementation to create a pointer device without buttons or scroll but those wouldn't work well with our implementation so let's just ignore those and require button + scroll.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
