### PR TITLE
base: only remove handlers if we actually have a client

### DIFF
--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -173,6 +173,10 @@ void ClientListener::handle_unknown_client(ClientProxyUnknown* unknownClient)
         // watch for client to disconnect while it's in our queue
         m_events->add_handler(EventType::CLIENT_PROXY_DISCONNECTED, client,
                               [this, client](const auto& e) { handle_client_disconnected(client); });
+
+        // now finished with unknown client
+        m_events->remove_handler(EventType::CLIENT_PROXY_UNKNOWN_SUCCESS, client);
+        m_events->remove_handler(EventType::CLIENT_PROXY_UNKNOWN_FAILURE, client);
     } else {
         auto* stream = unknownClient->getStream();
         if (stream) {
@@ -180,9 +184,6 @@ void ClientListener::handle_unknown_client(ClientProxyUnknown* unknownClient)
         }
     }
 
-    // now finished with unknown client
-    m_events->remove_handler(EventType::CLIENT_PROXY_UNKNOWN_SUCCESS, client);
-    m_events->remove_handler(EventType::CLIENT_PROXY_UNKNOWN_FAILURE, client);
     m_newClients.erase(unknownClient);
 
     delete unknownClient;


### PR DESCRIPTION
This caused a null-pointer dereference in EventQueue::remove_handler since that was unconditionally called even when the client was NULL.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
