### PR TITLE
fix(EiScreen): Change `NULL` to C++ `nullptr`

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -594,7 +594,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
                                               EI_DEVICE_CAP_KEYBOARD,
                                               EI_DEVICE_CAP_BUTTON,
                                               EI_DEVICE_CAP_SCROLL,
-                                              NULL);
+                                              nullptr);
                     LOG((CLOG_DEBUG "using seat %s", ei_seat_get_name(ei_seat_)));
                     // we don't care about touch
                 }


### PR DESCRIPTION
Update `EiScreen.cpp` usage of `NULL` in method call to `nullptr`, as per C++ style conventions.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
