### PR TITLE
User Selectable Qt Version at Config time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions (-DNDEBUG)
 endif()
 
+if(NOT QT_DEFAULT_MAJOR_VERSION)
+    set(QT_DEFAULT_MAJOR_VERSION 5)
+endif()
+
 include (cmake/Version.cmake)
 include (cmake/Package.cmake)
 
@@ -54,6 +58,14 @@ endif()
 
 set (libs)
 
+
+if (INPUTLEAP_BUILD_GUI)
+    if (QT_DEFAULT_MAJOR_VERSION EQUAL 5)
+        set(REQUIRED_QT_VERSION 5.9)
+    elseif (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
+        set(REQUIRED_QT_VERSION 6.2)
+    endif()
+endif()
 if (UNIX)
     if (NOT APPLE)
         set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)

--- a/doc/newsfragments/qt-cmake-select.feature
+++ b/doc/newsfragments/qt-cmake-select.feature
@@ -1,0 +1,7 @@
+Allow Qt version to be selected via CMake
+
+CMake now uses a sane default of Qt 5, but allows for a CMake option of
+`QT_DEFAULT_MAJOR_VERSION`, for overriding of the Qt library used during build.
+
+For example, setting `QT_DEFAULT_MAJOR_VERSION` to `6` uses Qt 6, and setting to
+`5` uses Qt 5. Older versions are not supported.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,13 +1,11 @@
 
-find_package (QT NAMES Qt6 Qt5 REQUIRED)
-find_package (Qt${QT_VERSION_MAJOR} COMPONENTS Core Widgets Network LinguistTools REQUIRED)
-# If Qt6 is in use, also link to Core5Compat
-if (Qt6_FOUND)
+find_package (Qt${QT_DEFAULT_MAJOR_VERSION} ${REQUIRED_QT_VERSION} COMPONENTS Core Widgets Network LinguistTools REQUIRED)
+
+if (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
     find_package (Qt6 REQUIRED COMPONENTS Core5Compat)
 endif()
 
-message(STATUS "Using Qt" ${QT_VERSION_MAJOR})
-
+message(STATUS "Using Qt ${QT_DEFAULT_MAJOR_VERSION}")
 
 set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTORCC ON)
@@ -172,7 +170,7 @@ set(TS_FILES
 )
 
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/res/lang")
-if (Qt5_FOUND)
+if (QT_DEFAULT_MAJOR_VERSION EQUAL 5)
     qt5_add_translation(QM_FILES ${TS_FILES} OPTIONS -silent)
 else()
     qt_add_translation(QM_FILES ${TS_FILES} OPTIONS -silent)
@@ -203,13 +201,13 @@ target_link_libraries(input-leap
     arch
     base
     io
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Widgets
-    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_DEFAULT_MAJOR_VERSION}::Core
+    Qt${QT_DEFAULT_MAJOR_VERSION}::Widgets
+    Qt${QT_DEFAULT_MAJOR_VERSION}::Network
 )
 
-if (Qt6_FOUND)
-    target_link_libraries(input-leap Qt6::Core5Compat)
+if (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
+    target_link_libraries(input-leap Qt::Core5Compat)
 endif()
 target_link_libraries(input-leap ${OPENSSL_LIBS})
 
@@ -258,5 +256,8 @@ if(INPUTLEAP_BUILD_TESTS)
              WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
     target_include_directories(guiunittests PUBLIC ../../ext)
-    target_link_libraries(guiunittests gtest gmock Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Network ${libs})
+    target_link_libraries(guiunittests gtest gmock Qt${QT_DEFAULT_MAJOR_VERSION}::Core Qt${QT_DEFAULT_MAJOR_VERSION}::Widgets Qt${QT_DEFAULT_MAJOR_VERSION}::Network ${libs})
+    if (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
+        target_link_libraries(guiunittests Qt::Core5Compat)
+    endif()
 endif()


### PR DESCRIPTION
## Contributor Checklist:

* [X] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 

Fixes: #1395

Allow the user to select the Qt Version if both Qt5 and Qt6 are installed.
 - Set `QT_DEFAULT_MAJOR_VERSION` to 6 to build with Qt6
 - Set `QT_DEFAULT_MAJOR_VERSION` to 5 to build with Qt5 ( Default if not set)
 
Few Changes to the GUI cmakelist
 1. Use `QT_DEFAULT_MAJOR_VERSION` to control the version of Qt Required
          -  Qt5 Builds Require Qt Version 5.9+
          -  Qt6 Builds Require Qt Version 6.2+
 2. Use `QT_DEFAULT_MAJOR_VERSION` in place of `Qt#_Found` for tool guards