### PR TITLE
gui: ActionDialog, overhaul UX

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -53,10 +53,7 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
     ui_->m_pComboSwitchInDirection->setCurrentIndex(action_.switchDirection());
     ui_->m_pComboLockCursorToScreen->setCurrentIndex(action_.lockCursorMode());
 
-    if (action_.activeOnRelease())
-        ui_->m_pRadioHotkeyReleased->setChecked(true);
-    else
-        ui_->m_pRadioHotkeyPressed->setChecked(true);
+    ui_->comboTriggerOn->setCurrentIndex(action_.activeOnRelease());
 
     ui_->m_pGroupBoxScreens->setChecked(action_.haveScreens());
 
@@ -94,7 +91,7 @@ void ActionDialog::accept()
     action_.setSwitchScreenName(ui_->m_pComboSwitchToScreen->currentText());
     action_.setSwitchDirection(ui_->m_pComboSwitchInDirection->currentIndex());
     action_.setLockCursorMode(ui_->m_pComboLockCursorToScreen->currentIndex());
-    action_.setActiveOnRelease(ui_->m_pRadioHotkeyReleased->isChecked());
+    action_.setActiveOnRelease(ui_->comboTriggerOn->currentIndex());
 
     QDialog::accept();
 }

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -25,31 +25,21 @@
 #include "ServerConfig.h"
 #include "KeySequence.h"
 
-#include <QButtonGroup>
-
 ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& hotkey, Action& action) :
     QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
     ui_{std::make_unique<Ui::ActionDialog>()},
     hotkey_(hotkey),
-    action_(action),
-    button_group_type_(new QButtonGroup(this))
+    action_(action)
 {
     ui_->setupUi(this);
     connect(ui_->keySequenceWidget, &KeySequenceWidget::keySequenceChanged, this, &ActionDialog::key_sequence_changed);
+    connect(ui_->comboActionType, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ActionDialog::actionTypeChanged);
     connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &ActionDialog::accept);
     connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &ActionDialog::reject);
-
-    // work around Qt Designer's lack of a QButtonGroup; we need it to get
-    // at the button id of the checked radio button
-    QRadioButton* const typeButtons[] = { ui_->m_pRadioPress, ui_->m_pRadioRelease, ui_->m_pRadioPressAndRelease, ui_->m_pRadioSwitchToScreen, ui_->m_pRadioToggleScreen, ui_->m_pRadioSwitchInDirection, ui_->m_pRadioLockCursorToScreen };
-
-    for (unsigned int i = 0; i < sizeof(typeButtons) / sizeof(typeButtons[0]); i++)
-        button_group_type_->addButton(typeButtons[i], i);
 
     ui_->keySequenceWidget->setText(action_.keySequence().toString());
     ui_->keySequenceWidget->setKeySequence(action_.keySequence());
 
-    button_group_type_->button(action_.type())->setChecked(true);
     ui_->m_pComboSwitchInDirection->setCurrentIndex(action_.switchDirection());
     ui_->m_pComboLockCursorToScreen->setCurrentIndex(action_.lockCursorMode());
 
