### PR TITLE
Fix clipboard sharing settings in GUI

### DIFF
--- a/doc/newsfragments/1789_fix_clipboard_sharing_toggle.bugfix
+++ b/doc/newsfragments/1789_fix_clipboard_sharing_toggle.bugfix
@@ -1,0 +1,1 @@
+Fixed clipboard sharing toggle in GUI (https://github.com/input-leap/input-leap/issues/1789)

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -259,6 +259,7 @@ QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
     outStream << "\t" << "screenSaverSync = " << (config.screenSaverSync() ? "true" : "false") << "\n";
     outStream << "\t" << "win32KeepForeground = " << (config.win32KeepForeground() ? "true" : "false") << "\n";
     outStream << "\t" << "clipboardSharing = " << (config.clipboardSharing() ? "true" : "false") << "\n";
+    outStream << "\t" << "clipboardSharingSize = " << config.clipboardSharingSize() << "\n";
 
     if (config.hasSwitchDelay())
         outStream << "\t" << "switchDelay = " << config.switchDelay() << "\n";
@@ -423,11 +424,6 @@ size_t ServerConfig::defaultClipboardSharingSize() {
 }
 
 size_t ServerConfig::setClipboardSharingSize(size_t size) {
-    if (size) {
-        setClipboardSharing(true);
-    } else {
-        setClipboardSharing(false);
-    }
     using std::swap;
     swap (size, m_ClipboardSharingSize);
     return size;

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -230,3 +230,8 @@ void ServerConfigDialog::on_m_pListActions_itemSelectionChanged()
     m_pButtonEditAction->setEnabled(!m_pListActions->selectedItems().isEmpty());
     m_pButtonRemoveAction->setEnabled(!m_pListActions->selectedItems().isEmpty());
 }
+
+void ServerConfigDialog::on_m_pCheckBoxEnableClipboard_stateChanged(int state)
+{
+    m_pSpinBoxClipboardSizeLimit->setEnabled(state == Qt::Checked);
+}

--- a/src/gui/src/ServerConfigDialog.h
+++ b/src/gui/src/ServerConfigDialog.h
@@ -49,6 +49,7 @@ class ServerConfigDialog : public QDialog, public Ui::ServerConfigDialogBase
         void on_m_pListActions_itemSelectionChanged();
         void on_m_pButtonEditAction_clicked();
         void on_m_pButtonRemoveAction_clicked();
+        void on_m_pCheckBoxEnableClipboard_stateChanged(int state);
 
     protected:
         ServerConfig& serverConfig() { return m_ServerConfig; }


### PR DESCRIPTION
Fixed clipboard sharing toggle in GUI (https://github.com/input-leap/input-leap/issues/1789)

1. Do not turn on clipboard sharing if clipboard sharing is unchecked, even if the clipboard size limit is above 0
2. Save clipboard size limit to generated server configuration file
3. Enable clipboard size spinbox based on clipboard sharing checkbox

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
