### PR TITLE
ei: try to restore RemoteDesktop sessions when we lose them

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -103,26 +103,26 @@ jobs:
           submodules: recursive
           set-safe-directory: ${{ github.workspace }}
 
-      - name: Get libei v1.0.0 from freedesktop
-        # Manual checkout of libinput/libei ref 1.0.0 from https://gitlab.freedesktop.org
+      - name: Get libei v1.2.1 from freedesktop
+        # Manual checkout of libinput/libei ref 1.2.1 from https://gitlab.freedesktop.org
         # because actions/checkout does not support gitlab
         if: matrix.wayland
         run: |
           git clone --depth=1 --branch="$ref" --recurse-submodules -- \
             "https://gitlab.freedesktop.org/libinput/libei" libei
         env:
-          ref: 1.0.0
+          ref: 1.2.1
 
-      - name: Get libportal from whot/libportal
+      - name: Get libportal from upstream
         uses: actions/checkout@v4
         if: matrix.wayland
         with:
-          repository: whot/libportal
-          ref: wip/inputcapture
+          repository: flatpak/libportal
+          ref: main
           path: libportal
 
       - if: matrix.wayland
-        name: build libei from git tag (1.0.0)
+        name: build libei from git tag
         run: |
             meson setup -Dprefix=/usr -Dtests=disabled -Dliboeffis=disabled -Ddocumentation=[] libei _libei_builddir
             ninja -C _libei_builddir install

--- a/src/lib/base/EventTypes.h
+++ b/src/lib/base/EventTypes.h
@@ -127,6 +127,11 @@ enum class EventType : std::uint32_t {
     */
     EI_SCREEN_CONNECTED_TO_EIS,
 
+    /** This event is sent whenever the portal session managing our EIS connection
+        is closed.
+    */
+    EI_SESSION_CLOSED,
+
     /// This event is sent whenever a server accepts a client.
     CLIENT_LISTENER_ACCEPTED,
 

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -42,14 +42,10 @@ EiKeyState::EiKeyState(EiScreen* screen, IEventQueue* events) :
 
 void EiKeyState::init_default_keymap()
 {
-    const struct xkb_rule_names names = {
-        nullptr, nullptr, nullptr, nullptr, nullptr // Use libxkbcommon compile-time defaults/env vars
-    };
-
     if (xkb_keymap_) {
         xkb_keymap_unref(xkb_keymap_);
     }
-    xkb_keymap_ = xkb_keymap_new_from_names(xkb_, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    xkb_keymap_ = xkb_keymap_new_from_names(xkb_, nullptr, XKB_KEYMAP_COMPILE_NO_FLAGS);
 
     if (xkb_state_) {
         xkb_state_unref(xkb_state_);

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -114,6 +114,8 @@ EiScreen::~EiScreen()
     ei_devices_.clear();
     ei_unref(ei_);
 
+    delete key_state_;
+
     delete portal_remote_desktop_;
 #if HAVE_LIBPORTAL_INPUTCAPTURE
     delete portal_input_capture_;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -47,15 +47,7 @@ EiScreen::EiScreen(bool is_primary, IEventQueue* events, bool use_portal) :
     events_(events),
     is_on_screen_(is_primary)
 {
-    if (is_primary)
-        ei_ = ei_new_receiver(nullptr); // we receive from the display server
-    else
-        ei_ = ei_new_sender(nullptr); // we send to the display server
-    ei_set_user_data(ei_, this);
-    ei_log_set_priority(ei_, EI_LOG_PRIORITY_DEBUG);
-    ei_log_set_handler(ei_, cb_handle_ei_log_event);
-    ei_configure_name(ei_, "InputLeap client");
-
+    init_ei();
     key_state_ = new EiKeyState(this, events);
     // install event handlers
     events_->add_handler(EventType::SYSTEM, events_->getSystemTarget(),
@@ -71,18 +63,18 @@ EiScreen::EiScreen(bool is_primary, IEventQueue* events, bool use_portal) :
             throw std::invalid_argument("Missing libportal InputCapture portal support");
 #endif
         } else {
+            events_->add_handler(EventType::EI_SESSION_CLOSED, get_event_target(),
+                                 [this](const auto& e){ handle_portal_session_closed(e); });
             portal_remote_desktop_ = new PortalRemoteDesktop(this, events_);
         }
     } else {
+        // Note: socket backend does not support reconnections
         auto rc = ei_setup_backend_socket(ei_, nullptr);
         if (rc != 0) {
             LOG_DEBUG("ei init error: %s", strerror(-rc));
             throw std::runtime_error("Failed to init ei context");
         }
     }
-
-    // install the platform event queue
-    events_->set_buffer(std::make_unique<EiEventQueueBuffer>(this, ei_, events_));
 }
 
 EiScreen::~EiScreen()
@@ -122,6 +114,23 @@ void EiScreen::handle_ei_log_event(ei* ei,
             LOG_PRINT("ei: %s", message);
             break;
     }
+}
+
+void EiScreen::init_ei()
+{
+    if (is_primary_) {
+        ei_ = ei_new_receiver(nullptr); // we receive from the display server
+    } else {
+        ei_ = ei_new_sender(nullptr); // we send to the display server
+    }
+    ei_set_user_data(ei_, this);
+    ei_log_set_priority(ei_, EI_LOG_PRIORITY_DEBUG);
+    ei_log_set_handler(ei_, cb_handle_ei_log_event);
+    ei_configure_name(ei_, "InputLeap client");
+
+    // install the platform event queue
+    events_->set_buffer(nullptr);
+    events_->set_buffer(std::make_unique<EiEventQueueBuffer>(this, ei_, events_));
 }
 
 void EiScreen::cleanup_ei()
@@ -694,9 +703,18 @@ void EiScreen::handle_connected_to_eis_event(const Event& event)
     }
 }
 
