### PR TITLE
Fix clazy issues

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -85,7 +85,8 @@ void ActionDialog::accept()
     m_Action.setHaveScreens(m_pGroupBoxScreens->isChecked());
 
     m_Action.clearTypeScreenNames();
-    for (const QListWidgetItem* pItem : m_pListScreens->selectedItems()) {
+    const auto selection = m_pListScreens->selectedItems();
+    for (const QListWidgetItem* pItem : selection) {
         m_Action.appendTypeScreenName(pItem->text());
     }
 

--- a/src/gui/src/AddClientDialog.cpp
+++ b/src/gui/src/AddClientDialog.cpp
@@ -39,25 +39,25 @@ AddClientDialog::AddClientDialog(const QString& clientName, QWidget* parent) :
     m_pButtonLeft->setIcon(icon);
     m_pButtonLeft->setIconSize(IconSize);
     gridLayout->addWidget(m_pButtonLeft, 2, 0, 1, 1, Qt::AlignCenter);
-    connect(m_pButtonLeft, SIGNAL(clicked()), this, SLOT(handleButtonLeft()));
+    connect(m_pButtonLeft, &QPushButton::clicked, this, &AddClientDialog::handleButtonLeft);
 
     m_pButtonUp = new QPushButton(this);
     m_pButtonUp->setIcon(icon);
     m_pButtonUp->setIconSize(IconSize);
     gridLayout->addWidget(m_pButtonUp, 1, 1, 1, 1, Qt::AlignCenter);
-    connect(m_pButtonUp, SIGNAL(clicked()), this, SLOT(handleButtonUp()));
+    connect(m_pButtonUp, &QPushButton::clicked, this, &AddClientDialog::handleButtonUp);
 
     m_pButtonRight = new QPushButton(this);
     m_pButtonRight->setIcon(icon);
     m_pButtonRight->setIconSize(IconSize);
     gridLayout->addWidget(m_pButtonRight, 2, 2, 1, 1, Qt::AlignCenter);
-    connect(m_pButtonRight, SIGNAL(clicked()), this, SLOT(handleButtonRight()));
+    connect(m_pButtonRight, &QPushButton::clicked, this, &AddClientDialog::handleButtonRight);
 
     m_pButtonDown = new QPushButton(this);
     m_pButtonDown->setIcon(icon);
     m_pButtonDown->setIconSize(IconSize);
     gridLayout->addWidget(m_pButtonDown, 3, 1, 1, 1, Qt::AlignCenter);
-    connect(m_pButtonDown, SIGNAL(clicked()), this, SLOT(handleButtonDown()));
+    connect(m_pButtonDown, &QPushButton::clicked, this, &AddClientDialog::handleButtonDown);
 
     m_pLabelCenter = new QLabel(this);
     m_pLabelCenter->setPixmap(QPixmap(":res/icons/64x64/video-display.png"));
@@ -69,7 +69,7 @@ AddClientDialog::AddClientDialog(const QString& clientName, QWidget* parent) :
 
     QPushButton* advanced = m_pDialogButtonBox->addButton("Advanced",
                                                     QDialogButtonBox::HelpRole);
-    connect(advanced, SIGNAL(clicked()), this, SLOT(handleButtonAdvanced()));
+    connect(advanced, &QPushButton::clicked, this, &AddClientDialog::handleButtonAdvanced);
 }
 
 AddClientDialog::~AddClientDialog()

--- a/src/gui/src/CommandProcess.cpp
+++ b/src/gui/src/CommandProcess.cpp
@@ -57,7 +57,7 @@ QString CommandProcess::run()
                 .toStdString());
     }
 
-    emit finished();
+    Q_EMIT finished();
 
     return output;
 }

--- a/src/gui/src/DataDownloader.cpp
+++ b/src/gui/src/DataDownloader.cpp
@@ -22,8 +22,7 @@ DataDownloader::DataDownloader(QObject* parent) :
     m_pReply(nullptr),
     m_IsFinished(false)
 {
-    connect(&m_NetworkManager, SIGNAL(finished(QNetworkReply*)),
-        SLOT(complete(QNetworkReply*)));
+    connect(&m_NetworkManager, &QNetworkAccessManager::finished, this, &DataDownloader::complete);
 }
 
 DataDownloader::~DataDownloader()

