### PR TITLE
Fix cut off label for clipboard max size on GUI Server window

### DIFF
--- a/doc/newsfragments/1644_fix_label_clipboard_max_size.bugfix
+++ b/doc/newsfragments/1644_fix_label_clipboard_max_size.bugfix
@@ -1,0 +1,2 @@
+Fixed spacing for max clipboard input on in the advanced server settings (https://github.com/input-leap/input-leap/issues/1644).
+

--- a/src/gui/src/ServerConfigDialogBase.ui
+++ b/src/gui/src/ServerConfigDialogBase.ui
@@ -427,50 +427,46 @@ Double click on a screen to edit its settings.</string>
             <property name="title">
              <string/>
             </property>
-            <widget class="QLabel" name="m_pLabelSharingSize">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>0</y>
-               <width>201</width>
-               <height>21</height>
-              </rect>
-             </property>
-             <property name="text">
-              <string>Max Clipboard sharing size</string>
-             </property>
-            </widget>
-            <widget class="QSpinBox" name="m_pSpinBoxClipboardSizeLimit">
-             <property name="geometry">
-              <rect>
-               <x>250</x>
-               <y>0</y>
-               <width>131</width>
-               <height>20</height>
-              </rect>
-             </property>
-             <property name="toolTip">
-              <string>Clipboard sharing size in bytes</string>
-             </property>
-             <property name="toolTipDuration">
-              <number>-3</number>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-             </property>
-             <property name="minimum">
-              <number>1000000</number>
-             </property>
-             <property name="maximum">
-              <number>100000000</number>
-             </property>
-             <property name="singleStep">
-              <number>1000</number>
-             </property>
-             <property name="value">
-              <number>3000000</number>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLabel" name="m_pLabelSharingSize">
+               <property name="text">
+                <string>Max Clipboard sharing size</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="m_pSpinBoxClipboardSizeLimit">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Clipboard sharing size in bytes</string>
+               </property>
+               <property name="toolTipDuration">
+                <number>-3</number>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+               </property>
+               <property name="minimum">
+                <number>1000000</number>
+               </property>
+               <property name="maximum">
+                <number>100000000</number>
+               </property>
+               <property name="singleStep">
+                <number>1000</number>
+               </property>
+               <property name="value">
+                <number>3000000</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item row="3" column="0">


### PR DESCRIPTION
Fixes #1644.

![Screenshot_20231024_222732](https://github.com/input-leap/input-leap/assets/7450820/930d9ea3-ad16-45d6-bf5a-a2e54d1eee66)

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 