+void EiScreen::handle_portal_session_closed(const Event &event)
+{
+    // Portal may or may EI_EVENT_DISCONNECT us before sending the DBus Closed signal
+    // Let's clean up either way.
+    cleanup_ei();
+    init_ei();
+}
+
 void EiScreen::handle_system_event(const Event& sysevent)
 {
     std::lock_guard<std::mutex> lock(mutex_);
+    bool disconnected = false;
 
     // Only one ei_dispatch per system event, see the comment in
     // EiEventQueueBuffer::addEvent
@@ -741,7 +759,14 @@ void EiScreen::handle_system_event(const Event& sysevent)
                 }
                 break;
             case EI_EVENT_DISCONNECT:
-                throw std::runtime_error("Oops, EIS didn't like us");
+                // We're using libei which emulates the various seat/device remove events
+                // so by the time we get here our EiScreen should be in a neutral state.
+                //
+                // We don't do anything here, we let the portal's Session.Closed signal
+                // handle the rest.
+                LOG_WARN("disconnected from EIS");
+                disconnected = true;
+                break;
             case EI_EVENT_DEVICE_PAUSED:
                 LOG_DEBUG("device %s is paused", ei_device_get_name(device));
                 break;
@@ -791,6 +816,9 @@ void EiScreen::handle_system_event(const Event& sysevent)
         }
         ei_event_unref(event);
     }
+
+    if (disconnected)
+        ei_ = ei_unref(ei_);
 }
 
 void EiScreen::updateButtons()

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -90,29 +90,7 @@ EiScreen::~EiScreen()
     events_->set_buffer(nullptr);
     events_->remove_handler(EventType::SYSTEM, events_->getSystemTarget());
 
-    if (ei_pointer_) {
-        free(ei_device_get_user_data(ei_pointer_));
-        ei_device_set_user_data(ei_pointer_, nullptr);
-        ei_device_unref(ei_pointer_);
-    }
-    if (ei_keyboard_) {
-        free(ei_device_get_user_data(ei_keyboard_));
-        ei_device_set_user_data(ei_keyboard_, nullptr);
-        ei_device_unref(ei_keyboard_);
-    }
-    if (ei_abs_) {
-        free(ei_device_get_user_data(ei_abs_));
-        ei_device_set_user_data(ei_abs_, nullptr);
-        ei_device_unref(ei_abs_);
-    }
-    ei_seat_unref(ei_seat_);
-    for (auto it = ei_devices_.begin(); it != ei_devices_.end(); it++) {
-        free(ei_device_get_user_data(*it));
-        ei_device_set_user_data(*it, nullptr);
-        ei_device_unref(*it);
-    }
-    ei_devices_.clear();
-    ei_unref(ei_);
+    cleanup_ei();
 
     delete key_state_;
 