--- a/src/gui/src/DataDownloader.cpp
+++ b/src/gui/src/DataDownloader.cpp
@@ -36,7 +36,7 @@ void DataDownloader::complete(QNetworkReply* reply)
 
     if (!m_Data.isEmpty()) {
         m_IsFinished = true;
-        emit isComplete();
+        Q_EMIT isComplete();
     }
 }
 

--- a/src/gui/src/IpcClient.cpp
+++ b/src/gui/src/IpcClient.cpp
@@ -30,15 +30,15 @@ m_ReaderStarted(false),
 m_Enabled(false)
 {
     m_Socket = new QTcpSocket(this);
-    connect(m_Socket, SIGNAL(connected()), this, SLOT(connected()));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    connect(m_Socket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this, SLOT(error(QAbstractSocket::SocketError)));
+    connect(m_Socket, &QTcpSocket::connected, this, &IpcClient::connected);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(m_Socket, &QTcpSocket::errorOccurred, this, &IpcClient::error);
 #else
     connect(m_Socket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(error(QAbstractSocket::SocketError)));
 #endif
 
     m_Reader = new IpcReader(m_Socket);
-    connect(m_Reader, SIGNAL(readLogLine(const QString&)), this, SLOT(handleReadLogLine(const QString&)));
+    connect(m_Reader, &IpcReader::readLogLine, this, &IpcClient::handleReadLogLine);
 }
 
 IpcClient::~IpcClient()

--- a/src/gui/src/IpcClient.cpp
+++ b/src/gui/src/IpcClient.cpp
@@ -48,14 +48,14 @@ IpcClient::~IpcClient()
 void IpcClient::connected()
 {
     sendHello();
-    infoMessage("connection established");
+    Q_EMIT infoMessage("connection established");
 }
 
 void IpcClient::connectToHost()
 {
     m_Enabled = true;
 
-    infoMessage("connecting to service...");
+    Q_EMIT infoMessage("connecting to service...");
     m_Socket->connectToHost(QHostAddress(QHostAddress::LocalHost), IPC_PORT);
 
     if (!m_ReaderStarted) {
@@ -66,7 +66,7 @@ void IpcClient::connectToHost()
 
 void IpcClient::disconnectFromHost()
 {
-    infoMessage("service disconnect");
+    Q_EMIT infoMessage("service disconnect");
     m_Reader->stop();
     m_Socket->close();
 }
@@ -80,7 +80,7 @@ void IpcClient::error(QAbstractSocket::SocketError error)
         default: text = QString("code=%1").arg(error); break;
     }
 
-    errorMessage(QString("ipc connection error, %1").arg(text));
+    Q_EMIT errorMessage(QString("ipc connection error, %1").arg(text));
 
     QTimer::singleShot(1000, this, SLOT(retryConnect()));
 }
@@ -125,7 +125,7 @@ void IpcClient::sendCommand(const QString& command, ElevateMode const elevate)
 
 void IpcClient::handleReadLogLine(const QString& text)
 {
-    readLogLine(text);
+    Q_EMIT readLogLine(text);
 }
 
 // TODO: qt must have a built in way of converting int to bytes.

--- a/src/gui/src/IpcReader.cpp
+++ b/src/gui/src/IpcReader.cpp
@@ -76,7 +76,7 @@ void IpcReader::read()
             QString line = QString::fromUtf8(data, len);
             delete[] data;
 