@@ -73,13 +63,13 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
 
 void ActionDialog::accept()
 {
-    if (!ui_->keySequenceWidget->valid() && button_group_type_->checkedId() >= 0 &&
-            button_group_type_->checkedId() < 3) {
+    if (!ui_->keySequenceWidget->valid() && ui_->comboActionType->currentIndex() >= 0 &&
+            ui_->comboActionType->currentIndex() < 3) {
         return;
     }
 
     action_.setKeySequence(ui_->keySequenceWidget->keySequence());
-    action_.setType(button_group_type_->checkedId());
+    action_.setType(ui_->comboActionType->currentIndex());
     action_.setHaveScreens(ui_->m_pGroupBoxScreens->isChecked());
 
     action_.clearTypeScreenNames();
@@ -100,6 +90,20 @@ void ActionDialog::key_sequence_changed()
 {
     ui_->m_pGroupBoxScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
     ui_->m_pListScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
+}
+
+void ActionDialog::actionTypeChanged(int index)
+{
+    ui_->keySequenceWidget->setEnabled(isKeyAction(index));
+    ui_->m_pListScreens->setEnabled(isKeyAction(index) && ui_->m_pGroupBoxScreens->isChecked());
+    ui_->m_pComboSwitchToScreen->setEnabled(index == ACTIONTYPES::ACTION_SWITCH_TO);
+    ui_->m_pComboSwitchInDirection->setEnabled(index == ACTIONTYPES::ACTION_SWITCH_IN_DIR);
+    ui_->m_pComboLockCursorToScreen->setEnabled(index == ACTIONTYPES::ACTION_MODIFY_CURSOR_LOCK);
+}
+
+bool ActionDialog::isKeyAction(int index)
+{
+    return ((index == ACTIONTYPES::ACTION_PRESS_KEY) || (index == ACTIONTYPES::ACTION_RELEASE_KEY) || (index == ACTIONTYPES::ACTION_TOGGLE_KEY));
 }
 
 ActionDialog::~ActionDialog() = default;

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -98,10 +98,12 @@ void ActionDialog::accept()
 void ActionDialog::key_sequence_changed()
 {
     ui_->listScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
+    ui_->buttonBox->button(QDialogButtonBox::Ok)->setEnabled((ui_->keySequenceWidget->valid() && isKeyAction(ui_->comboActionType->currentIndex())) || isKeyAction(ui_->comboActionType->currentIndex()));
 }
 
 void ActionDialog::actionTypeChanged(int index)
 {
+    ui_->buttonBox->button(QDialogButtonBox::Ok)->setEnabled((ui_->keySequenceWidget->valid() && isKeyAction(index)) || !isKeyAction(index));
     ui_->keySequenceWidget->setVisible(isKeyAction(index));
     ui_->group_screens->setVisible(isKeyAction(index));
     ui_->listScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -40,8 +40,8 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
     ui_->keySequenceWidget->setText(action_.keySequence().toString());
     ui_->keySequenceWidget->setKeySequence(action_.keySequence());
 
-    ui_->m_pComboSwitchInDirection->setCurrentIndex(action_.switchDirection());
-    ui_->m_pComboLockCursorToScreen->setCurrentIndex(action_.lockCursorMode());
+    ui_->comboSwitchInDirection->setCurrentIndex(action_.switchDirection());
+    ui_->comboLockCursorToScreen->setCurrentIndex(action_.lockCursorMode());
 
     ui_->comboTriggerOn->setCurrentIndex(action_.activeOnRelease());
 
@@ -53,11 +53,16 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
         if (action_.typeScreenNames().indexOf(screen.name()) != -1)
             newListItem->setCheckState(Qt::Unchecked);
         ui_->listScreens->addItem(newListItem);
-        ui_->m_pComboSwitchToScreen->addItem(screen.name());
+        ui_->comboSwitchToScreen->addItem(tr("Switch to %1").arg(screen.name()));
         if(screen.name() == action.switchScreenName())
-            ui_->m_pComboSwitchToScreen->setCurrentIndex(ui_->m_pComboSwitchToScreen->count() - 1);
+            ui_->comboSwitchToScreen->setCurrentIndex(ui_->comboSwitchToScreen->count() - 1);
     }
-
+    ui_->keySequenceWidget->setVisible(false);
+    ui_->group_screens->setVisible(false);
+    ui_->listScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
+    ui_->comboSwitchToScreen->setVisible(false);
+    ui_->comboSwitchInDirection->setVisible(false);
+    ui_->comboLockCursorToScreen->setVisible(false);
 }
 
 void ActionDialog::accept()
@@ -82,9 +87,9 @@ void ActionDialog::accept()
     action_.setHaveScreens(screenCount);
 
 
-    action_.setSwitchScreenName(ui_->m_pComboSwitchToScreen->currentText());
-    action_.setSwitchDirection(ui_->m_pComboSwitchInDirection->currentIndex());
-    action_.setLockCursorMode(ui_->m_pComboLockCursorToScreen->currentIndex());
+    action_.setSwitchScreenName(ui_->comboSwitchToScreen->currentText().remove(tr("Switch to ")));
+    action_.setSwitchDirection(ui_->comboSwitchInDirection->currentIndex());
+    action_.setLockCursorMode(ui_->comboLockCursorToScreen->currentIndex());
     action_.setActiveOnRelease(ui_->comboTriggerOn->currentIndex());
 
     QDialog::accept();
@@ -92,16 +97,18 @@ void ActionDialog::accept()
 
 void ActionDialog::key_sequence_changed()
 {
-    ui_->listScreens->setEnabled(ui_->keySequenceWidget->valid() && !ui_->keySequenceWidget->keySequence().isMouseButton());
+    ui_->listScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
 }
 
 void ActionDialog::actionTypeChanged(int index)
 {
-    ui_->keySequenceWidget->setEnabled(isKeyAction(index));
-    ui_->listScreens->setEnabled(isKeyAction(index));
-    ui_->m_pComboSwitchToScreen->setEnabled(index == ACTIONTYPES::ACTION_SWITCH_TO);
-    ui_->m_pComboSwitchInDirection->setEnabled(index == ACTIONTYPES::ACTION_SWITCH_IN_DIR);
-    ui_->m_pComboLockCursorToScreen->setEnabled(index == ACTIONTYPES::ACTION_MODIFY_CURSOR_LOCK);
+    ui_->keySequenceWidget->setVisible(isKeyAction(index));
+    ui_->group_screens->setVisible(isKeyAction(index));
+    ui_->listScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
+    ui_->comboSwitchToScreen->setVisible(index == ACTIONTYPES::ACTION_SWITCH_TO);
+    ui_->comboSwitchInDirection->setVisible(index == ACTIONTYPES::ACTION_SWITCH_IN_DIR);
+    ui_->comboLockCursorToScreen->setVisible(index == ACTIONTYPES::ACTION_MODIFY_CURSOR_LOCK);
+    adjustSize();
 }
 
 bool ActionDialog::isKeyAction(int index)
@@ -110,4 +117,3 @@ bool ActionDialog::isKeyAction(int index)
 }
 
 ActionDialog::~ActionDialog() = default;