@@ -144,6 +122,33 @@ void EiScreen::handle_ei_log_event(ei* ei,
             LOG_PRINT("ei: %s", message);
             break;
     }
+}
+
+void EiScreen::cleanup_ei()
+{
+    if (ei_pointer_) {
+            free(ei_device_get_user_data(ei_pointer_));
+            ei_device_set_user_data(ei_pointer_, nullptr);
+            ei_pointer_ = ei_device_unref(ei_pointer_);
+    }
+    if (ei_keyboard_) {
+            free(ei_device_get_user_data(ei_keyboard_));
+            ei_device_set_user_data(ei_keyboard_, nullptr);
+            ei_keyboard_ = ei_device_unref(ei_keyboard_);
+    }
+    if (ei_abs_) {
+            free(ei_device_get_user_data(ei_abs_));
+            ei_device_set_user_data(ei_abs_, nullptr);
+            ei_abs_ = ei_device_unref(ei_abs_);
+    }
+    ei_seat_unref(ei_seat_);
+    for (auto it = ei_devices_.begin(); it != ei_devices_.end(); it++) {
+            free(ei_device_get_user_data(*it));
+            ei_device_set_user_data(*it, nullptr);
+            ei_device_unref(*it);
+    }
+    ei_devices_.clear();
+    ei_ = ei_unref(ei_);
 }
 
 const EventTarget* EiScreen::get_event_target() const

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -317,18 +317,17 @@ void EiScreen::disable()
 
 void EiScreen::enter()
 {
-    static int sequence_number;
     is_on_screen_ = true;
     if (!is_primary_) {
-        ++sequence_number;
+        ++sequence_number_;
         if (ei_pointer_) {
-            ei_device_start_emulating(ei_pointer_, sequence_number);
+            ei_device_start_emulating(ei_pointer_, sequence_number_);
         }
         if (ei_keyboard_) {
-            ei_device_start_emulating(ei_keyboard_, sequence_number);
+            ei_device_start_emulating(ei_keyboard_, sequence_number_);
         }
         if (ei_abs_) {
-            ei_device_start_emulating(ei_abs_, sequence_number);
+            ei_device_start_emulating(ei_abs_, sequence_number_);
         }
     }
 #if HAVE_LIBPORTAL_INPUTCAPTURE
@@ -772,6 +771,9 @@ void EiScreen::handle_system_event(const Event& sysevent)
                 break;
             case EI_EVENT_DEVICE_RESUMED:
                 LOG_DEBUG("device %s is resumed", ei_device_get_name(device));
+                if (is_on_screen_) {
+                    ei_device_start_emulating(device, ++sequence_number_);
+                }
                 break;
             case EI_EVENT_KEYBOARD_MODIFIERS:
                 // FIXME

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -154,9 +154,9 @@ private:
 
     mutable std::mutex mutex_;
 
-    PortalRemoteDesktop* portal_remote_desktop_;
+    PortalRemoteDesktop* portal_remote_desktop_ = nullptr;
 #if HAVE_LIBPORTAL_INPUTCAPTURE
-    PortalInputCapture* portal_input_capture_;
+    PortalInputCapture* portal_input_capture_ = nullptr;
 #endif
 
     struct HotKeyItem {

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -99,6 +99,7 @@ protected:
     void remove_device(ei_device* device);
 
 private:
+    void cleanup_ei();
     void send_event(EventType type, EventDataBase* data);
     ButtonID map_button_from_evdev(ei_event* event) const;
     void on_key_event(ei_event *event);

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -143,6 +143,8 @@ private:
     ei_device* ei_keyboard_ = nullptr;
     ei_device* ei_abs_ = nullptr;
 
+    std::uint32_t sequence_number_ = 0;
+
     std::uint32_t x_ = 0;
     std::uint32_t y_ = 0;
     std::uint32_t w_ = 0;

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -91,6 +91,7 @@ protected:
     // IPlatformScreen overrides
     void handle_system_event(const Event& event) override;
     void handle_connected_to_eis_event(const Event& event);
+    void handle_portal_session_closed(const Event &event);
     void updateButtons() override;
     IKeyState* getKeyState() const override;
 
@@ -99,6 +100,7 @@ protected:
     void remove_device(ei_device* device);
 
 private:
+    void init_ei();
     void cleanup_ei();
     void send_event(EventType type, EventDataBase* data);
     ButtonID map_button_from_evdev(ei_event* event) const;

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -26,8 +26,7 @@ PortalRemoteDesktop::PortalRemoteDesktop(EiScreen *screen,
                                          IEventQueue* events) :
     screen_(screen),
     events_(events),
-    portal_(xdp_portal_new()),
-    session_(nullptr)
+    portal_(xdp_portal_new())
 {
     glib_main_loop_ = g_main_loop_new(nullptr, true);
     glib_thread_ = new Thread([this](){ glib_thread(); });

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -112,6 +112,7 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
         LOG_ERR("Failed to start session");
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
+        return;
     }
 
     // ConnectToEIS requires version 2 of the xdg-desktop-portal (and the same

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -31,12 +31,7 @@ PortalRemoteDesktop::PortalRemoteDesktop(EiScreen *screen,
     glib_main_loop_ = g_main_loop_new(nullptr, true);
     glib_thread_ = new Thread([this](){ glib_thread(); });
 
-    auto init_cb = [](gpointer data) -> gboolean
-    {
-        return reinterpret_cast<PortalRemoteDesktop*>(data)->init_remote_desktop_session();
-    };
-
-    g_idle_add(init_cb, this);
+    reconnect(0);
 }
 
 PortalRemoteDesktop::~PortalRemoteDesktop()
@@ -59,6 +54,8 @@ PortalRemoteDesktop::~PortalRemoteDesktop()
     if (session_ != nullptr)
         g_object_unref(session_);
     g_object_unref(portal_);
+
+    free(session_restore_token_);
 }
 
 gboolean PortalRemoteDesktop::timeout_handler()
@@ -66,13 +63,30 @@ gboolean PortalRemoteDesktop::timeout_handler()
     return true; // keep re-triggering
 }
 
