### PR TITLE
Remove `cmake_minimium_version` declarations from non-root `CMakeLists.txt`

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 3.4)
 
 set(INPUTLEAP_VERSION_MAJOR 2)
 set(INPUTLEAP_VERSION_MINOR 4)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 3.4)
 
 find_package (QT NAMES Qt6 Qt5 REQUIRED)
 find_package (Qt${QT_VERSION_MAJOR} COMPONENTS Core Widgets Network LinguistTools REQUIRED)


### PR DESCRIPTION
Remove duplicate call to `cmake_minimum_version`. 

It should be set only by the main `CMakeLists.txt`.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 