### PR TITLE
gui: code clean up Settings Dialog

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -1158,8 +1158,11 @@ void MainWindow::on_m_pActionAbout_triggered()
 
 void MainWindow::on_m_pActionSettings_triggered()
 {
-    if (SettingsDialog(this, appConfig()).exec() == QDialog::Accepted)
+    auto dialog = std::make_unique<SettingsDialog>(this, appConfig());
+    connect(dialog.get(), &SettingsDialog::requestLanguageChange, this, &MainWindow::requestLanguageChange);
+    if (dialog.get()->exec() == QDialog::Accepted)
         updateSSLFingerprint();
+    disconnect(dialog.get(), &SettingsDialog::requestLanguageChange, this, &MainWindow::requestLanguageChange);
 }
 
 void MainWindow::autoAddScreen(const QString name)

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -70,7 +70,6 @@ class MainWindow : public QMainWindow
 
     friend class QInputLeapApplication;
     friend class SetupWizard;
-    friend class SettingsDialog;
 
     public:
         enum qLevel {
@@ -103,6 +102,9 @@ class MainWindow : public QMainWindow
         void autoAddScreen(const QString name);
         void updateZeroconfService();
         void serverDetected(const QString name);
+
+    Q_SIGNALS:
+        void requestLanguageChange(QString newLanguage);
 
 public slots:
         void appendLogRaw(const QString& text);

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -1,5 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023-2024 InputLeap Developers
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
  *

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -21,7 +21,6 @@
 #include "ui_SettingsDialog.h"
 
 #include "AppLocale.h"
-#include "QInputLeapApplication.h"
 #include "QUtility.h"
 #include "AppConfig.h"
 #include "SslCertificate.h"
@@ -93,7 +92,7 @@ void SettingsDialog::accept()
 void SettingsDialog::reject()
 {
     if (app_config_.language() != ui_->m_pComboLanguage->itemData(ui_->m_pComboLanguage->currentIndex()).toString()) {
-        QInputLeapApplication::getInstance()->switchTranslator(app_config_.language());
+        Q_EMIT requestLanguageChange(app_config_.language());
     }
     QDialog::reject();
 }
@@ -145,8 +144,7 @@ void SettingsDialog::browseLogClicked()
 
 void SettingsDialog::languageChanged(int index)
 {
-    QString ietfCode = ui_->m_pComboLanguage->itemData(index).toString();
-    QInputLeapApplication::getInstance()->switchTranslator(ietfCode);
+    Q_EMIT requestLanguageChange(ui_->m_pComboLanguage->itemData(index).toString());
 }
 
 SettingsDialog::~SettingsDialog() = default;

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -36,7 +36,7 @@
 SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
     ui_{std::make_unique<Ui::SettingsDialog>()},
-    m_appConfig(config)
+    app_config_(config)
 {
     ui_->setupUi(this);
 
@@ -45,21 +45,21 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
 
     m_Locale.fillLanguageComboBox(ui_->m_pComboLanguage);
 
-    ui_->m_pLineEditScreenName->setText(appConfig().screenName());
-    ui_->m_pSpinBoxPort->setValue(appConfig().port());
-    ui_->m_pLineEditInterface->setText(appConfig().networkInterface());
-    ui_->m_pComboLogLevel->setCurrentIndex(appConfig().logLevel());
-    ui_->m_pCheckBoxLogToFile->setChecked(appConfig().logToFile());
-    ui_->m_pLineEditLogFilename->setText(appConfig().logFilename());
-    setIndexFromItemData(ui_->m_pComboLanguage, appConfig().language());
-    ui_->m_pCheckBoxAutoHide->setChecked(appConfig().getAutoHide());
-    ui_->m_pCheckBoxAutoStart->setChecked(appConfig().getAutoStart());
-    ui_->m_pCheckBoxMinimizeToTray->setChecked(appConfig().getMinimizeToTray());
-    ui_->m_pCheckBoxEnableCrypto->setChecked(m_appConfig.getCryptoEnabled());
-    ui_->checkbox_require_client_certificate->setChecked(m_appConfig.getRequireClientCertificate());
+    ui_->m_pLineEditScreenName->setText(app_config_.screenName());
+    ui_->m_pSpinBoxPort->setValue(app_config_.port());
+    ui_->m_pLineEditInterface->setText(app_config_.networkInterface());
+    ui_->m_pComboLogLevel->setCurrentIndex(app_config_.logLevel());
+    ui_->m_pCheckBoxLogToFile->setChecked(app_config_.logToFile());
+    ui_->m_pLineEditLogFilename->setText(app_config_.logFilename());
+    setIndexFromItemData(ui_->m_pComboLanguage, app_config_.language());
+    ui_->m_pCheckBoxAutoHide->setChecked(app_config_.getAutoHide());
+    ui_->m_pCheckBoxAutoStart->setChecked(app_config_.getAutoStart());
+    ui_->m_pCheckBoxMinimizeToTray->setChecked(app_config_.getMinimizeToTray());
+    ui_->m_pCheckBoxEnableCrypto->setChecked(app_config_.getCryptoEnabled());
+    ui_->checkbox_require_client_certificate->setChecked(app_config_.getRequireClientCertificate());
 
 #if defined(Q_OS_WIN)
-    ui_->m_pComboElevate->setCurrentIndex(static_cast<int>(appConfig().elevateMode()));
+    ui_->m_pComboElevate->setCurrentIndex(static_cast<int>(app_config_.elevateMode()));
 #else
     // elevate checkbox is only useful on ms windows.
     ui_->m_pLabelElevate->hide();
@@ -73,27 +73,27 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
 
 void SettingsDialog::accept()
 {
-    m_appConfig.setScreenName(ui_->m_pLineEditScreenName->text());
-    m_appConfig.setPort(ui_->m_pSpinBoxPort->value());
-    m_appConfig.setNetworkInterface(ui_->m_pLineEditInterface->text());
-    m_appConfig.setCryptoEnabled(ui_->m_pCheckBoxEnableCrypto->isChecked());
-    m_appConfig.setRequireClientCertificate(ui_->checkbox_require_client_certificate->isChecked());
-    m_appConfig.setLogLevel(ui_->m_pComboLogLevel->currentIndex());
-    m_appConfig.setLogToFile(ui_->m_pCheckBoxLogToFile->isChecked());
-    m_appConfig.setLogFilename(ui_->m_pLineEditLogFilename->text());
-    m_appConfig.setLanguage(ui_->m_pComboLanguage->itemData(ui_->m_pComboLanguage->currentIndex()).toString());
-    m_appConfig.setElevateMode(static_cast<ElevateMode>(ui_->m_pComboElevate->currentIndex()));
-    m_appConfig.setAutoHide(ui_->m_pCheckBoxAutoHide->isChecked());
-    m_appConfig.setAutoStart(ui_->m_pCheckBoxAutoStart->isChecked());
-    m_appConfig.setMinimizeToTray(ui_->m_pCheckBoxMinimizeToTray->isChecked());
-    m_appConfig.saveSettings();
+    app_config_.setScreenName(ui_->m_pLineEditScreenName->text());
+    app_config_.setPort(ui_->m_pSpinBoxPort->value());
+    app_config_.setNetworkInterface(ui_->m_pLineEditInterface->text());
+    app_config_.setCryptoEnabled(ui_->m_pCheckBoxEnableCrypto->isChecked());
+    app_config_.setRequireClientCertificate(ui_->checkbox_require_client_certificate->isChecked());
+    app_config_.setLogLevel(ui_->m_pComboLogLevel->currentIndex());
+    app_config_.setLogToFile(ui_->m_pCheckBoxLogToFile->isChecked());
+    app_config_.setLogFilename(ui_->m_pLineEditLogFilename->text());
+    app_config_.setLanguage(ui_->m_pComboLanguage->itemData(ui_->m_pComboLanguage->currentIndex()).toString());
+    app_config_.setElevateMode(static_cast<ElevateMode>(ui_->m_pComboElevate->currentIndex()));
+    app_config_.setAutoHide(ui_->m_pCheckBoxAutoHide->isChecked());
+    app_config_.setAutoStart(ui_->m_pCheckBoxAutoStart->isChecked());
+    app_config_.setMinimizeToTray(ui_->m_pCheckBoxMinimizeToTray->isChecked());
+    app_config_.saveSettings();
     QDialog::accept();
 }
 
 void SettingsDialog::reject()
 {
-    if (m_appConfig.language() != ui_->m_pComboLanguage->itemData(ui_->m_pComboLanguage->currentIndex()).toString()) {
-        QInputLeapApplication::getInstance()->switchTranslator(m_appConfig.language());
+    if (app_config_.language() != ui_->m_pComboLanguage->itemData(ui_->m_pComboLanguage->currentIndex()).toString()) {
+        QInputLeapApplication::getInstance()->switchTranslator(app_config_.language());
     }
     QDialog::reject();
 }

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -42,7 +42,8 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::accept);
     connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &SettingsDialog::reject);
 
-    m_Locale.fillLanguageComboBox(ui_->m_pComboLanguage);
+    AppLocale locale;
+    locale.fillLanguageComboBox(ui_->m_pComboLanguage);
 
     ui_->m_pLineEditScreenName->setText(app_config_.screenName());
     ui_->m_pSpinBoxPort->setValue(app_config_.port());

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -23,8 +23,6 @@
 #include "AppLocale.h"
 #include "QUtility.h"
 #include "AppConfig.h"
-#include "SslCertificate.h"
-#include "MainWindow.h"
 
 #include <QtCore>
 #include <QtGui>

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -65,6 +65,10 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     ui_->m_pLabelElevate->hide();
     ui_->m_pComboElevate->hide();
 #endif
+
+    connect(ui_->m_pCheckBoxLogToFile, &QCheckBox::stateChanged, this, &SettingsDialog::logToFileChanged);
+    connect(ui_->m_pButtonBrowseLog, &QPushButton::clicked, this, &SettingsDialog::browseLogClicked);
+    connect(ui_->m_pComboLanguage, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::languageChanged);
 }
 
 void SettingsDialog::accept()
