### PR TITLE
Set initial tab to 0 on ServerConfigDialog window

### DIFF
--- a/doc/newsfragments/server-config-dialog-starting-tab-screen.bugfix
+++ b/doc/newsfragments/server-config-dialog-starting-tab-screen.bugfix
@@ -1,0 +1,1 @@
+Set the server configuration dialog's initial tab to screens

--- a/src/gui/src/ServerConfigDialogBase.ui
+++ b/src/gui/src/ServerConfigDialogBase.ui
@@ -16,9 +16,6 @@
   <layout class="QVBoxLayout">
    <item>
     <widget class="QTabWidget" name="m_pTabWidget">
-     <property name="currentIndex">
-      <number>2</number>
-     </property>
      <widget class="QWidget" name="m_pTabScreens">
       <attribute name="title">
        <string>Screens and links</string>


### PR DESCRIPTION
Set initial tab to 0 on ServerConfigDialog window

Change the Server Configuration Dialog, so it opens with the Screens
tab, as opposed to the Advanced tab.

## Contributor Checklist:

* [X] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