-

--- a/src/gui/src/ActionDialog.h
+++ b/src/gui/src/ActionDialog.h
@@ -24,7 +24,6 @@
 
 class Hotkey;
 class Action;
-class QButtonGroup;
 class ServerConfig;
 
 namespace Ui
@@ -37,6 +36,15 @@ class ActionDialog : public QDialog
     Q_OBJECT
 
     public:
+        enum ACTIONTYPES {
+            ACTION_PRESS_KEY,
+            ACTION_RELEASE_KEY,
+            ACTION_TOGGLE_KEY,
+            ACTION_SWITCH_TO,
+            ACTION_NEXT_SCREEN,
+            ACTION_SWITCH_IN_DIR,
+            ACTION_MODIFY_CURSOR_LOCK
+        };
         ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& hotkey, Action& action);
         ~ActionDialog() override;
 
@@ -49,5 +57,6 @@ class ActionDialog : public QDialog
         std::unique_ptr<Ui::ActionDialog> ui_;
         Hotkey& hotkey_;
         Action& action_;
-        QButtonGroup* button_group_type_;
+        void actionTypeChanged(int index);
+        bool isKeyAction(int index);
 };

--- a/src/gui/src/ActionDialog.ui
+++ b/src/gui/src/ActionDialog.ui
@@ -6,14 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>372</width>
-    <height>484</height>
+    <width>304</width>
+    <height>441</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configure Action</string>
   </property>
-  <layout class="QVBoxLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QComboBox" name="comboTriggerOn">
+     <item>
+      <property name="text">
+       <string>When the hotkey is pressed</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>When the hotkey is released</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="m_pGroupType">
      <property name="title">