@@ -118,7 +122,7 @@ void SettingsDialog::changeEvent(QEvent* event)
     }
 }
 
-void SettingsDialog::on_m_pCheckBoxLogToFile_stateChanged(int i)
+void SettingsDialog::logToFileChanged(int i)
 {
     bool checked = i == 2;
 
@@ -126,7 +130,7 @@ void SettingsDialog::on_m_pCheckBoxLogToFile_stateChanged(int i)
     ui_->m_pButtonBrowseLog->setEnabled(checked);
 }
 
-void SettingsDialog::on_m_pButtonBrowseLog_clicked()
+void SettingsDialog::browseLogClicked()
 {
     QString fileName = QFileDialog::getSaveFileName(
         this, tr("Save log file to..."),
@@ -139,7 +143,7 @@ void SettingsDialog::on_m_pButtonBrowseLog_clicked()
     }
 }
 
-void SettingsDialog::on_m_pComboLanguage_currentIndexChanged(int index)
+void SettingsDialog::languageChanged(int index)
 {
     QString ietfCode = ui_->m_pComboLanguage->itemData(index).toString();
     QInputLeapApplication::getInstance()->switchTranslator(ietfCode);

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -39,6 +39,9 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
 {
     ui_->setupUi(this);
 
+    connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::accept);
+    connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &SettingsDialog::reject);
+
     m_Locale.fillLanguageComboBox(ui_->m_pComboLanguage);
 
     ui_->m_pLineEditScreenName->setText(appConfig().screenName());

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -1,5 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2023-2024 InputLeap Developers
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
  *

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -43,7 +43,6 @@ class SettingsDialog : public QDialog
         void accept() override;
         void reject() override;
         void changeEvent(QEvent* event) override;
