### PR TITLE
do not require gtest dependency if building without tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,8 @@ if (WIN32)
     add_subdirectory(daemon)
 endif()
 
-include(../cmake/gtest.cmake)
-
 if(INPUTLEAP_BUILD_TESTS)
+    include(../cmake/gtest.cmake)
     add_subdirectory(test/integtests)
     add_subdirectory(test/unittests)
 endif()


### PR DESCRIPTION
Remove dependency on gtest if tests are disabled (INPUTLEAP_BUILD_TESTS set to OFF)

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
