### PR TITLE
fix(wayland-warn): Make Wayland warning a compile-time option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ option(INPUTLEAP_USE_EXTERNAL_GTEST "Use external installation of Google Test fr
 option(INPUTLEAP_BUILD_X11 "Build with XWindows support" ON)
 option(INPUTLEAP_BUILD_LIBEI "Build with libei support" OFF)
 option(INPUTLEAP_DEPLOY_FLATPAK_SCRIPT "Deploy Flatpak script [Experimental]" OFF)
+option(INPUTLEAP_WAYLAND_WARN_USER "Warn upon GUI start about Wayland support" ON)
+
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CXX_EXTENSIONS OFF)
@@ -207,6 +209,10 @@ if (UNIX)
                         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
                 )
             endif()
+        endif()
+
+        if (INPUTLEAP_WAYLAND_WARN_USER AND (BUILD_XWINDOWS OR BUILD_LIBEI))
+            add_definitions(-DINPUTLEAP_WAYLAND_WARN_USER=1)
         endif()
 
         check_include_files ("dns_sd.h" HAVE_DNSSD)

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -62,9 +62,7 @@ void copy_qsettings(const QSettings &src, QSettings &dst)
 
 int main(int argc, char* argv[])
 {
-#if (defined(WINAPI_XWINDOWS) || \
-    (defined(HAVE_LIBPORTAL_INPUTCAPTURE) || \
-    defined(HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS)))
+#ifdef INPUTLEAP_WAYLAND_WARN_USER
     const auto platformType = QGuiApplication::platformName();
 
     if (platformType == "xcb") {


### PR DESCRIPTION
Tweak the GUI startup warning regarding Wayland to be a compile-time
flag. This is enabled by default, but can be disabled.

I've made this PR a draft, as I'm going to add a newsfragment. I'll do that
shortly, then remove this paragraph with `<del>`.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