-        AppConfig& appConfig() { return m_appConfig; }
 
     private:
         void languageChanged(int index);
@@ -51,7 +50,7 @@ class SettingsDialog : public QDialog
         void browseLogClicked();
 
         std::unique_ptr<Ui::SettingsDialog> ui_;
-        AppConfig& m_appConfig;
+        AppConfig& app_config_;
         AppLocale m_Locale;
 
 };

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -22,8 +22,6 @@
 #include <QDialog>
 #include <memory>
 
-#include "AppLocale.h"
-
 class AppConfig;
 
 namespace Ui
@@ -54,6 +52,4 @@ class SettingsDialog : public QDialog
 
         std::unique_ptr<Ui::SettingsDialog> ui_;
         AppConfig& app_config_;
-        AppLocale m_Locale;
-
 };

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -39,6 +39,9 @@ class SettingsDialog : public QDialog
         SettingsDialog(QWidget* parent, AppConfig& config);
         ~SettingsDialog() override;
 
+    Q_SIGNALS:
+        void requestLanguageChange(QString newLang);
+
     protected:
         void accept() override;
         void reject() override;

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -46,12 +46,12 @@ class SettingsDialog : public QDialog
         AppConfig& appConfig() { return m_appConfig; }
 
     private:
+        void languageChanged(int index);
+        void logToFileChanged(int i);
+        void browseLogClicked();
+
         std::unique_ptr<Ui::SettingsDialog> ui_;
         AppConfig& m_appConfig;
         AppLocale m_Locale;
 
