### PR TITLE
CI: bump to build against libei 1.0.0

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -81,17 +81,19 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - if: matrix.os == 'ubuntu:22.04'
-        name: build libei from git tag (0.99.1)
+        name: build libei from git tag (1.0.0)
         run: |
             apt-get install -y python3-pip
             pip3 install meson
             apt-get install -y libsystemd-dev meson git ca-certificates python3-pytest python3-attr python3-dbusmock python3-structlog python3-jinja2
-            git clone --depth 1 --branch 0.99.1 https://gitlab.freedesktop.org/libinput/libei
+            git clone --depth 1 --branch $LIBEI_REVISION https://gitlab.freedesktop.org/libinput/libei
             cd libei
             meson -Dprefix=/usr -Dtests=disabled -Dliboeffis=disabled -Ddocumentation=[] _libei_builddir
             ninja -C _libei_builddir install
             cd ..
             rm -rf libei
+        env:
+            LIBEI_REVISION: 1.0.0
 
       - if: matrix.os == 'ubuntu:22.04'
         name: build libportal from whot/libportal


### PR DESCRIPTION
Also move this into an env, this way it sticks out a bit more

There was a last-minute minor libeis ABI and protocol change though neither of those would have any effect on the bits input-leap uses. Still, better to build against the latest released version.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
