### PR TITLE
RFC: When portal code is builtin silence Wayland support warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,12 +173,6 @@ if (UNIX)
             install(FILES "dist/flatpak/input-leap-flatpak"
                     DESTINATION bin
                     PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-
-	    if (INPUTLEAP_WARN_ON_WAYLAND)
-                add_definitions(-DINPUTLEAP_WARN_ON_WAYLAND=1)
-                set(INPUTLEAP_WARN_ON_WAYLAND=1)
-            endif()
-
         endif()
 
         check_include_files ("dns_sd.h" HAVE_DNSSD)
@@ -207,6 +201,10 @@ if (UNIX)
         if(INPUTLEAP_BUILD_LIBEI)
             add_definitions(-DWINAPI_LIBEI=1)
             set(BUILD_LIBEI 1)
+            if (INPUTLEAP_WARN_ON_WAYLAND)
+                add_definitions(-DINPUTLEAP_WARN_ON_WAYLAND=1)
+                set(INPUTLEAP_WARN_ON_WAYLAND 1)
+            endif()
         endif()
         if(NOT INPUTLEAP_BUILD_X11 AND NOT INPUTLEAP_BUILD_LIBEI)
             message(FATAL_ERROR "One of X11 or libei is required")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(INPUTLEAP_BUILD_TESTS "Build the tests" ON)
 option(INPUTLEAP_USE_EXTERNAL_GTEST "Use external installation of Google Test framework" OFF)
 option(INPUTLEAP_BUILD_X11 "Build with XWindows support" ON)
 option(INPUTLEAP_BUILD_LIBEI "Build with libei support" OFF)
+option(INPUTLEAP_WARN_ON_WAYLAND "Warn the user about Wayland support when run on Wayland" ON)
 
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_STANDARD 14)
@@ -172,6 +173,12 @@ if (UNIX)
             install(FILES "dist/flatpak/input-leap-flatpak"
                     DESTINATION bin
                     PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+	    if (INPUTLEAP_WARN_ON_WAYLAND)
+                add_definitions(-DINPUTLEAP_WARN_ON_WAYLAND=1)
+                set(INPUTLEAP_WARN_ON_WAYLAND=1)
+            endif()
+
         endif()
 
         check_include_files ("dns_sd.h" HAVE_DNSSD)

--- a/src/client/input-leapc.cpp
+++ b/src/client/input-leapc.cpp
@@ -20,6 +20,7 @@
 #include "arch/Arch.h"
 #include "base/Log.h"
 #include "base/EventQueue.h"
+#include "config.h"
 
 #if WINAPI_MSWINDOWS
 #include "MSWindowsClientTaskBarReceiver.h"
@@ -31,8 +32,7 @@ namespace inputleap {
 CreateTaskBarReceiverFunc createTaskBarReceiver = nullptr;
 #endif
 
-int client_main(int argc, char** argv)
-{
+int client_main(int argc, char** argv) {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
     ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
@@ -43,6 +43,22 @@ int client_main(int argc, char** argv)
 
     Log log;
     EventQueue events;
+
+    // TODO: Remove once Wayland support is stabilised.
+
+    // This block only warns when `libportal` and `libeis` aren't available - as well as if the top-level CMake option is enabled - by default, it is.
+    // It serves as a way to warn users that using Wayland on platforms matching this boolean expression, that their platform might not be fully supported.
+    // It does *not* run on X11 platforms, Win32, or macOS.
+#if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
+    const char *val = std::getenv("WAYLAND_DISPLAY");
+    if (val == nullptr) {
+        // Return, we're not running on Wayland. Possibly. Could be enhanced.
+        return
+    } else {
+        // We are running on Wayland.
+        // TODO: Add log message.
+    };
+#endif
 
     ClientApp app(&events, createTaskBarReceiver);
     int result = app.run(argc, argv);

--- a/src/client/input-leapc.cpp
+++ b/src/client/input-leapc.cpp
@@ -46,8 +46,13 @@ int client_main(int argc, char** argv) {
 
     // TODO: Remove once Wayland support is stabilised.
 
-    // This block only warns when `libportal` and `libeis` aren't available - as well as if the top-level CMake option is enabled - by default, it is.
-    // It serves as a way to warn users that using Wayland on platforms matching this boolean expression, that their platform might not be fully supported.
+    // This block only warns when `libportal` and `libeis` aren't available - as
+    // well as if the top-level CMake option is enabled - by default, it is.
+
+    // It serves as a way to warn users that using Wayland on platforms matching
+    // this boolean expression, that their platform might not be fully
+    // supported.
+
     // It does *not* run on X11 platforms, Win32, or macOS.
 #if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
     const char *val = std::getenv("WAYLAND_DISPLAY");

--- a/src/client/input-leapc.cpp
+++ b/src/client/input-leapc.cpp
@@ -32,6 +32,21 @@ namespace inputleap {
 CreateTaskBarReceiverFunc createTaskBarReceiver = nullptr;
 #endif
 
+#if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
+#include <cstdlib>
+
+void check_for_wayland() {
+    const char *val = std::getenv("WAYLAND_DISPLAY");
+    if (val == nullptr) {
+        // Return, we're not running on Wayland. Possibly. Could be enhanced.
+        return;
+    } else {
+        // We are running on Wayland.
+        // TODO: Add log message.
+    };
+}
+#endif
+
 int client_main(int argc, char** argv) {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
@@ -55,14 +70,7 @@ int client_main(int argc, char** argv) {
 
     // It does *not* run on X11 platforms, Win32, or macOS.
 #if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
-    const char *val = std::getenv("WAYLAND_DISPLAY");
-    if (val == nullptr) {
-        // Return, we're not running on Wayland. Possibly. Could be enhanced.
-        return
-    } else {
-        // We are running on Wayland.
-        // TODO: Add log message.
-    };
+    check_for_wayland();
 #endif
 
     ClientApp app(&events, createTaskBarReceiver);

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -38,6 +38,8 @@
 #include <cstdlib>
 #endif
 
+#include "config.h"
+
 class QThreadImpl : public QThread
 {
 public:
@@ -106,11 +108,13 @@ int main(int argc, char* argv[])
 	QApplication::setQuitOnLastWindowClosed(false);
 
     // TODO: Remove once Wayland support is stabilised.
+#if !HAVE_LIBPORTAL_INPUTCAPTURE or !HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS
     if (QGuiApplication::platformName() == "wayland") {
         QMessageBox::warning(
         nullptr, "InputLeap",
         "You are using wayland session, which is currently not fully supported by InputLeap.");
     }
+#endif
 
 	QSettings settings;
     if (settings.allKeys().empty()) {

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -38,8 +38,6 @@
 #include <cstdlib>
 #endif
 
-#include "config.h"
-
 class QThreadImpl : public QThread
 {
 public:
@@ -108,7 +106,7 @@ int main(int argc, char* argv[])
 	QApplication::setQuitOnLastWindowClosed(false);
 
     // TODO: Remove once Wayland support is stabilised.
-#if !HAVE_LIBPORTAL_INPUTCAPTURE or !HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS
+#if defined(INPUTLEAP_WARN_ON_WAYLAND) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
     if (QGuiApplication::platformName() == "wayland") {
         QMessageBox::warning(
         nullptr, "InputLeap",

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -106,11 +106,15 @@ int main(int argc, char* argv[])
 	QApplication::setQuitOnLastWindowClosed(false);
 
     // TODO: Remove once Wayland support is stabilised.
+
+    // This block only warns when `libportal` and `libeis` aren't available - as well as if the top-level CMake option is enabled - by default, it is.
+    // It serves as a way to warn users that using Wayland on platforms matching this boolean expression, that their platform might not be fully supported.
+    // It does *not* run on X11 platforms, Win32, or macOS.
 #if defined(INPUTLEAP_WARN_ON_WAYLAND) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
     if (QGuiApplication::platformName() == "wayland") {
         QMessageBox::warning(
-        nullptr, "InputLeap",
-        "You are using wayland session, which is currently not fully supported by InputLeap.");
+        nullptr, "Input Leap",
+        "You are using an Wayland session, which is currently not fully supported by Input Leap.");
     }
 #endif
 

--- a/src/server/input-leaps.cpp
+++ b/src/server/input-leaps.cpp
@@ -20,6 +20,7 @@
 #include "arch/Arch.h"
 #include "base/Log.h"
 #include "base/EventQueue.h"
+#include "config.h"
 
 #if WINAPI_MSWINDOWS
 #include "MSWindowsServerTaskBarReceiver.h"
@@ -50,6 +51,22 @@ int server_main(int argc, char** argv)
 
     Log log;
     EventQueue events;
+
+    // TODO: Remove once Wayland support is stabilised.
+
+    // This block only warns when `libportal` and `libeis` aren't available - as well as if the top-level CMake option is enabled - by default, it is.
+    // It serves as a way to warn users that using Wayland on platforms matching this boolean expression, that their platform might not be fully supported.
+    // It does *not* run on X11 platforms, Win32, or macOS.
+#if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
+    const char *val = std::getenv("WAYLAND_DISPLAY");
+    if (val == nullptr) {
+        // Return, we're not running on Wayland. Possibly. Could be enhanced.
+        return
+    } else {
+        // We are running on Wayland.
+        // TODO: Add log message.
+    };
+#endif
 
     ServerApp app(&events, createTaskBarReceiver);
     int result = app.run(argc, argv);

--- a/src/server/input-leaps.cpp
+++ b/src/server/input-leaps.cpp
@@ -32,6 +32,21 @@ namespace inputleap {
 CreateTaskBarReceiverFunc createTaskBarReceiver = nullptr;
 #endif
 
+#if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
+#include <cstdlib>
+
+void check_for_wayland() {
+    const char *val = std::getenv("WAYLAND_DISPLAY");
+    if (val == nullptr) {
+        // Return, we're not running on Wayland. Possibly. Could be enhanced.
+        return;
+    } else {
+        // We are running on Wayland.
+        // TODO: Add log message.
+    };
+}
+#endif
+
 int server_main(int argc, char** argv)
 {
 #if SYSAPI_WIN32
@@ -54,18 +69,16 @@ int server_main(int argc, char** argv)
 
     // TODO: Remove once Wayland support is stabilised.
 
-    // This block only warns when `libportal` and `libeis` aren't available - as well as if the top-level CMake option is enabled - by default, it is.
-    // It serves as a way to warn users that using Wayland on platforms matching this boolean expression, that their platform might not be fully supported.
+    // This block only warns when `libportal` and `libeis` aren't available - as
+    // well as if the top-level CMake option is enabled - by default, it is.
+
+    // It serves as a way to warn users that using Wayland on platforms matching
+    // this boolean expression, that their platform might not be fully
+    // supported.
+
     // It does *not* run on X11 platforms, Win32, or macOS.
 #if (defined(WINAPI_LIBEI) && defined(INPUTLEAP_WARN_ON_WAYLAND)) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS))
-    const char *val = std::getenv("WAYLAND_DISPLAY");
-    if (val == nullptr) {
-        // Return, we're not running on Wayland. Possibly. Could be enhanced.
-        return
-    } else {
-        // We are running on Wayland.
-        // TODO: Add log message.
-    };
+    check_for_wayland();
 #endif
 
     ServerApp app(&events, createTaskBarReceiver);


### PR DESCRIPTION
This is a user visible in that is disable a warning popup if running under wayland.
I did not add a doc/newfragments as there were none when introducing this popup.

This is an RFC as we might want to keep the popup to tell the user that wayland is still officially not supported.
Still, I find that my code only removes the popup if the EI support is building which is disabled by default. So it is redundant to me.
The popup is kept for if the libei/inputcapture support is not builtin and running under a wayland session.

I wonder if config.h should be imported in a header instead of the implementation as I did.

