### PR TITLE
ei: xdp_session_connect_to_eis() now takes a GError

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -140,9 +140,9 @@ void PortalInputCapture::cb_init_input_capture_session(GObject* object, GAsyncRe
 
     session_ = session;
 
-    auto fd = xdp_input_capture_session_connect_to_eis(session);
+    auto fd = xdp_input_capture_session_connect_to_eis(session, &error);
     if (fd < 0) {
-            LOG((CLOG_ERR "Failed to connect to EIS: %s", strerror(-fd)));
+            LOG((CLOG_ERR "Failed to connect to EIS: %s", error->message));
 
             // FIXME: Development hack to avoid having to assemble all parts just for
             // testing this code.

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -119,13 +119,10 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
     // top of everything...
     auto fd = -1;
 #if HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS
-    fd = xdp_session_connect_to_eis(session);
+    fd = xdp_session_connect_to_eis(session, &error);
 #endif
     if (fd < 0) {
-        if (fd == -ENOTSUP)
-            LOG((CLOG_ERR "The XDG desktop portal does not support EI.", strerror(-fd)));
-        else
-            LOG((CLOG_ERR "Failed to connect to EIS: %s", strerror(-fd)));
+        LOG((CLOG_ERR "Failed to connect to EIS: %s", error->message));
 
         // FIXME: Development hack to avoid having to assemble all parts just for
         // testing this code.


### PR DESCRIPTION
Last minute change before the libportal branch got merged into upstream - it takes a GError instead of returning a negative errno.

And the same change for the inputcapture invocation though that one hasn't been merged yet.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
