### PR TITLE
fix(gui/$DISPLAY): Add guard to X11/XWayland `$DISPLAY` check

### DIFF
--- a/src/gui/src/DisplayIsValid.cpp
+++ b/src/gui/src/DisplayIsValid.cpp
@@ -1,4 +1,4 @@
-#ifdef WINAPI_XWINDOWS
+#if (defined(WINAPI_XWINDOWS) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS)))
 
 #include "DisplayIsValid.h"
 #include <X11/Xlib.h>

--- a/src/gui/src/DisplayIsValid.h
+++ b/src/gui/src/DisplayIsValid.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#ifdef WINAPI_XWINDOWS
+#if (defined(WINAPI_XWINDOWS) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS)))
 bool display_is_valid();
 #endif

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -63,7 +63,7 @@ void copy_qsettings(const QSettings &src, QSettings &dst)
 
 int main(int argc, char* argv[])
 {
-#ifdef WINAPI_XWINDOWS
+#if (defined(WINAPI_XWINDOWS) && (!defined(HAVE_LIBPORTAL_INPUTCAPTURE) || !defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS)))
     // QApplication's constructor will call a fscking abort() if
     // DISPLAY is bad. Let's check it first and handle it gracefully
     if (!display_is_valid()) {


### PR DESCRIPTION
As reported in #1792, a bug has been noticed where Input Leap GUI
doesn't recognise 'libportal' support as being present on the system,
and thus refuses to start.

This is a compile-time guard, so it's not checked at run-time.

In future, I will refactor this check to be optional (enabled by
default, adjustable by CMake option), and to simply probe libportal
and/or X11 safely, to ascertain whenever it needs the `$DISPLAY`
variable. It is not a perfect fix, and we should look to refactor.

Fixes #1792.
Closes #1800 - this PR and #1800 are mutually exclusive, and only one is
needed at this point. Both address #1792, but I've approached the
problem from two different perspectives.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