+void PortalRemoteDesktop::reconnect(unsigned int timeout)
+{
+    auto init_cb = [](gpointer data) -> gboolean
+    {
+        return reinterpret_cast<PortalRemoteDesktop*>(data)->init_remote_desktop_session();
+    };
+
+    if (timeout > 0)
+        g_timeout_add(timeout, init_cb, this);
+    else
+        g_idle_add(init_cb, this);
+}
+
 void PortalRemoteDesktop::cb_session_closed(XdpSession* session)
 {
-    LOG_ERR("Our RemoteDesktop session was closed, exiting.");
-    g_main_loop_quit(glib_main_loop_);
-    events_->add_event(EventType::QUIT);
-
+    LOG_ERR("Our RemoteDesktop session was closed, re-connecting.");
     g_signal_handler_disconnect(session, session_signal_id_);
+    session_signal_id_ = 0;
+    events_->add_event(EventType::EI_SESSION_CLOSED, screen_->get_event_target());
+
+    // gcc warning "Suspicious usage of 'sizeof(A*)'" can be ignored
+    g_clear_object(&session_);
+
+    reconnect(1000);
 }
 
 void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
@@ -86,6 +100,8 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
         events_->add_event(EventType::QUIT);
         return;
     }
+
+    session_restore_token_ = xdp_session_get_restore_token(session);
 
     // ConnectToEIS requires version 2 of the xdg-desktop-portal (and the same
     // version in the impl.portal), i.e. you'll need an updated compositor on
