### PR TITLE
Buffer the log window entries and cap the memory usage

### DIFF
--- a/doc/newsfragments/1717_fix-host-freeze-from-logwindow-issue.bugfix
+++ b/doc/newsfragments/1717_fix-host-freeze-from-logwindow-issue.bugfix
@@ -1,0 +1,1 @@
+Use a buffer to dramatically lower CPU use of log window.  Limit log window to 10,000 lines to prevent RAM use from constantly increasing.

--- a/src/gui/src/LogWindow.h
+++ b/src/gui/src/LogWindow.h
@@ -48,7 +48,8 @@ class LogWindow : public QDialog
 
     private:
         std::unique_ptr<Ui::LogWindow> ui_;
-
+        QString buffer_;
+        void flushBuffer();
 };
 
 #endif // LOGWINDOW__H

--- a/src/gui/src/LogWindow.ui
+++ b/src/gui/src/LogWindow.ui
@@ -27,7 +27,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QTextEdit" name="m_pLogOutput">
+    <widget class="QPlainTextEdit" name="m_pLogOutput">
      <property name="font">
       <font>
        <family>Courier</family>
@@ -40,7 +40,7 @@
       <bool>false</bool>
      </property>
      <property name="lineWrapMode">
-       <enum>QTextEdit::NoWrap</enum>
+      <enum>QPlainTextEdit::NoWrap</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>


### PR DESCRIPTION
Use a buffer before appending to the log window to significantly lower CPU use Also cap the memory usage by setting maximumBlockCount to 10000. This will purge old log entries from the log window once 10,000 lines have been reached. This caps the memory use around 40 to 50MB

Fixes #1717

v2: based on sithlord48 review

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 


I took over @hunterzero99 PR #1797  and applied the recommendations from @sithlord48 code review.

One item I recently added is a preprocessor macro to define the logwindow refresh from buffer qtimer timeout.
I also modified the doc fragment file name to include the issue number as the doc for towncrier tells.

The code rationale is hunterzero99. I tested it for more than three days in debug2 log mode. No issue whatsoever and logging to file at the same time seems fine too.