### PR TITLE
Add note to 'Wayland' warning code

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -105,6 +105,7 @@ int main(int argc, char* argv[])
 
 	QApplication::setQuitOnLastWindowClosed(false);
 
+    // TODO: Remove once Wayland support is stabilised.
     if (QGuiApplication::platformName() == "wayland") {
         QMessageBox::warning(
         nullptr, "InputLeap",


### PR DESCRIPTION
This is a note we can refer back to when Wayland support is stabilised, and we can fully promote Input Leap as 'Wayland-ready'.

By 'stabilised', I mean, works without crashes, works on GNOME/KDE/wlroots/other major DEs/WMs, and users have reported success.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
