### PR TITLE
ei: remove some leftover debug printfs and logs

### DIFF
--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -230,13 +230,6 @@ void EiKeyState::getKeyMap(inputleap::KeyMap& keyMap)
                 uint32_t mods_required = 0;
                 for (std::size_t m = 0; m < nmasks; m++) {
                     mods_required |= masks[m];
-                    if (keycode < 13) {
-                        printf("..... %d: %#x (%s) level=%d modmask: %#06x (sensitive: %#06x)\n",
-                               keycode, keysym, keysym_name,
-                               level,
-                               mods_required,
-                               mods_sensitive);
-                    }
                 }
                 item.m_required = convert_mod_mask(mods_required);
 

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -192,17 +192,10 @@ void PortalRemoteDesktop::glib_thread()
 {
     auto context = g_main_loop_get_context(glib_main_loop_);
 
-    LOG((CLOG_DEBUG "GLib thread running"));
-
     while (g_main_loop_is_running(glib_main_loop_)) {
         Thread::testCancel();
-
-        if (g_main_context_iteration(context, true)) {
-            LOG((CLOG_DEBUG "Glib events!!"));
-        }
+        g_main_context_iteration(context, true);
     }
-
-    LOG((CLOG_DEBUG "Shutting down GLib thread"));
 }
 
 } // namespace inputleap


### PR DESCRIPTION
these were just spamming the logs


## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
