### PR TITLE
ei: fix the scroll events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,8 +175,9 @@ if (UNIX)
             pkg_check_modules(LIBXKBCOMMON REQUIRED xkbcommon)
             pkg_check_modules(GLIB2 REQUIRED glib-2.0 gio-2.0)
             pkg_check_modules(LIBPORTAL REQUIRED libportal)
-            include_directories(${LIBEI_INCLUDE_DIRS} ${LIBXKBCOMMON_INCLUDE_DIRS} ${GLIB2_INCLUDE_DIRS} ${LIBPORTAL_INCLUDE_DIRS})
-            list(APPEND libs ${LIBEI_LINK_LIBRARIES} ${LIBXKBCOMMON_LINK_LIBRARIES} ${GLIB2_LINK_LIBRARIES} ${LIBPORTAL_LINK_LIBRARIES})
+            find_library(LIBM m)
+            include_directories(${LIBEI_INCLUDE_DIRS} ${LIBXKBCOMMON_INCLUDE_DIRS} ${GLIB2_INCLUDE_DIRS} ${LIBPORTAL_INCLUDE_DIRS} ${LIBM_INCLUDE_DIRS})
+            list(APPEND libs ${LIBEI_LINK_LIBRARIES} ${LIBXKBCOMMON_LINK_LIBRARIES} ${GLIB2_LINK_LIBRARIES} ${LIBPORTAL_LINK_LIBRARIES} ${LIBM_LIBRARIES})
 
             # no libportal release has xdp_session_connect_to_eis, so let's check for that
             # and enable the hackaround in the code

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -101,6 +101,7 @@ private:
     ButtonID map_button_from_evdev(ei_event* event) const;
     void on_key_event(ei_event *event);
     void on_button_event(ei_event *event);
+    void send_wheel_events(ei_device *device, const int threshold, double dx, double dy, bool is_discrete);
     void on_pointer_scroll_event(ei_event* event);
     void on_pointer_scroll_discrete_event(ei_event* event);
     void on_motion_event(ei_event *event);


### PR DESCRIPTION
We may get scroll events or scroll discrete events and both may be in fractions of a single logical scroll event. Handle this by mapping 10 pixels to one wheel click (that's what mutter/gtk do too) and otherwise keeping the remainder around in the device for the next scroll event.

Note that we're always sending things through as wheel, so on the client side we only ever call ei_device_scroll_discrete().

In theory, our pointer and keyboard device may be the same ei device, so let's assume we have a user data on all of them and free them during cleanup - that way we don't need complicated checks of which devices are the same device.

Fixes #1840

cc @brianjmurrell, @prahal

---
Note that there's a remaining issue: mutter seems to be sending both normal and discrete scroll events so the scrolling is still twice what it should be. That seems to be a bug in mutter somewhere, not in input-leap.