### PR TITLE
Log window fixes (solution for issue 1717)

### DIFF
--- a/doc/newsfragments/LogWindow.bugfix
+++ b/doc/newsfragments/LogWindow.bugfix
@@ -1,0 +1,1 @@
+Use a buffer to dramatically lower CPU use of log window.  Limit log window to 10,000 lines to prevent RAM use from constantly increasing. 

--- a/src/gui/src/LogWindow.cpp
+++ b/src/gui/src/LogWindow.cpp
@@ -66,12 +66,6 @@ void LogWindow::appendError(const QString& text)
 void LogWindow::appendRaw(const QString& text)
 {
     buffer += text + '\n';
-
-    // Truncate the buffer if it exceeds the maximum size
-    if (buffer.size() > maxBufferSize)
-    {
-        buffer = buffer.right(maxBufferSize);
-    }
 }
 
 void LogWindow::flushBuffer()

--- a/src/gui/src/LogWindow.h
+++ b/src/gui/src/LogWindow.h
@@ -36,7 +36,10 @@ class LogWindow : public QDialog, public Ui::LogWindowBase
         void appendInfo(const QString& text);
         void appendDebug(const QString& text);
         void appendError(const QString& text);
-
+        QString buffer;
+        int maxBufferSize = 1024;
+        void flushBuffer();
+    
     private slots:
         void on_m_pButtonHide_clicked();
         void on_m_pButtonClearLog_clicked();

--- a/src/gui/src/LogWindow.h
+++ b/src/gui/src/LogWindow.h
@@ -37,7 +37,6 @@ class LogWindow : public QDialog, public Ui::LogWindowBase
         void appendDebug(const QString& text);
         void appendError(const QString& text);
         QString buffer;
-        int maxBufferSize = 1024;
         void flushBuffer();
     
     private slots:

--- a/src/gui/src/LogWindowBase.ui
+++ b/src/gui/src/LogWindowBase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>996</width>
     <height>371</height>
    </rect>
   </property>
@@ -27,7 +27,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QTextEdit" name="m_pLogOutput">
+    <widget class="QPlainTextEdit" name="m_pLogOutput">
      <property name="font">
       <font>
        <family>Courier</family>
@@ -40,7 +40,7 @@
       <bool>false</bool>
      </property>
      <property name="lineWrapMode">
-       <enum>QTextEdit::NoWrap</enum>
+      <enum>QPlainTextEdit::NoWrap</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>
@@ -83,4 +83,6 @@
    </item>
   </layout>
  </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/src/gui/src/LogWindowBase.ui
+++ b/src/gui/src/LogWindowBase.ui
@@ -45,6 +45,9 @@
      <property name="readOnly">
       <bool>true</bool>
      </property>
+     <property name="maximumBlockCount">
+      <number>10000</number>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Used a buffer written to screen every 100ms to dramatically lower CPU use of log window.  
Limit log window to 10,000 lines to prevent RAM use from constantly increasing. 

Proposed fix for https://github.com/input-leap/input-leap/issues/1717