@@ -112,13 +128,19 @@ void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsync
 
     auto session = xdp_portal_create_remote_desktop_session_finish(XDP_PORTAL(object), res, &error);
     if (!session) {
-        LOG_ERR("Failed to initialize RemoteDesktop session, quitting: %s", error->message);
-        g_main_loop_quit(glib_main_loop_);
-        events_->add_event(EventType::QUIT);
+        LOG_ERR("Failed to initialize RemoteDesktop session: %s", error->message);
+        // This was the first attempt to connect to the RD portal - quit if that fails.
+        if (session_iteration_ == 0) {
+            g_main_loop_quit(glib_main_loop_);
+            events_->add_event(EventType::QUIT);
+        } else {
+            this->reconnect(1000);
+        }
         return;
     }
 
     session_ = session;
+    ++session_iteration_;
 
     // FIXME: the lambda trick doesn't work here for unknown reasons, we need
     // the static function
@@ -126,6 +148,7 @@ void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsync
                                          G_CALLBACK(cb_session_closed_cb),
                                          this);
 
+    LOG_DEBUG("Session ready, starting");
     xdp_session_start(session,
                       nullptr, // parent
                       nullptr, // cancellable
@@ -137,20 +160,22 @@ void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsync
 
 gboolean PortalRemoteDesktop::init_remote_desktop_session()
 {
-    LOG_DEBUG("Setting up the RemoteDesktop session");
-    xdp_portal_create_remote_desktop_session(
+    LOG_DEBUG("Setting up the RemoteDesktop session with restore token %s", session_restore_token_);
+    xdp_portal_create_remote_desktop_session_full(
                 portal_,
                 static_cast<XdpDeviceType>(XDP_DEVICE_POINTER | XDP_DEVICE_KEYBOARD),
                 XDP_OUTPUT_NONE,
                 XDP_REMOTE_DESKTOP_FLAG_NONE,
                 XDP_CURSOR_MODE_HIDDEN,
+                XDP_PERSIST_MODE_TRANSIENT,
+                session_restore_token_,
                 nullptr, // cancellable
                 [](GObject *obj, GAsyncResult *res, gpointer data) {
                     reinterpret_cast<PortalRemoteDesktop*>(data)->cb_init_remote_desktop_session(obj, res);
                 },
                 this);
 
-    return false;
+    return false; // don't reschedule
 }
 
 void PortalRemoteDesktop::glib_thread()

--- a/src/lib/platform/PortalRemoteDesktop.h
+++ b/src/lib/platform/PortalRemoteDesktop.h
@@ -58,12 +58,13 @@ private:
     IEventQueue* events_;
 
     Thread* glib_thread_;
-    GMainLoop* glib_main_loop_;
+    GMainLoop* glib_main_loop_ = nullptr;
 
-    XdpPortal* portal_;
-    XdpSession* session_;
+    XdpPortal* portal_ = nullptr;
+    XdpSession* session_ = nullptr;
+    char *session_restore_token_ = nullptr;
 
-    guint session_signal_id_;
+    guint session_signal_id_ = 0;
 };
 
 } // namespace inputleap

--- a/src/lib/platform/PortalRemoteDesktop.h
+++ b/src/lib/platform/PortalRemoteDesktop.h
@@ -44,6 +44,7 @@ private:
     void cb_init_remote_desktop_session(GObject* object, GAsyncResult* res);
     void cb_session_started(GObject* object, GAsyncResult* res);
     void cb_session_closed(XdpSession* session);
+    void reconnect(unsigned int timeout=1000);
 
     /// g_signal_connect callback wrapper
     static void cb_session_closed_cb(XdpSession* session, gpointer data)
@@ -65,6 +66,7 @@ private:
     char *session_restore_token_ = nullptr;
 
     guint session_signal_id_ = 0;
+    guint session_iteration_ = 0; /// The number of successful sessions we've had already
 };
 
 } // namespace inputleap


### PR DESCRIPTION
Use the restore_token provided in RemoteDesktop.Start to re-initialize our sessions if we get disconnected. This gives us back the session without any need for interactive user input after e.g. a lock screen.

Fixes #1699 

cc @prahal

Note: filing this as draft because I haven't fully debugged this yet and there may be some memleaks, this is just the first working version.

Requires:
- [x] https://github.com/flatpak/xdg-desktop-portal/pull/1128
- [x] [GNOME/xdg-desktop-portal-gnome!108](https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/108)
- [x] https://github.com/flatpak/libportal/pull/128
