### PR TITLE
Increase the max corner size to 9999

### DIFF
--- a/doc/newsfragments/159-fix-corner-size-value.bugfix
+++ b/doc/newsfragments/159-fix-corner-size-value.bugfix
@@ -1,0 +1,4 @@
+Solve Issue 159:
+  Corner Size GUI should allow higher value than 99(https://github.com/input-leap/input-leap/issues/159)
+
+Changes the maximum corner size to 9999

--- a/src/gui/src/ServerConfigDialogBase.ui
+++ b/src/gui/src/ServerConfigDialogBase.ui
@@ -659,7 +659,11 @@ Double click on a screen to edit its settings.</string>
              </widget>
             </item>
             <item>
-             <widget class="QSpinBox" name="m_pSpinBoxSwitchCornerSize"/>
+             <widget class="QSpinBox" name="m_pSpinBoxSwitchCornerSize">
+              <property name="maximum">
+               <number>9999</number>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
Fixes #159
 - Increases the max corner size to 9999.

## Contributor Checklist:

* [X] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
