### PR TITLE
gui: MainWindow, Set MenuRoles Where possible

### DIFF
--- a/src/gui/src/MainWindow.ui
+++ b/src/gui/src/MainWindow.ui
@@ -371,6 +371,9 @@
    <property name="shortcut">
     <string notr="true"/>
    </property>
+   <property name="menuRole">
+    <enum>QAction::AboutRole</enum>
+   </property>
   </action>
   <action name="m_pActionQuit">
    <property name="text">
@@ -381,6 +384,9 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Q</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
    </property>
   </action>
   <action name="m_pActionStartCmdApp">
@@ -450,6 +456,9 @@
    </property>
    <property name="shortcut">
     <string notr="true">F4</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
   <action name="m_pActionShowLog">


### PR DESCRIPTION
 Set [menuRoles](https://doc.qt.io/qt-6/qaction.html#MenuRole-enum) for the items where possible, this will act as a hint for window managers to put these menu items in the correct location (i.e mac os puts settings under the menu with the app name)

 - Configure Settings ->    `PreferencesRole`
 - Quit -> `QuitRole`
 - About InputLeap -> `AboutRole`