-            readLogLine(line);
+            Q_EMIT readLogLine(line);
         }
         else {
             IPC_LOG(std::cerr << "aborting, message invalid" << std::endl);

--- a/src/gui/src/IpcReader.cpp
+++ b/src/gui/src/IpcReader.cpp
@@ -43,12 +43,12 @@ IpcReader::~IpcReader()
 
 void IpcReader::start()
 {
-    connect(m_Socket, SIGNAL(readyRead()), this, SLOT(read()));
+    connect(m_Socket, &QTcpSocket::readyRead, this, &IpcReader::read);
 }
 
 void IpcReader::stop()
 {
-    disconnect(m_Socket, SIGNAL(readyRead()), this, SLOT(read()));
+    disconnect(m_Socket, &QTcpSocket::readyRead, this, &IpcReader::read);
 }
 
 void IpcReader::read()

--- a/src/gui/src/KeySequenceWidget.cpp
+++ b/src/gui/src/KeySequenceWidget.cpp
@@ -81,7 +81,7 @@ void KeySequenceWidget::stopRecording()
     focusNextChild();
     releaseKeyboard();
     setStatus(Stopped);
-    emit keySequenceChanged();
+    Q_EMIT keySequenceChanged();
 }
 
 bool KeySequenceWidget::event(QEvent* event)

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -367,10 +367,11 @@ void MainWindow::logOutput()
     {
         QString text(cmd_app_process_->readAllStandardOutput());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        for (QString line : text.split(QRegularExpression("\r|\n|\r\n"))) {
+        const auto results = text.split(QRegularExpression("\r|\n|\r\n"));
 #else
-        for (QString line : text.split(QRegExp("\r|\n|\r\n"))) {
+        const auto results = text.split(QRegExp("\r|\n|\r\n"));
 #endif
+        for (const auto& line : results) {
             if (!line.isEmpty())
             {
                 appendLogRaw(line);
@@ -408,9 +409,9 @@ void MainWindow::appendLogError(const QString& text)
 void MainWindow::appendLogRaw(const QString& text)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    auto lines = text.split(QRegularExpression("\r|\n|\r\n"));
+    const auto lines = text.split(QRegularExpression("\r|\n|\r\n"));
 #else
-    auto lines = text.split(QRegExp("\r|\n|\r\n"));
+    const auto lines = text.split(QRegExp("\r|\n|\r\n"));
 #endif
     for (const auto& line : lines) {
         if (!line.isEmpty()) {

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -149,9 +149,9 @@ MainWindow::MainWindow(QSettings& settings, AppConfig& appConfig) :
 
 #if defined(Q_OS_WIN)
     // ipc must always be enabled, so that we can disable command when switching to desktop mode.
-    connect(&m_IpcClient, SIGNAL(readLogLine(const QString&)), this, SLOT(appendLogRaw(const QString&)));
-    connect(&m_IpcClient, SIGNAL(errorMessage(const QString&)), this, SLOT(appendLogError(const QString&)));
-    connect(&m_IpcClient, SIGNAL(infoMessage(const QString&)), this, SLOT(appendLogInfo(const QString&)));
+    connect(&m_IpcClient, &IpcClient::readLogLine, this, &MainWindow::appendLogRaw);
+    connect(&m_IpcClient, &IpcClient::errorMessage, this, &MainWindow::appendLogError);
+    connect(&m_IpcClient, &IpcClient::infoMessage, this, &MainWindow::appendLogInfo);
     m_IpcClient.connectToHost();
 #endif
 
@@ -174,7 +174,7 @@ MainWindow::MainWindow(QSettings& settings, AppConfig& appConfig) :
 
     updateSSLFingerprint();
 
-    connect(toolbutton_show_fingerprint, &QToolButton::clicked, [this](bool checked)
+    connect(toolbutton_show_fingerprint, &QToolButton::clicked, this, [this](bool checked)
     {
         (void) checked;
 
@@ -261,8 +261,7 @@ void MainWindow::createTrayIcon()
     m_pTrayIcon->setContextMenu(m_pTrayIconMenu);
     m_pTrayIcon->setToolTip("InputLeap");
 
-    connect(m_pTrayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
-            this, SLOT(trayActivated(QSystemTrayIcon::ActivationReason)));
+    connect(m_pTrayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayActivated);
 
     set_icon(AppConnectionState::DISCONNECTED);
 
@@ -313,12 +312,12 @@ void MainWindow::loadSettings()
 
 void MainWindow::initConnections()
 {
-    connect(m_pActionMinimize, SIGNAL(triggered()), this, SLOT(hide()));
-    connect(m_pActionRestore, SIGNAL(triggered()), this, SLOT(showNormal()));
-    connect(m_pActionStartCmdApp, SIGNAL(triggered()), this, SLOT(start_cmd_app()));
-    connect(m_pActionStopCmdApp, SIGNAL(triggered()), this, SLOT(stop_cmd_app()));
-    connect(m_pActionShowLog, SIGNAL(triggered()), this, SLOT(showLogWindow()));
-    connect(m_pActionQuit, SIGNAL(triggered()), qApp, SLOT(quit()));
+    connect(m_pActionMinimize, &QAction::triggered, this, &MainWindow::hide);
+    connect(m_pActionRestore, &QAction::triggered, this, &MainWindow::showNormal);
+    connect(m_pActionStartCmdApp, &QAction::triggered, this, &MainWindow::start_cmd_app);
+    connect(m_pActionStopCmdApp, &QAction::triggered, this, &MainWindow::stop_cmd_app);
+    connect(m_pActionShowLog, &QAction::triggered, this, &MainWindow::showLogWindow);
+    connect(m_pActionQuit, &QAction::triggered, qApp, &QCoreApplication::quit);
 }
 
 void MainWindow::saveSettings()
@@ -607,9 +606,9 @@ void MainWindow::start_cmd_app()
 
     if (desktopMode)
     {
-        connect(cmd_app_process_, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(cmd_app_finished(int, QProcess::ExitStatus)));
-        connect(cmd_app_process_, SIGNAL(readyReadStandardOutput()), this, SLOT(logOutput()));
-        connect(cmd_app_process_, SIGNAL(readyReadStandardError()), this, SLOT(logError()));
+        connect(cmd_app_process_, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &MainWindow::cmd_app_finished);
+        connect(cmd_app_process_, &QProcess::readyReadStandardOutput, this, &MainWindow::logOutput);
+        connect(cmd_app_process_, &QProcess::readyReadStandardError, this, &MainWindow::logError);
     }
 
     m_pLogWindow->startNewInstance();
@@ -845,7 +844,7 @@ void MainWindow::cmd_app_finished(int exitCode, QProcess::ExitStatus)
     }
 
     if (m_ExpectedRunningState == kStarted) {
-        QTimer::singleShot(1000, this, SLOT(start_cmd_app()));
+        QTimer::singleShot(1000, this, &MainWindow::start_cmd_app);
         appendLogInfo(QString("detected process not running, auto restarting"));
     }
     else {
@@ -860,15 +859,15 @@ void MainWindow::set_connection_state(AppConnectionState state)
 
     if (state == AppConnectionState::CONNECTED || state == AppConnectionState::CONNECTING)
     {
-        disconnect(m_pButtonToggleStart, SIGNAL(clicked()), m_pActionStartCmdApp, SLOT(trigger()));
-        connect(m_pButtonToggleStart, SIGNAL(clicked()), m_pActionStopCmdApp, SLOT(trigger()));
+        disconnect(m_pButtonToggleStart, &QPushButton::clicked, m_pActionStartCmdApp, &QAction::trigger);
+        connect(m_pButtonToggleStart, &QPushButton::clicked, m_pActionStopCmdApp, &QAction::trigger);
         m_pButtonToggleStart->setText(tr("&Stop"));
         m_pButtonReload->setEnabled(true);
     }
     else if (state == AppConnectionState::DISCONNECTED)
     {
-        disconnect(m_pButtonToggleStart, SIGNAL(clicked()), m_pActionStopCmdApp, SLOT(trigger()));
-        connect(m_pButtonToggleStart, SIGNAL(clicked()), m_pActionStartCmdApp, SLOT(trigger()));
+        disconnect(m_pButtonToggleStart, &QPushButton::clicked, m_pActionStopCmdApp, &QAction::trigger);
+        connect(m_pButtonToggleStart, &QPushButton::clicked, m_pActionStartCmdApp, &QAction::trigger);
         m_pButtonToggleStart->setText(tr("&Start"));
         m_pButtonReload->setEnabled(false);
     }
@@ -1050,10 +1049,7 @@ void MainWindow::updateSSLFingerprint()
 {
     if (m_AppConfig->getCryptoEnabled() && m_pSslCertificate == nullptr) {
         m_pSslCertificate = new SslCertificate(this);
-        connect(m_pSslCertificate, &SslCertificate::info, [&](QString info)
-        {
-            appendLogInfo(info);
-        });
+        connect(m_pSslCertificate, &SslCertificate::info, this, &MainWindow::appendLogInfo);
         m_pSslCertificate->generateCertificate();
     }
 
@@ -1267,7 +1263,7 @@ void MainWindow::downloadBonjour()
 
     if (m_pDataDownloader == nullptr) {
         m_pDataDownloader = new DataDownloader(this);
-        connect(m_pDataDownloader, SIGNAL(isComplete()), SLOT(installBonjour()));
+        connect(m_pDataDownloader, &DataDownloader::isComplete, this, &MainWindow::installBonjour);
     }
 
     m_pDataDownloader->download(url);
@@ -1325,10 +1321,9 @@ void MainWindow::installBonjour()
     }
 
     QThread* thread = new QThread;
-    connect(m_BonjourInstall, SIGNAL(finished()), this,
-        SLOT(bonjourInstallFinished()));
-    connect(m_BonjourInstall, SIGNAL(finished()), thread, SLOT(quit()));
-    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+    connect(m_BonjourInstall, &CommandProcess::finished, this, &MainWindow::bonjourInstallFinished);
+    connect(m_BonjourInstall, &CommandProcess::finished, thread, &QThread::quit);
+    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
 
     m_BonjourInstall->moveToThread(thread);
     thread->start();

--- a/src/gui/src/QInputLeapApplication.cpp
+++ b/src/gui/src/QInputLeapApplication.cpp
@@ -34,7 +34,8 @@ QInputLeapApplication::~QInputLeapApplication() = default;
 
 void QInputLeapApplication::commitData(QSessionManager&)
 {
-    for (QWidget* widget : topLevelWidgets()) {
+    const auto all_topLevelWidgets = topLevelWidgets();
+    for (QWidget* widget : all_topLevelWidgets) {
         MainWindow* mainWindow = qobject_cast<MainWindow*>(widget);
         if (mainWindow)
             mainWindow->saveSettings();

--- a/src/gui/src/QUtility.cpp
+++ b/src/gui/src/QUtility.cpp
@@ -51,7 +51,8 @@ QString hash(const QString& string)
 QString getFirstMacAddress()
 {
     QString mac;
-    for (const QNetworkInterface &interface : QNetworkInterface::allInterfaces()) {
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface& interface : interfaces) {
         mac = interface.hardwareAddress();
         if (mac.size() != 0)
         {

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -163,7 +163,7 @@ QDataStream& operator>>(QDataStream& inStream, Screen& screen)
         ;
 
     screen.m_Modifiers.clear();
-    for (auto mod : modifiers) {
+    for (auto mod : qAsConst(modifiers)) {
         screen.m_Modifiers.push_back(static_cast<Screen::Modifier>(mod));
     }
 

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -84,7 +84,7 @@ void ScreenSetupView::remove(const QModelIndex& index)
     Screen& screen = model()->screen(index);
     if (!screen.isNull()) {
         screen = Screen();
-        emit dataChanged(index, index);
+        dataChanged(index, index);
     }
 }
 

--- a/src/gui/src/SetupWizard.cpp
+++ b/src/gui/src/SetupWizard.cpp
@@ -46,8 +46,8 @@ SetupWizard::SetupWizard(MainWindow& mainWindow, bool startMain) :
 
 #endif
 
-    connect(m_pServerRadioButton, SIGNAL(toggled(bool)), m_MainWindow.m_pGroupServer, SLOT(setChecked(bool)));
-    connect(m_pClientRadioButton, SIGNAL(toggled(bool)), m_MainWindow.m_pGroupClient, SLOT(setChecked(bool)));
+    connect(m_pServerRadioButton, &QRadioButton::toggled, m_MainWindow.m_pGroupServer, &QGroupBox::setChecked);
+    connect(m_pClientRadioButton, &QRadioButton::toggled, m_MainWindow.m_pGroupClient, &QGroupBox::setChecked);
 
     m_Locale.fillLanguageComboBox(m_pComboLanguage);
     setIndexFromItemData(m_pComboLanguage, m_MainWindow.appConfig().language());

--- a/src/gui/src/ZeroconfBrowser.cpp
+++ b/src/gui/src/ZeroconfBrowser.cpp
@@ -39,12 +39,12 @@ void ZeroconfBrowser::browseForType(const QString& type)
         type.toUtf8().constData(), nullptr, browseReply, this);
 
     if (err != kDNSServiceErr_NoError) {
-        emit error(err);
+        Q_EMIT error(err);
     }
     else {
         int sockFD = DNSServiceRefSockFD(m_DnsServiceRef);
         if (sockFD == -1) {
-            emit error(kDNSServiceErr_Invalid);
+            Q_EMIT error(kDNSServiceErr_Invalid);
         }
         else {
             socket_ = std::make_unique<QSocketNotifier>(sockFD, QSocketNotifier::Read, this);
@@ -57,7 +57,7 @@ void ZeroconfBrowser::socketReadyRead()
 {
     DNSServiceErrorType err = DNSServiceProcessResult(m_DnsServiceRef);
     if (err != kDNSServiceErr_NoError) {
-        emit error(err);
+        Q_EMIT error(err);
     }
 }
 
@@ -67,7 +67,7 @@ void ZeroconfBrowser::browseReply(DNSServiceRef, DNSServiceFlags flags,
 {
     ZeroconfBrowser* browser = static_cast<ZeroconfBrowser*>(context);
     if (errorCode != kDNSServiceErr_NoError) {
-        emit browser->error(errorCode);
+        Q_EMIT browser->error(errorCode);
     }
     else {
         ZeroconfRecord record(serviceName, regType, replyDomain);
@@ -80,7 +80,7 @@ void ZeroconfBrowser::browseReply(DNSServiceRef, DNSServiceFlags flags,
             browser->m_Records.removeAll(record);
         }
         if (!(flags & kDNSServiceFlagsMoreComing)) {
-            emit browser->currentRecordsChanged(browser->m_Records);
+            Q_EMIT browser->currentRecordsChanged(browser->m_Records);
         }
     }
 }

--- a/src/gui/src/ZeroconfBrowser.cpp
+++ b/src/gui/src/ZeroconfBrowser.cpp
@@ -48,8 +48,7 @@ void ZeroconfBrowser::browseForType(const QString& type)
         }
         else {
             socket_ = std::make_unique<QSocketNotifier>(sockFD, QSocketNotifier::Read, this);
-            connect(socket_.get(), SIGNAL(activated(int)), this,
-                SLOT(socketReadyRead()));
+            connect(socket_.get(), &QSocketNotifier::activated, this, &ZeroconfBrowser::socketReadyRead);
         }
     }
 }

--- a/src/gui/src/ZeroconfRegister.cpp
+++ b/src/gui/src/ZeroconfRegister.cpp
@@ -56,12 +56,12 @@ void ZeroconfRegister::registerService(const ZeroconfRecord& record,
         nullptr, bigEndianPort, 0, nullptr, registerService, this);
 
     if (err != kDNSServiceErr_NoError) {
-        emit error(err);
+        Q_EMIT error(err);
     }
     else {
         int sockfd = DNSServiceRefSockFD(m_DnsServiceRef);
         if (sockfd == -1) {
-            emit error(kDNSServiceErr_Invalid);
+            Q_EMIT error(kDNSServiceErr_Invalid);
         }
         else {
             socket_ = std::make_unique<QSocketNotifier>(sockfd, QSocketNotifier::Read, this);
@@ -74,7 +74,7 @@ void ZeroconfRegister::socketReadyRead()
 {
     DNSServiceErrorType err = DNSServiceProcessResult(m_DnsServiceRef);
     if (err != kDNSServiceErr_NoError) {
-        emit error(err);
+        Q_EMIT error(err);
     }
 }
 
@@ -88,6 +88,6 @@ void ZeroconfRegister::registerService(DNSServiceRef, DNSServiceFlags,
 
     ZeroconfRegister* serviceRegister = static_cast<ZeroconfRegister*>(data);
     if (errorCode != kDNSServiceErr_NoError) {
-        emit serviceRegister->error(errorCode);
+        Q_EMIT serviceRegister->error(errorCode);
     }
 }

--- a/src/gui/src/ZeroconfRegister.cpp
+++ b/src/gui/src/ZeroconfRegister.cpp
@@ -65,7 +65,7 @@ void ZeroconfRegister::registerService(const ZeroconfRecord& record,
         }
         else {
             socket_ = std::make_unique<QSocketNotifier>(sockfd, QSocketNotifier::Read, this);
-            connect(socket_.get(), SIGNAL(activated(int)), this, SLOT(socketReadyRead()));
+            connect(socket_.get(), &QSocketNotifier::activated, this, &ZeroconfRegister::socketReadyRead);
         }
     }
 }

--- a/src/gui/src/ZeroconfServer.cpp
+++ b/src/gui/src/ZeroconfServer.cpp
@@ -28,6 +28,6 @@ ZeroconfServer::ZeroconfServer(QObject* parent) :
 void ZeroconfServer::incomingConnection(qintptr socketDescriptor)
 {
     ZeroconfThread* thread = new ZeroconfThread(socketDescriptor, this);
-    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+    connect(thread, &ZeroconfThread::finished, thread, &ZeroconfThread::deleteLater);
     thread->start();
 }

--- a/src/gui/src/ZeroconfService.cpp
+++ b/src/gui/src/ZeroconfService.cpp
@@ -84,7 +84,7 @@ ZeroconfService::~ZeroconfService() = default;
 
 void ZeroconfService::serverDetected(const QList<ZeroconfRecord>& list)
 {
-    for (ZeroconfRecord record : list) {
+    for (const ZeroconfRecord& record : list) {
         registerService(false);
         m_pMainWindow->appendLogInfo(tr("zeroconf server detected: %1").arg(
             record.serviceName));
@@ -94,7 +94,7 @@ void ZeroconfService::serverDetected(const QList<ZeroconfRecord>& list)
 
 void ZeroconfService::clientDetected(const QList<ZeroconfRecord>& list)
 {
-    for (ZeroconfRecord record : list) {
+    for (const ZeroconfRecord& record : list) {
         m_pMainWindow->appendLogInfo(tr("zeroconf client detected: %1").arg(
             record.serviceName));
         m_pMainWindow->autoAddScreen(record.serviceName);

--- a/src/gui/src/ZeroconfService.cpp
+++ b/src/gui/src/ZeroconfService.cpp
@@ -67,22 +67,17 @@ ZeroconfService::ZeroconfService(MainWindow* mainWindow) :
     if (m_pMainWindow->app_role() == AppRole::Server) {
         if (registerService(true)) {
             zeroconf_browser_ = std::make_unique<ZeroconfBrowser>(this);
-            connect(zeroconf_browser_.get(), SIGNAL(
-                currentRecordsChanged(const QList<ZeroconfRecord>&)),
-                this, SLOT(clientDetected(const QList<ZeroconfRecord>&)));
+            connect(zeroconf_browser_.get(), &ZeroconfBrowser::currentRecordsChanged, this, &ZeroconfService::clientDetected);
             zeroconf_browser_->browseForType(QLatin1String(m_ClientServiceName));
         }
     }
     else {
         zeroconf_browser_ = std::make_unique<ZeroconfBrowser>(this);
-        connect(zeroconf_browser_.get(), SIGNAL(
-            currentRecordsChanged(const QList<ZeroconfRecord>&)),
-            this, SLOT(serverDetected(const QList<ZeroconfRecord>&)));
+        connect(zeroconf_browser_.get(), &ZeroconfBrowser::currentRecordsChanged, this, &ZeroconfService::serverDetected);
         zeroconf_browser_->browseForType(QLatin1String(m_ServerServiceName));
     }
 
-    connect(zeroconf_browser_.get(), SIGNAL(error(DNSServiceErrorType)),
-        this, SLOT(errorHandle(DNSServiceErrorType)));
+    connect(zeroconf_browser_.get(), &ZeroconfBrowser::error, this, &ZeroconfService::errorHandle);
 }
 
 ZeroconfService::~ZeroconfService() = default;

--- a/src/gui/src/ZeroconfThread.cpp
+++ b/src/gui/src/ZeroconfThread.cpp
@@ -29,7 +29,7 @@ void ZeroconfThread::run()
 {
     QTcpSocket tcpSocket;
     if (!tcpSocket.setSocketDescriptor(m_SocketDescriptor)) {
-        emit error(tcpSocket.error());
+        Q_EMIT error(tcpSocket.error());
         return;
     }
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -54,7 +54,7 @@ bool checkMacAssistiveDevices();
 
 void copy_qsettings(const QSettings &src, QSettings &dst)
 {
-    auto keys = src.allKeys();
+    const auto keys = src.allKeys();
     for (const auto& key : keys) {
         dst.setValue(key, src.value(key));
     }


### PR DESCRIPTION
 - Use Qt5 style connections 
    - Old SIGNAL / SLOT macros are slower and more error prone 
 - Use `const &` for current item and a `const list` for input to all ranged for loops to prevent detachment
 - Use `Q_EMIT` in place of `emit` emitting a signal (added a few missing ones also ) 