### PR TITLE
Code cleanup: AboutDialog

### DIFF
--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -1,5 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023-2024 InputLeap Developers
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
  *

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -20,8 +20,6 @@
 #include "AboutDialog.h"
 #include "ui_AboutDialog.h"
 
-#include <QtCore>
-#include <QtGui>
 #include "common/Version.h"
 
 AboutDialog::AboutDialog(QWidget* parent, const QString& app_name) :

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -32,19 +32,7 @@ AboutDialog::AboutDialog(QWidget* parent, const QString& app_name) :
     version.append(QStringLiteral("-%1").arg(INPUTLEAP_REVISION));
 #endif
     ui_->m_pLabelAppVersion->setText(version);
-
-	// change default size based on os
-#if defined(Q_OS_MAC)
-	QSize size(600, 380);
-	setMaximumSize(size);
-	setMinimumSize(size);
-	resize(size);
-#elif defined(Q_OS_LINUX)
-	QSize size(600, 330);
-	setMaximumSize(size);
-	setMinimumSize(size);
-	resize(size);
-#endif
+    setFixedSize(sizeHint());
 }
 
 AboutDialog::~AboutDialog() = default;

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -27,12 +27,9 @@ AboutDialog::AboutDialog(QWidget* parent, const QString& app_name) :
     ui_{std::make_unique<Ui::AboutDialog>()}
 {
     ui_->setupUi(this);
-
-    QString version = kVersion;
-    version = version + '-' + INPUTLEAP_VERSION_STAGE;
+    QString version = QStringLiteral("%1-%2").arg(kVersion, INPUTLEAP_VERSION_STAGE);
 #ifdef INPUTLEAP_REVISION
-    version +=  '-';
-    version += INPUTLEAP_REVISION;
+    version.append(QStringLiteral("-%1").arg(INPUTLEAP_REVISION));
 #endif
     ui_->m_pLabelAppVersion->setText(version);
 

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -32,6 +32,12 @@ AboutDialog::AboutDialog(QWidget* parent, const QString& app_name) :
     version.append(QStringLiteral("-%1").arg(INPUTLEAP_REVISION));
 #endif
     ui_->m_pLabelAppVersion->setText(version);
+    const int scaled_logo_height = sizeHint().width() <= 300 ? 45 : 90;
+    const QPixmap scaled_logo = QPixmap(":/res/image/about.png")
+                 .scaled(QSize(sizeHint().width(), scaled_logo_height),
+                         Qt::KeepAspectRatio, Qt::SmoothTransformation
+    );
+    ui_->logoLabel->setPixmap(scaled_logo);
     setFixedSize(sizeHint());
 }
 

--- a/src/gui/src/AboutDialog.h
+++ b/src/gui/src/AboutDialog.h
@@ -1,5 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023-2024 InputLeap Developers
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
  *

--- a/src/gui/src/AboutDialog.h
+++ b/src/gui/src/AboutDialog.h
@@ -27,9 +27,6 @@ namespace Ui
     class AboutDialog;
 }
 
-class QWidget;
-class QString;
-
 class AboutDialog : public QDialog
 {
     Q_OBJECT

--- a/src/gui/src/AboutDialog.ui
+++ b/src/gui/src/AboutDialog.ui
@@ -12,8 +12,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>450</width>
-    <height>300</height>
+    <width>0</width>
+    <height>0</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -21,18 +21,6 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>450</width>
-    <height>300</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>450</width>
-    <height>300</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>About InputLeap</string>
@@ -77,7 +65,7 @@ The InputLeap GUI is based on QSynergy by Volker Lanz.
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>100</height>
+       <height>50</height>
       </size>
      </property>
     </spacer>

--- a/src/gui/src/AboutDialog.ui
+++ b/src/gui/src/AboutDialog.ui
@@ -52,6 +52,7 @@
      <property name="text">
       <string>&lt;p&gt;
 Keyboard and mouse sharing application. Cross platform and open source.&lt;br /&gt;&lt;br /&gt;
+Copyright © 2022-2024 InputLeap Developers&lt;br /&gt;
 Copyright © 2018 Debauchee Open Source Group&lt;br /&gt;
 Copyright © 2012-2016 Symless Ltd.&lt;br /&gt;
 Copyright © 2002-2012 Chris Schoeneman, Nick Bolton, Volker Lanz.&lt;br /&gt;&lt;br /&gt;

--- a/src/gui/src/AboutDialog.ui
+++ b/src/gui/src/AboutDialog.ui
@@ -71,15 +71,12 @@ The InputLeap GUI is based on QSynergy by Volker Lanz.
     </spacer>
    </item>
    <item row="0" column="1">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="pixmap">
-      <pixmap resource="../res/InputLeap.qrc">:/res/image/about.png</pixmap>
-     </property>
-     <property name="margin">
-      <number>0</number>
+    <widget class="QLabel" name="logoLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
About Dialog
 - Add an `Input Leap Developers` line to the copyright of the object files
 - Allow it to size itself
 - Allow the  the logo scale upto 2x
 - Remove unneeded includes 
 - Use Arg substitution to create the version string displayed 
 - Use `#pragma once`
 