### PR TITLE
Require Cmake 3.21

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -48,6 +48,34 @@ jobs:
     steps:
 
       # Preparation steps
+      - name: preinstall depends
+        run: |
+          apt-get update -y
+          # software-properties-common is needed for add-apt-repository
+          apt-get install -y software-properties-common gpg wget
+
+      - if: matrix.os == 'ubuntu:20.04'
+        name: Add repositories with newer git and cmake
+        run: |
+          # InputLeap requires at least CMake 3.21.
+          # This mirrors instructions at https://apt.kitware.com
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+            | gpg --dearmor - \
+            > /usr/share/keyrings/kitware-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' \
+            > /etc/apt/sources.list.d/kitware.list
+
+      - if: matrix.os == 'ubuntu:22.04'
+        name: Add repositories with newer git and cmake
+        run: |
+          # InputLeap requires at least CMake 3.21.
+          # This mirrors instructions at https://apt.kitware.com
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+            | gpg --dearmor - \
+            > /usr/share/keyrings/kitware-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+            > /etc/apt/sources.list.d/kitware.list
+
       - name: Update image and install pre-reqs
         run: |
           apt-get update -y

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.21)
 project(InputLeap C CXX)
 
 option(INPUTLEAP_BUILD_GUI "Build the GUI" ON)


### PR DESCRIPTION
Split from #1715 
Bump The required cmake version to 3.21

This is wanted to avoid a possible issue linking OpenSSL 3.0+ in some cases.