-    private slots:
-        void on_m_pComboLanguage_currentIndexChanged(int index);
-        void on_m_pCheckBoxLogToFile_stateChanged(int );
-        void on_m_pButtonBrowseLog_clicked();
 };

--- a/src/gui/src/SettingsDialog.ui
+++ b/src/gui/src/SettingsDialog.ui
@@ -129,7 +129,7 @@
       <item row="5" column="0">
        <widget class="QCheckBox" name="m_pCheckBoxAutoStart">
         <property name="text">
-         <string>Start &amp;InputLeap on startup</string>
+         <string>Show Tray &amp;Icon upon App Start</string>
         </property>
        </widget>
       </item>

--- a/src/gui/src/SettingsDialog.ui
+++ b/src/gui/src/SettingsDialog.ui
@@ -112,21 +112,21 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="m_pCheckBoxMinimizeToTray">
         <property name="text">
          <string>Minimize to System &amp;Tray</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="m_pCheckBoxAutoHide">
         <property name="text">
          <string>&amp;Hide on startup</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="m_pCheckBoxAutoStart">
         <property name="text">
          <string>Show Tray &amp;Icon upon App Start</string>

--- a/src/gui/src/SettingsDialog.ui
+++ b/src/gui/src/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>616</width>
-    <height>580</height>
+    <width>400</width>
+    <height>0</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/gui/src/SettingsDialog.ui
+++ b/src/gui/src/SettingsDialog.ui
@@ -346,38 +346,5 @@
   <tabstop>m_pButtonBrowseLog</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>SettingsDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>266</x>
-     <y>340</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>SettingsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>334</x>
-     <y>340</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
 	{
 		mainWindow.open();
 	}
-
+    QObject::connect(&mainWindow, &MainWindow::requestLanguageChange, &app, &QInputLeapApplication::switchTranslator);
 	return app.exec();
 }
 


### PR DESCRIPTION
Assorted Code cleanup for the Settings Dialog
 - Fixes #1826 : 
     - Changes the label to say `Show Tray Icon upon App Start`
- Allow the Checkbox Options to span the columns.
- The dialog will default to 400 width and a height based on the contents
- Remove the auto connections (`on_...`) 
- Make the button box connections in the constructor
- Add InputLeap Developers to the copyright
- Cleanup unneeded includes
- Use Signals to request a language change
- `MainWindow` and `SettingsDialog` are no longer friends
