### PR TITLE
macOS: fix power management assertion handling

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -250,6 +250,9 @@ private:
     // true if mouse has entered the screen
     bool m_isOnScreen;
 
+    // IOKit power management assertion, refreshed on every enter()
+    IOPMAssertionID assertionID;
+
     // the display
     CGDirectDisplayID m_displayID;
 

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -811,8 +811,9 @@ OSXScreen::enter()
 			IORegistryEntrySetCFProperty(entry, CFSTR("IORequestIdle"), kCFBooleanFalse);
 			IOObjectRelease(entry);
 		}
-		IOPMAssertionID assertionID;
-		IOPMAssertionDeclareUserActivity(CFSTR("Input Leap Wakeup Assertion"), kIOPMUserActiveLocal, &assertionID);
+
+		// IOKit API for declaring a power management assertion
+		IOPMAssertionDeclareUserActivity(CFSTR("Input Leap - entering screen"), kIOPMUserActiveLocal, &assertionID);
 
 		avoidSupression();
 	}


### PR DESCRIPTION
Create a single power management assertion ID for announcing user activity on screen enter, instead of creating a new one each time.
