### PR TITLE
Fix missing tilde

### DIFF
--- a/doc/newsfragments/1541-fix-broken-tilde-and-grave
+++ b/doc/newsfragments/1541-fix-broken-tilde-and-grave
@@ -1,0 +1,2 @@
+Fix regression introduced in #1214 that caused tilde (~) and grave (`) to stop
+being sendable from at least a MacOS Barrier Server (and probably others).

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -122,8 +122,6 @@ static const KeyEntry    s_controlKeys[] = {
     { kKeyEisuToggle, kVK_JIS_Eisu },
     { kKeyKana, kVK_JIS_Kana },
     { kKeyMuhenkan, s_int5VK },
-    { kKeyHenkan, s_int4VK },
-    { kKeyZenkaku, kVK_ANSI_Grave }
 };
 
 


### PR DESCRIPTION
Fix broken Tilde and Grave (Backtick/Backquote)

This was copied from https://github.com/debauchee/barrier/pull/1711 by
@dgentry.

Resolves #1541 and #1407.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
