### PR TITLE
gui: ActionDialog A few more logic improvements

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -27,10 +27,9 @@
 
 #include <QButtonGroup>
 
-ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey, Action& action) :
+ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& hotkey, Action& action) :
     QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
     ui_{std::make_unique<Ui::ActionDialog>()},
-    server_config_(config),
     hotkey_(hotkey),
     action_(action),
     button_group_type_(new QButtonGroup(this))
@@ -62,7 +61,7 @@ ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey
     ui_->m_pGroupBoxScreens->setChecked(action_.haveScreens());
 
     int idx = 0;
-    for (const Screen& screen : serverConfig().screens()) {
+    for (const Screen& screen : config.screens()) {
         if (!screen.isNull())
         {
             QListWidgetItem *pListItem = new QListWidgetItem(screen.name());

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -60,7 +60,6 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
 
     ui_->m_pGroupBoxScreens->setChecked(action_.haveScreens());
 
-    int idx = 0;
     for (const Screen& screen : config.screens()) {
         if (screen.isNull())
             continue;
@@ -71,9 +70,7 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
 
         ui_->m_pComboSwitchToScreen->addItem(screen.name());
         if (screen.name() == action_.switchScreenName())
-            ui_->m_pComboSwitchToScreen->setCurrentIndex(idx);
-
-        idx++;
+            ui_->m_pComboSwitchToScreen->setCurrentIndex(ui_->m_pComboSwitchToScreen->count() - 1);
     }
 }
 

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -101,16 +101,8 @@ void ActionDialog::accept()
 
 void ActionDialog::key_sequence_changed()
 {
-    if (ui_->keySequenceWidget->keySequence().isMouseButton())
-    {
-        ui_->m_pGroupBoxScreens->setEnabled(false);
-        ui_->m_pListScreens->setEnabled(false);
-    }
-    else
-    {
-        ui_->m_pGroupBoxScreens->setEnabled(true);
-        ui_->m_pListScreens->setEnabled(true);
-    }
+    ui_->m_pGroupBoxScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
+    ui_->m_pListScreens->setEnabled(!ui_->keySequenceWidget->keySequence().isMouseButton());
 }
 
 ActionDialog::~ActionDialog() = default;

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -62,19 +62,18 @@ ActionDialog::ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& 
 
     int idx = 0;
     for (const Screen& screen : config.screens()) {
-        if (!screen.isNull())
-        {
-            QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
-            ui_->m_pListScreens->addItem(pListItem);
-            if (action_.typeScreenNames().indexOf(screen.name()) != -1)
-                ui_->m_pListScreens->setCurrentItem(pListItem);
+        if (screen.isNull())
+            continue;
+        QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
+        ui_->m_pListScreens->addItem(pListItem);
+        if (action_.typeScreenNames().indexOf(screen.name()) != -1)
+            ui_->m_pListScreens->setCurrentItem(pListItem);
 
-            ui_->m_pComboSwitchToScreen->addItem(screen.name());
-            if (screen.name() == action_.switchScreenName())
-                ui_->m_pComboSwitchToScreen->setCurrentIndex(idx);
+        ui_->m_pComboSwitchToScreen->addItem(screen.name());
+        if (screen.name() == action_.switchScreenName())
+            ui_->m_pComboSwitchToScreen->setCurrentIndex(idx);
 
-            idx++;
-        }
+        idx++;
     }
 }
 

--- a/src/gui/src/ActionDialog.h
+++ b/src/gui/src/ActionDialog.h
@@ -37,20 +37,16 @@ class ActionDialog : public QDialog
     Q_OBJECT
 
     public:
-        ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey, Action& action);
+        ActionDialog(QWidget* parent, const ServerConfig& config, Hotkey& hotkey, Action& action);
         ~ActionDialog() override;
 
     protected slots:
         void accept() override;
 
-    protected:
-        const ServerConfig& serverConfig() const { return server_config_; }
-
     private:
         void key_sequence_changed();
 
         std::unique_ptr<Ui::ActionDialog> ui_;
-        const ServerConfig& server_config_;
         Hotkey& hotkey_;
         Action& action_;
         QButtonGroup* button_group_type_;


### PR DESCRIPTION
When #1837 was split to from #1830 a few non gui changes were left behind , This adds them back

 - Remove the need for the ActionDialog to store and have a protected member for the `ServerConfig`.
 - Remove the need to track how many items are in the screen combobox to select the current screen 
 - Speed up screen list filling (and save some horizontal space) by continuing if the screen is null
 - Simplify the logic for the `key_sequence_changed` method