@@ -254,32 +268,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>This action is performed when</string>
-     </property>
-     <layout class="QHBoxLayout">
-      <item>
-       <widget class="QRadioButton" name="m_pRadioHotkeyPressed">
-        <property name="text">
-         <string>the hotkey is pressed</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_pRadioHotkeyReleased">
-        <property name="text">
-         <string>the hotkey is released</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -300,102 +288,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>m_pGroupType</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>104</x>
-     <y>194</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>110</x>
-     <y>132</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchInDirection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>118</x>
-     <y>322</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>81</x>
-     <y>129</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioLockCursorToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>101</x>
-     <y>353</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>68</x>
-     <y>126</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPress</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>48</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>45</x>
-     <y>129</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>135</x>
-     <y>70</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>148</x>
-     <y>125</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPressAndRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>194</x>
-     <y>100</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>201</x>
-     <y>125</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>m_pRadioSwitchToScreen</sender>
    <signal>toggled(bool)</signal>
@@ -537,22 +429,6 @@
     <hint type="destinationlabel">
      <x>79</x>
      <y>234</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>84</x>
-     <y>280</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>185</x>
-     <y>123</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/src/ActionDialog.ui
+++ b/src/gui/src/ActionDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>304</width>
-    <height>344</height>
+    <width>393</width>
+    <height>314</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,40 +97,18 @@
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="m_pGroupBoxScreens">
+       <widget class="QGroupBox" name="group_screens">
         <property name="title">
-         <string>only on these screens</string>
+         <string>Screens to recieve the keystroke</string>
         </property>
-        <property name="flat">
-         <bool>true</bool>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <layout class="QHBoxLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QListWidget" name="m_pListScreens">
-           <property name="minimumSize">
-            <size>
-             <width>128</width>
-             <height>64</height>
-            </size>
+          <widget class="QListWidget" name="listScreens">
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::AdjustToContents</enum>
            </property>
            <property name="selectionMode">
-            <enum>QAbstractItemView::ExtendedSelection</enum>
+            <enum>QAbstractItemView::NoSelection</enum>
            </property>
           </widget>
          </item>

--- a/src/gui/src/ActionDialog.ui
+++ b/src/gui/src/ActionDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>304</width>
-    <height>441</height>
+    <height>344</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,49 +15,68 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QComboBox" name="comboTriggerOn">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
-      <property name="text">
-       <string>When the hotkey is pressed</string>
-      </property>
+      <widget class="QComboBox" name="comboTriggerOn">
+       <item>
+        <property name="text">
+         <string>When the hotkey is pressed</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>When the hotkey is released</string>
+        </property>
+       </item>
+      </widget>
      </item>
      <item>
-      <property name="text">
-       <string>When the hotkey is released</string>
-      </property>
+      <widget class="QComboBox" name="comboActionType">
+       <item>
+        <property name="text">
+         <string>Press a key</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Release a key</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Toggle a key</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Switch to a specific screen</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Switch to the next screen</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Switch to the screen in a direction</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Modify the cursor lock</string>
+        </property>
+       </item>
+      </widget>
      </item>
-    </widget>
+    </layout>
    </item>
    <item>
     <widget class="QGroupBox" name="m_pGroupType">
      <property name="title">
-      <string>Choose the action to perform</string>
+      <string/>
      </property>
      <layout class="QVBoxLayout">
-      <item>
-       <widget class="QRadioButton" name="m_pRadioPress">
-        <property name="text">
-         <string>Press a hotkey</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_pRadioRelease">
-        <property name="text">
-         <string>Release a hotkey</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_pRadioPressAndRelease">
-        <property name="text">
-         <string>Press and release a hotkey</string>
-        </property>
-       </widget>
-      </item>
       <item>
        <widget class="KeySequenceWidget" name="keySequenceWidget">
         <property name="sizePolicy">
@@ -128,9 +147,9 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QRadioButton" name="m_pRadioSwitchToScreen">
+         <widget class="QLabel" name="label">
           <property name="text">
-           <string>Switch to screen</string>
+           <string>Switch to</string>
           </property>
          </widget>
         </item>
@@ -159,20 +178,9 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QRadioButton" name="m_pRadioToggleScreen">
+         <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Toggle screen</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QRadioButton" name="m_pRadioSwitchInDirection">
-          <property name="text">
-           <string>Switch in direction</string>
+           <string>Direction to move</string>
           </property>
          </widget>
         </item>
