### PR TITLE
chore(issue template): Tidy up template, add new question (Wayland/X11)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
       label: If applicable, where did you install Input Leap from?
       description: This includes Snaps, Flatpaks, and self-built executables.
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: os
     attributes:
@@ -58,8 +58,16 @@ body:
         - Linux
         - Windows
         - macOS
+        - FreeBSD
     validations:
       required: true
+  - type: textarea
+    id: backend
+    attributes:
+      label: If applicable, are you using Wayland or X11?
+      description: This applies to both client(s) and the server.
+    validations:
+      required: false
   - type: textarea
     id: os-version
     attributes:
@@ -71,7 +79,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: Please copy and paste any relevant log output. This will be automatically formatted correctly, so no need for backticks.
       render: shell
   - type: textarea
     id: misc-info


### PR DESCRIPTION
This PR tidies up the issue template. Changes include, but didn't warrant a separate PR for each change, are:

- Setting a required field for 'where did you install Input Leap from?'
- Adding FreeBSD to OS. Port coming soon.
- Adding Wayland/X11 question.
- Correcting terminology on last Q.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
