### PR TITLE
PortalInputCapture: Change `NULL` to `nullptr`

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -195,7 +195,7 @@ void PortalInputCapture::cb_set_pointer_barriers(GObject* object, GAsyncResult* 
                 if (*elem == it->data) {
                     int x1, x2, y1, y2;
 
-                    g_object_get(G_OBJECT(*elem), "x1", &x1, "x2", &x2, "y1", &y1, "y2", &y2, NULL);
+                    g_object_get(G_OBJECT(*elem), "x1", &x1, "x2", &x2, "y1", &y1, "y2", &y2, nullptr);
 
                     LOG((CLOG_WARN "Failed to apply barrier %d (%d/%d-%d/%d)", id, x1, y1, x2, y2));
                     g_object_unref(*elem);


### PR DESCRIPTION
To adhere to the existing unspoken code style in Input Leap, I've
changed the `NULL` argument to `nullptr`.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

## Contributor Checklist:

This isn't a user-visible change, so I didn't create a newsfragment.

<del>* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory)</del>