@@ -221,9 +229,9 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QRadioButton" name="m_pRadioLockCursorToScreen">
+         <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>Lock cursor to screen</string>
+           <string>Cursor lock will</string>
           </property>
          </widget>
         </item>
@@ -287,150 +295,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>m_pRadioSwitchToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pComboSwitchToScreen</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>148</x>
-     <y>291</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>290</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchInDirection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pComboSwitchInDirection</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>158</x>
-     <y>322</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>321</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioLockCursorToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pComboLockCursorToScreen</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>180</x>
-     <y>353</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>352</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPress</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>25</x>
-     <y>47</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>33</x>
-     <y>155</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>278</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>98</x>
-     <y>153</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>264</x>
-     <y>67</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>241</x>
-     <y>158</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPressAndRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>286</x>
-     <y>98</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>290</x>
-     <y>156</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchInDirection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>38</x>
-     <y>313</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>64</x>
-     <y>195</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioLockCursorToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>339</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>79</x>
-     <y>234</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/gui/src/ActionDialog.ui
+++ b/src/gui/src/ActionDialog.ui
@@ -6,18 +6,33 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>393</width>
-    <height>314</height>
+    <width>0</width>
+    <height>0</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Configure Action</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QComboBox" name="comboTriggerOn">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
          <string>When the hotkey is pressed</string>
@@ -32,6 +47,12 @@
      </item>
      <item>
       <widget class="QComboBox" name="comboActionType">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
          <string>Press a key</string>
@@ -72,183 +93,126 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="m_pGroupType">
-     <property name="title">
-      <string/>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QComboBox" name="comboSwitchToScreen">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboSwitchInDirection">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Move to the screen on the left</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Move to the screen on the right</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Move to the screen above</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Move to the screen below</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboLockCursorToScreen">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Toggle the Cursor Lock</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Enable the cursor lock</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Disable the cursor lock</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="KeySequenceWidget" name="keySequenceWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="group_screens">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QVBoxLayout">
+     <property name="title">
+      <string>Screens to recieve the keystroke</string>
+     </property>
+     <layout class="QHBoxLayout">
       <item>
-       <widget class="KeySequenceWidget" name="keySequenceWidget">
+       <widget class="QListWidget" name="listScreens">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>1</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="minimumSize">
+        <property name="maximumSize">
          <size>
-          <width>256</width>
-          <height>0</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
-        <property name="text">
-         <string/>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::NoSelection</enum>
+        </property>
+        <property name="sortingEnabled">
+         <bool>false</bool>
         </property>
        </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="group_screens">
-        <property name="title">
-         <string>Screens to recieve the keystroke</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="QListWidget" name="listScreens">
-           <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustToContents</enum>
-           </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::NoSelection</enum>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Switch to</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_pComboSwitchToScreen">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Direction to move</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_pComboSwitchInDirection">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <item>
-           <property name="text">
-            <string>left</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>right</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>up</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>down</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Cursor lock will</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_pComboLockCursorToScreen">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <item>
-           <property name="text">
-            <string>toggle</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>on</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>off</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This Pr will be used to Improve the UX for the Action Dialog

 Before: 
<img alt="" width="350" src="https://github.com/user-attachments/assets/b7ebb4f3-ac4d-425b-b050-8f4452f4a101">

After Ui:

Key press, toggle and release look the same but different action strings

<img alt="" width="350" src="https://github.com/input-leap/input-leap/assets/7450820/417c01ed-1660-4730-9255-865bacd2c942">

<img alt="" width="350" src="https://github.com/input-leap/input-leap/assets/7450820/e0e5d03c-7c6e-4e1f-b352-ac35b7fdc3b5">

<img alt="" width="350" src="https://github.com/input-leap/input-leap/assets/7450820/bf0bcfbb-42b5-40c9-8aa6-3e7a6b77f9e8">

<img alt="" width="350" src="https://github.com/input-leap/input-leap/assets/7450820/98b015be-54fc-4d92-be91-b8e73f9b2869">
