### PR TITLE
Add warning when running IL GUI from an Git untagged build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ option(INPUTLEAP_USE_EXTERNAL_GTEST "Use external installation of Google Test fr
 option(INPUTLEAP_BUILD_X11 "Build with XWindows support" ON)
 option(INPUTLEAP_BUILD_LIBEI "Build with libei support" OFF)
 option(INPUTLEAP_BUILD_GULRAK_FILESYSTEM "Use internal filesystem library" OFF)
+option(INPUTLEAP_DEPLOY_FLATPAK_SCRIPT "Deploy Flatpak script [Experimental]" OFF)
+option(INPUTLEAP_RELEASE_BUILD "This is an official release" OFF)
+
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -46,6 +49,15 @@ endif()
 
 include (cmake/Version.cmake)
 include (cmake/Package.cmake)
+
+if (NOT INPUTLEAP_VERSION_STAGE)
+    set (INPUTLEAP_VERSION_STAGE "Debug")
+endif()
+
+if (INPUTLEAP_RELEASE_BUILD)
+    add_definitions (-DINPUTLEAP_RELEASE_BUILD=1)
+    set (INPUTLEAP_RELEASE_BUILD 1)
+endif()
 
 # TODO: Find out why we need these, and remove them
 if (COMMAND cmake_policy)

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -23,6 +23,7 @@
 #include "MainWindow.h"
 #include "AppConfig.h"
 #include "SetupWizard.h"
+#include "common/GitChecks.h"
 
 #include <QtCore>
 #include <QtGui>
@@ -110,6 +111,17 @@ int main(int argc, char* argv[])
 	{
 		return 1;
 	}
+#endif
+
+    // Verify if build was built from a Git tag, or from a Git branch/untagged commit.
+    // TODO: Add CMake support.
+    // For now, this `QMessageBox` is disabled.
+#if defined(INPUTLEAP_GIT_UNTAG_WARNING)
+    if (1)
+        QMessageBox::warning(
+            nullptr, "Input Leap",
+            "This build of Input Leap was built from an untagged commit.\n"
+            "We recommend using a Git tag to build. Here be dragons");
 #endif
 
 	int trayAvailable = waitForTray();


### PR DESCRIPTION
The reason for this PR is to be able to warn users about running Input Leap from an untagged Git commit. We should not apply this PR until v3.0.0 of Input Leap is released.

Remaining tasks:

* [ ] Add CMake warning during build process.
* [ ] Add CMake scaffolding for determining Git status, and passing as compiler option.
* [ ] Add warning to CLI tools.
* [ ] Add newsfragment.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
