### PR TITLE
ei: inhibit idle while we have a RemoteDesktop session active

### DIFF
--- a/src/lib/platform/PortalRemoteDesktop.h
+++ b/src/lib/platform/PortalRemoteDesktop.h
@@ -45,6 +45,7 @@ private:
     void cb_init_remote_desktop_session(GObject* object, GAsyncResult* res);
     void cb_session_started(GObject* object, GAsyncResult* res);
     void cb_session_closed(XdpSession* session);
+    void cb_inhibited(GObject* object, GAsyncResult* res);
 
     /// g_signal_connect callback wrapper
     static void cb_session_closed_cb(XdpSession* session, gpointer data)


### PR DESCRIPTION
Inhibit the session while we have a RemoteDesktop session active.

Filed as Draft until XXX is resolved.

Related to #1699

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
