### PR TITLE
github-ci: Add macOS Universal and Apple Silicon builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -294,6 +294,16 @@ jobs:
           path: ./build/bundle/*.dmg
           if-no-files-found: error
 
+      - name: Archive debug app
+        if: env.B_BUILD_TYPE != 'Release'
+        run: tar -czf InputLeap-${{matrix.name}}.tar.gz -C build/bundle InputLeap.app
+
+      - uses: actions/upload-artifact@v4
+        if: env.B_BUILD_TYPE != 'Release'
+        with:
+          name: ${{ matrix.name }}-debug
+          path: ./InputLeap*.tar.gz
+          if-no-files-found: error
 
   win-build:
     name: ${{ matrix.name }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -206,17 +206,19 @@ jobs:
           if-no-files-found: error
 
   mac-build:
+    name: ${{ matrix.name}}
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
        include:
-         - os: macos-11
+         - name: macOS-x86_64
+           os: macos-11
            qt-version: 5.15
            min-macOS-version: 10.9
            arch: 'x86_64'
-         - os: macos-12
+         - name: macOS-Universal
+           os: macos-12
            qt-version: 6.6
            min-macOS-version: 11
            qt-modules: qt5compat

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -224,6 +224,8 @@ jobs:
     env:
       VERBOSE: 1
       TERM: xterm-256color
+      OpenSSL_Install_Path: "/Users/runner/openssl"
+      OpenSSL_Version: 3.2.0
 
     steps:
       - name: Install Qt
@@ -238,6 +240,34 @@ jobs:
         run: |
           brew install ninja
 
+      - name: Cache OpenSSL Universal
+        id: cache-openssl
+        if: matrix.os == 'macos-12'
+        uses: actions/cache@v3.0.11
+        with:
+          path: ${{env.OpenSSL_Install_Path}}
+          key: macOS-${{matrix.os}}-ssl-${{matrix.arch}}-${{env.OpenSSL_Version}}
+
+      - name: Build OpenSSL Universal
+        if: ((steps.cache-openssl.outputs.cache-hit != 'true') && (matrix.os == 'macos-12'))
+        run: |
+          wget https://github.com/openssl/openssl/releases/download/openssl-${{env.OpenSSL_Version}}/openssl-${{env.OpenSSL_Version}}.tar.gz
+          tar -xf openssl-${{env.OpenSSL_Version}}.tar.gz
+          echo "#!/bin/bash
+          if [[ \$* == *-arch\ x86_64* ]] && ! [[ \$* == *-arch\ arm64* ]]; then
+            cc -arch arm64 \$@
+          else
+            cc \$@
+          fi" >> /Users/runner/cc_override
+          chmod a+x /Users/runner/cc_override
+          cat /Users/runner/cc_override
+          export MACOSX_DEPLOYMENT_TARGET=${{matrix.min-macOS-version}}
+          export CC=/Users/runner/cc_override
+          cd openssl-${{env.OpenSSL_Version}}
+          ./configure no-asm darwin64-x86_64-cc --prefix=${{env.OpenSSL_Install_Path}}
+          make
+          make install
+
       - uses: actions/checkout@v4
         with:
           path: input-leap
@@ -245,7 +275,7 @@ jobs:
 
       - name: Setup the build
         run: |
-          cmake -DCMAKE_BUILD_TYPE="${B_BUILD_TYPE}" -S input-leap -B build -G Ninja \
+          cmake -DCMAKE_BUILD_TYPE="${B_BUILD_TYPE}" -S input-leap -B build -G Ninja -DOpenSSL_ROOT=${{env.OpenSSL_Install_Path}} \
                 -DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
                 -DCMAKE_OSX_DEPLOYMENT_TARGET=${{matrix.min-macOS-version}} -DCMAKE_UNITY_BUILD=1 -DQT_DEFAULT_MAJOR_VERSION=$(echo ${{matrix.qt-version}} | cut -c -1)
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -223,6 +223,12 @@ jobs:
            min-macOS-version: 11
            qt-modules: qt5compat
            arch: 'arm64;x86_64'
+         - name: macOS-Apple_Silicon
+           os: macos-14
+           qt-version: 6.6
+           min-macOS-version: 14
+           qt-modules: qt5compat
+           arch: 'arm64'
 
     env:
       VERBOSE: 1

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -215,11 +215,12 @@ jobs:
          - os: macos-11
            qt-version: 5.15
            min-macOS-version: 10.9
+           arch: 'x86_64'
          - os: macos-12
            qt-version: 6.6
            min-macOS-version: 11
            qt-modules: qt5compat
-
+           arch: 'arm64;x86_64'
 
     env:
       VERBOSE: 1
@@ -277,7 +278,8 @@ jobs:
         run: |
           cmake -DCMAKE_BUILD_TYPE="${B_BUILD_TYPE}" -S input-leap -B build -G Ninja -DOpenSSL_ROOT=${{env.OpenSSL_Install_Path}} \
                 -DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
-                -DCMAKE_OSX_DEPLOYMENT_TARGET=${{matrix.min-macOS-version}} -DCMAKE_UNITY_BUILD=1 -DQT_DEFAULT_MAJOR_VERSION=$(echo ${{matrix.qt-version}} | cut -c -1)
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${{matrix.min-macOS-version}} -DCMAKE_UNITY_BUILD=1 -DQT_DEFAULT_MAJOR_VERSION=$(echo ${{matrix.qt-version}} | cut -c -1) \
+                -DCMAKE_OSX_ARCHITECTURES="${{matrix.arch}}"
 
       - name: Run the build
         run: |


### PR DESCRIPTION
Requires: #1845
- Build a macOS Universal Binary Also build for mac os 12   
   - Fixes #1703  
   - Fixes #1704 
   - Fixes #1057 
   - Fixes #960
   - Fixes #166 
- Add Os 10.14 Native Arm only on CI 
    - Fixes #1208
- CI Updates to support this
    -  Build and cache proper openSSL config
    - Upload build artifacts for mac os actions.