### PR TITLE
Re-add manifests for Windows with DPI-aware flag

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -21,7 +21,10 @@ set(sources
 if (BUILD_MSWINDOWS)
     file(GLOB mswin_headers "MSWindows*.h")
     file(GLOB mswin_sources "MSWindows*.cpp")
-    list(APPEND sources input-leapc.rc)
+    list(APPEND sources
+        input-leapc.exe.manifest
+        input-leapc.rc
+    )
     set_property(SOURCE input-leapc.rc PROPERTY COMPILE_FLAGS /nologo)
 endif()
 if (BUILD_CARBON)

--- a/src/client/input-leapc.exe.manifest
+++ b/src/client/input-leapc.exe.manifest
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"><trustInfo xmlns="urn:schemas-microsoft-com:asm.v3"><security><requestedPrivileges><requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel></requestedPrivileges></security></trustInfo><application xmlns="urn:schemas-microsoft-com:asm.v3"><windowsSettings><dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware></windowsSettings></application></assembly>

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -21,7 +21,10 @@ set(sources
 if (BUILD_MSWINDOWS)
     file(GLOB mswin_headers "MSWindows*.h")
     file(GLOB mswin_sources "MSWindows*.cpp")
-    list(APPEND sources input-leaps.rc)
+    list(APPEND sources
+        input-leaps.exe.manifest
+        input-leaps.rc
+    )        
     set_property(SOURCE input-leaps.rc PROPERTY COMPILE_FLAGS /nologo)
 endif()
 if (BUILD_CARBON)

--- a/src/server/input-leaps.exe.manifest
+++ b/src/server/input-leaps.exe.manifest
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"><trustInfo xmlns="urn:schemas-microsoft-com:asm.v3"><security><requestedPrivileges><requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel></requestedPrivileges></security></trustInfo><application xmlns="urn:schemas-microsoft-com:asm.v3"><windowsSettings><dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware></windowsSettings></application></assembly>


### PR DESCRIPTION
Seems like a long time ago when this was named Barrier these files got removed here:

https://github.com/input-leap/input-leap/commit/aea488167af19845369e062bf9af4edfadc4fa71

Adding them back into the Windows build seems to correct the issues people have been having moving the mouse away from Windows servers that have their DPI scaling set to anything other than 100%. Should fix these Github issues:

- https://github.com/debauchee/barrier/issues/1713
- https://github.com/input-leap/input-leap/issues/1108
