### PR TITLE
Update for libportal wip/inputcapture rebased on 0.7.1

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -213,7 +213,7 @@ gboolean PortalInputCapture::init_input_capture_session()
     xdp_portal_create_input_capture_session(
                 portal_,
                 nullptr, // parent
-                static_cast<XdpCapability>(XDP_CAPABILITY_KEYBOARD | XDP_CAPABILITY_POINTER),
+                static_cast<XdpInputCapability>(XDP_INPUT_CAPABILITY_KEYBOARD | XDP_INPUT_CAPABILITY_POINTER),
                 nullptr, // cancellable
                 [](GObject *obj, GAsyncResult *res, gpointer data) {
                 reinterpret_cast<PortalInputCapture*>(data)->cb_init_input_capture_session(obj, res);


### PR DESCRIPTION
Since 5 days ago since CI last ran on master, with commit [whot/libportal#6ecf17f](https://github.com/whot/libportal/tree/6ecf17f1dc99353b470d5cb9fb6e50566e275375) (taken from CI log)  the [`wip/inputcapture`](https://github.com/whot/libportal/tree/7371f619176dc8c7d2ecdfdc1988ee1ce8f1beb7) has been rebased on the lastest main which includes the `0.7.1` release and separation between qt5/qt6:

```
> git show-branch 6ecf17f wip/inputcapture main 
! [6ecf17f] Implement support for the InputCapture portal
 * [wip/inputcapture] Implement support for the InputCapture portal
  ! [main] Introduce libportal-qt6
---
 *  [wip/inputcapture] Implement support for the InputCapture portal
 *  [wip/inputcapture^] session: implement a generic close/closed handling
 *  [wip/inputcapture~2] Move the generic session declarations to a separate header
 *+ [main] Introduce libportal-qt6
 *+ [main^] CI: Upgrade Fedora environments
 *+ [main~2] meson: Adjust "qt" to "qt5"
 *+ [main~3] 0.7.1
 *+ [main~4] Restore ability to call g_object_new (XDP_TYPE_PORTAL, ...)
 *+ [main~5] 0.7
+   [6ecf17f] Implement support for the InputCapture portal
+   [6ecf17f^] session: implement a generic close/closed handling
+   [6ecf17f~2] Move the generic session declarations to a separate header
+*+ [main~6] remote: support the ConnectToEIS method added in version 2
```

More importantly, **`XdpCapability` has been renamed `XdpInputCapability`** (and similarly for the enum values`XDP_CAP…` to `XDP_INPUT_CAP…`), which means CI now breaks. This PR addresses the issue.

-----

I don’t think breaking changes are unexpected, after all the branch being referred to is called `wip/…`. Going forward input-leap could:
1. keep fetching the `wip/…` branch and keep addressing any breaking changes that may appear (not sure it’s a huge burden tbh, seems rare enough)
2. refer to the hash of the commit that the project wants to use, possibly with a warning in case of branch update
3. get the `wip/…` branch from a read-only fork of `whot/libportal` (no issues no PRs etc. -- maybe under the `input-leap` namespace?). This is a somewhat cleaner version to option 2 as it preserves names that would otherwise disappear. Optionally warn when branches from both repos disagree.

## Contributor Checklist:

* no user-visible change
