### PR TITLE
Minor grammatical updates to newsfragments README

### DIFF
--- a/doc/newsfragments/README.md
+++ b/doc/newsfragments/README.md
@@ -1,10 +1,9 @@
 This is the directory for release note fragments processed by
 [towncrier](https://github.com/hawkowl/towncrier).
 
-When making a user-visible change create a file in this directory and it will be automatically be
-included into the release note document when the next release is published.
+Create a file in this directory for user-visible changes, and it will automatically be included in the next release note document.
 
-The file extension specifies the type of a change. The following are currently supported:
+The following supported file extensions specify the type of change: 
 
  - .feature: a new feature.
  - .bugfix: a bug fix.

--- a/doc/newsfragments/newsfragments-readme-grammar-update.doc
+++ b/doc/newsfragments/newsfragments-readme-grammar-update.doc
@@ -1,0 +1,1 @@
+Minor grammatical updates in newsfragments README.md.


### PR DESCRIPTION
(Ported to Input Leap by @shymega, squashed two duplicate commits, rebased against master.

See: debauchee/barrier#1937)

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
