### PR TITLE
Clean up the logging handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ endif()
 
 set (libs)
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag (-Wformat HAVE_WFORMAT)
+if (HAVE_WFORMAT)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat")
+endif()
 
 if (INPUTLEAP_BUILD_GUI)
     if (QT_DEFAULT_MAJOR_VERSION EQUAL 5)

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -89,7 +89,7 @@ void EventQueue::set_buffer(std::unique_ptr<IEventQueueBuffer> buffer)
     if (m_events.size() != 0) {
         // this can come as a nasty surprise to programmers expecting
         // their events to be raised, only to have them deleted.
-        LOG((CLOG_DEBUG "discarding %d event(s)", m_events.size()));
+        LOG((CLOG_DEBUG "discarding %zd event(s)", m_events.size()));
     }
 
     // discard old buffer and old events

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -66,7 +66,6 @@ Log::Log()
 
     // other initialization
     m_maxPriority = g_defaultMaxPriority;
-    m_maxNewlineLength = 0;
     insert(new ConsoleLogOutputter);
 
     s_log = this;
@@ -136,9 +135,6 @@ Log::print(const char* file, int line, const char* fmt, ...)
     // compute prefix padding length
     char stack[1024];
 
-    // compute suffix padding length
-    int sPad = m_maxNewlineLength;
-
     // print to buffer, leaving space for a newline at the end and prefix
     // at the beginning.
     char* buffer = stack;
@@ -147,7 +143,7 @@ Log::print(const char* file, int line, const char* fmt, ...)
         // try printing into the buffer
         va_list args;
         va_start(args, fmt);
-        int n = std::vsnprintf(buffer, len - sPad, fmt, args);
+        int n = std::vsnprintf(buffer, len, fmt, args);
         va_end(args);
 
         // if the buffer wasn't big enough then make it bigger and try again

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -151,7 +151,7 @@ Log::print(const char* file, int line, const char* fmt, ...)
         va_end(args);
 
         // if the buffer wasn't big enough then make it bigger and try again
-        if (n < 0 || n > static_cast<int>(len)) {
+        if (n < 0 || n > len) {
             if (buffer != stack) {
                 delete[] buffer;
             }

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -116,7 +116,7 @@ Log::print(const char* file, int line, const char* fmt, ...)
 {
     // check if fmt begins with a priority argument
     ELevel priority = kINFO;
-    if ((strlen(fmt) > 2) && (fmt[0] == '%' && fmt[1] == 'z')) {
+    if ((strlen(fmt) > 2) && (fmt[0] == '@' && fmt[1] == 'z')) {
 
         // 060 in octal is 0 (48 in decimal), so subtracting this converts ascii
         // number it a true number. we could use atoi instead, but this is how

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <iostream>
 #include <ctime>
+#include <vector>
 
 namespace inputleap {
 
@@ -132,74 +133,48 @@ Log::print(const char* file, int line, const char* fmt, ...)
         return;
     }
 
-    // compute prefix padding length
-    char stack[1024];
+    std::vector<char> buffer(2048);
+    int offset = 0;
+    size_t remaining = buffer.size();
+    int n;
 
-    // print to buffer, leaving space for a newline at the end and prefix
-    // at the beginning.
-    char* buffer = stack;
-    int len = static_cast<int>(sizeof(stack) / sizeof(stack[0]));
-    while (true) {
-        // try printing into the buffer
-        va_list args;
-        va_start(args, fmt);
-        int n = std::vsnprintf(buffer, len, fmt, args);
-        va_end(args);
-
-        // if the buffer wasn't big enough then make it bigger and try again
-        if (n < 0 || n > len) {
-            if (buffer != stack) {
-                delete[] buffer;
-            }
-            len     *= 2;
-            buffer = new char[len];
-        }
-
-        // if the buffer was big enough then continue
-        else {
-            break;
-        }
-    }
-
-    // print the prefix to the buffer.    leave space for priority label.
+    // print the prefix to the buffer
     // do not prefix time and file for kPRINT (CLOG_PRINT)
     if (priority != kPRINT) {
-
         struct tm *tm;
-        char timestamp[50];
         time_t t;
         time(&t);
         tm = localtime(&t);
-        std::snprintf(timestamp, sizeof(timestamp), "%04i-%02i-%02iT%02i:%02i:%02i", tm->tm_year + 1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
 
-        // square brackets, spaces, comma and null terminator take about 10
-        size_t size = 10;
-        size += strlen(timestamp);
-        size += strlen(g_priority[priority]);
-        size += strlen(buffer);
-#ifndef NDEBUG
-        size += strlen(file);
-        // assume there is no file contains over 100k lines of code
-        size += 6;
-#endif
-        char* message = new char[size];
+        offset = std::snprintf(buffer.data(), remaining, "[%04i-%02i-%02iT%02i:%02i:%02i] %s: ",
+                               tm->tm_year + 1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec,
+                               g_priority[priority]);
+        if (offset == -1) {
+            output(kERROR, "Failed to print to log");
+            return;
+        }
 
-#ifndef NDEBUG
-        std::snprintf(message, size, "[%s] %s: %s\n\t%s,%d", timestamp, g_priority[priority], buffer, file, line);
-#else
-        std::snprintf(message, size, "[%s] %s: %s", timestamp, g_priority[priority], buffer);
-#endif
-
-        output(priority, message);
-        delete[] message;
-    } else {
-        output(priority, buffer);
+        remaining -= offset;
     }
 
-    // clean up
-    if (buffer != stack) {
-        delete[] buffer;
+    // now print our actual message
+    va_list args;
+    va_start(args, fmt);
+    n = std::vsnprintf(buffer.data() + offset, remaining, fmt, args);
+    va_end(args);
+    if (n == -1) {
+        output(kERROR, "Failed to print to log (invalid arguments)");
+        return;
     }
+
+    remaining -= n;
+    offset += n;
+
+#ifndef NDEBUG
+    n = std::snprintf(buffer.data() + offset, remaining - offset, "\n\t%s,%d", file, line);
+#endif
+
+    output(priority, buffer.data());
 }
 
 void

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -174,7 +174,7 @@ Log::print(const char* file, int line, const char* fmt, ...)
         time_t t;
         time(&t);
         tm = localtime(&t);
-        sprintf(timestamp, "%04i-%02i-%02iT%02i:%02i:%02i", tm->tm_year + 1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+        std::snprintf(timestamp, sizeof(timestamp), "%04i-%02i-%02iT%02i:%02i:%02i", tm->tm_year + 1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
 
         // square brackets, spaces, comma and null terminator take about 10
         size_t size = 10;
@@ -189,9 +189,9 @@ Log::print(const char* file, int line, const char* fmt, ...)
         char* message = new char[size];
 
 #ifndef NDEBUG
-        sprintf(message, "[%s] %s: %s\n\t%s,%d", timestamp, g_priority[priority], buffer, file, line);
+        std::snprintf(message, size, "[%s] %s: %s\n\t%s,%d", timestamp, g_priority[priority], buffer, file, line);
 #else
-        sprintf(message, "[%s] %s: %s", timestamp, g_priority[priority], buffer);
+        std::snprintf(message, size, "[%s] %s: %s", timestamp, g_priority[priority], buffer);
 #endif
 
         output(priority, message);

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -280,7 +280,7 @@ Log::getFilter() const
 }
 
 void
-Log::output(ELevel priority, char* msg)
+Log::output(ELevel priority, const char* msg)
 {
     assert(priority >= -1 && priority < g_numPriority);
     assert(msg != nullptr);

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -199,17 +199,17 @@ otherwise it expands to a call that doesn't.
 // end, then we resort to using non-numerical chars. this still works (since
 // to deduce the number we subtract octal \060, so '/' is -1, and ':' is 10
 
-#define CLOG_PRINT        CLOG_TRACE "%z\057" // char is '/'
-#define CLOG_CRIT        CLOG_TRACE "%z\060" // char is '0'
-#define CLOG_ERR        CLOG_TRACE "%z\061"
-#define CLOG_WARN        CLOG_TRACE "%z\062"
-#define CLOG_NOTE        CLOG_TRACE "%z\063"
-#define CLOG_INFO        CLOG_TRACE "%z\064"
-#define CLOG_DEBUG        CLOG_TRACE "%z\065"
-#define CLOG_DEBUG1        CLOG_TRACE "%z\066"
-#define CLOG_DEBUG2        CLOG_TRACE "%z\067"
-#define CLOG_DEBUG3        CLOG_TRACE "%z\070"
-#define CLOG_DEBUG4        CLOG_TRACE "%z\071" // char is '9'
-#define CLOG_DEBUG5        CLOG_TRACE "%z\072" // char is ':'
+#define CLOG_PRINT        CLOG_TRACE "@z\057" // char is '/'
+#define CLOG_CRIT        CLOG_TRACE "@z\060" // char is '0'
+#define CLOG_ERR        CLOG_TRACE "@z\061"
+#define CLOG_WARN        CLOG_TRACE "@z\062"
+#define CLOG_NOTE        CLOG_TRACE "@z\063"
+#define CLOG_INFO        CLOG_TRACE "@z\064"
+#define CLOG_DEBUG        CLOG_TRACE "@z\065"
+#define CLOG_DEBUG1        CLOG_TRACE "@z\066"
+#define CLOG_DEBUG2        CLOG_TRACE "@z\067"
+#define CLOG_DEBUG3        CLOG_TRACE "@z\070"
+#define CLOG_DEBUG4        CLOG_TRACE "@z\071" // char is '9'
+#define CLOG_DEBUG5        CLOG_TRACE "@z\072" // char is ':'
 
 } // namespace inputleap

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -137,7 +137,6 @@ private:
     mutable std::mutex m_mutex;
     OutputterList m_outputters;
     OutputterList m_alwaysOutputters;
-    int m_maxNewlineLength;
     int m_maxPriority;
 };
 

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -106,6 +106,7 @@ public:
     preceded by the filename and line number.  If \c file is nullptr then
     neither the file nor the line are printed.
     */
+    _X_ATTRIBUTE_PRINTF(4, 5)
     void print(const char* file, int line,
                             const char* format, ...);
 

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -127,7 +127,7 @@ public:
     //@}
 
 private:
-    void output(ELevel priority, char* msg);
+    void output(ELevel priority, const char* msg);
 
 private:
     typedef std::list<ILogOutputter*> OutputterList;

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -398,7 +398,7 @@ Client::sendClipboard(ClipboardID id)
         std::string data = clipboard.marshall();
         if (data.size() >= m_maximumClipboardSize) {
             LOG((CLOG_NOTE "Skipping clipboard transfer because the clipboard"
-                " contents exceeds the %i MB size limit set by the server",
+                " contents exceeds the %zi MB size limit set by the server",
                 m_maximumClipboardSize));
             return;
         }

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -560,10 +560,10 @@ ServerProxy::setClipboard()
 
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
-        LOG((CLOG_DEBUG "receiving clipboard %d size=%d", id, size));
+        LOG((CLOG_DEBUG "receiving clipboard %d size=%zd", id, size));
     }
     else if (r == kFinish) {
-        LOG((CLOG_DEBUG "received clipboard %d size=%d", id, dataCached.size()));
+        LOG((CLOG_DEBUG "received clipboard %d size=%zd", id, dataCached.size()));
 
         // forward
         Clipboard clipboard;
@@ -806,7 +806,7 @@ ServerProxy::setOptions()
     // parse
     OptionsList options;
     ProtocolUtil::readf(m_stream, kMsgDSetOptions + 4, &options);
-    LOG((CLOG_DEBUG1 "recv set options size=%d", options.size()));
+    LOG((CLOG_DEBUG1 "recv set options size=%zd", options.size()));
 
     // forward
     m_client->setOptions(options);

--- a/src/lib/common/common.h
+++ b/src/lib/common/common.h
@@ -36,3 +36,12 @@ enum {
     kExitConfig       = 4, // cannot read configuration
     kExitSubscription = 5  // subscription error
 };
+
+// From XFuncproto.h
+/* Added in X11R6.9, so available in any version of modular xproto */
+#if __has_attribute(__format__) \
+  || defined(__GNUC__) && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 203)
+# define _X_ATTRIBUTE_PRINTF(x,y) __attribute__((__format__(__printf__,x,y)))
+#else /* not gcc >= 2.3 */
+# define _X_ATTRIBUTE_PRINTF(x,y)
+#endif

--- a/src/lib/inputleap/ClipboardChunk.cpp
+++ b/src/lib/inputleap/ClipboardChunk.cpp
@@ -85,7 +85,7 @@ int ClipboardChunk::assemble(inputleap::IStream* stream, std::string& dataCached
             return kError;
         }
         else if (s_expectedSize != dataCached.size()) {
-            LOG((CLOG_ERR "corrupted clipboard data, expected size=%d actual size=%d", s_expectedSize, dataCached.size()));
+            LOG((CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", s_expectedSize, dataCached.size()));
             return kError;
         }
         return kFinish;

--- a/src/lib/inputleap/DragInformation.cpp
+++ b/src/lib/inputleap/DragInformation.cpp
@@ -73,11 +73,11 @@ void DragInformation::parseDragInfo(DragFileList& dragFileList, std::uint32_t fi
         ++index;
     }
 
-    LOG((CLOG_DEBUG "drag info received, total drag file number: %i",
+    LOG((CLOG_DEBUG "drag info received, total drag file number: %zi",
         dragFileList.size()));
 
     for (size_t i = 0; i < dragFileList.size(); ++i) {
-        LOG((CLOG_DEBUG "dragging file %i name: %s",
+        LOG((CLOG_DEBUG "dragging file %zi name: %s",
             i + 1,
             dragFileList.at(i).getFilename().c_str()));
     }

--- a/src/lib/inputleap/DropHelper.cpp
+++ b/src/lib/inputleap/DropHelper.cpp
@@ -27,7 +27,7 @@ namespace inputleap {
 void
 DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, std::string& data)
 {
-    LOG((CLOG_DEBUG "dropping file, files=%i target=%s", fileList.size(), destination.c_str()));
+    LOG((CLOG_DEBUG "dropping file, files=%zi target=%s", fileList.size(), destination.c_str()));
 
     if (!destination.empty() && fileList.size() > 0) {
         std::fstream file;

--- a/src/lib/inputleap/FileChunk.cpp
+++ b/src/lib/inputleap/FileChunk.cpp
@@ -81,7 +81,7 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
     case kDataChunk:
         dataReceived.append(content);
         if (CLOG->getFilter() >= kDEBUG2) {
-                LOG((CLOG_DEBUG2 "recv file chunk size=%i", content.size()));
+                LOG((CLOG_DEBUG2 "recv file chunk size=%zi", content.size()));
                 double interval = stopwatch.getTime();
                 receivedDataSize += content.size();
                 LOG((CLOG_DEBUG2 "recv file interval=%f s", interval));
@@ -98,7 +98,7 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
 
     case kDataEnd:
         if (expectedSize != dataReceived.size()) {
-            LOG((CLOG_ERR "corrupted clipboard data, expected size=%d actual size=%d", expectedSize, dataReceived.size()));
+            LOG((CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", expectedSize, dataReceived.size()));
             return kError;
         }
 
@@ -107,7 +107,7 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
             elapsedTime += stopwatch.getTime();
             double averageSpeed = expectedSize / elapsedTime / 1000;
             LOG((CLOG_DEBUG2 "file transfer finished: total time consumed=%f s", elapsedTime));
-            LOG((CLOG_DEBUG2 "file transfer finished: total data received=%i kb", expectedSize / 1000));
+            LOG((CLOG_DEBUG2 "file transfer finished: total data received=%zi kb", expectedSize / 1000));
             LOG((CLOG_DEBUG2 "file transfer finished: total average speed=%f kb/s", averageSpeed));
         }
         return kFinish;

--- a/src/lib/inputleap/KeyMap.cpp
+++ b/src/lib/inputleap/KeyMap.cpp
@@ -681,7 +681,7 @@ std::int32_t KeyMap::findBestKey(const KeyEntryList& entryList, KeyModifierMask 
         const KeyItem& item = entryList[i].back();
         if ((item.m_required & desiredState) == item.m_required &&
             (item.m_required & desiredState) == (item.m_sensitive & desiredState)) {
-            LOG((CLOG_DEBUG1 "best key index %d of %d (exact)", i + 1, entryList.size()));
+            LOG((CLOG_DEBUG1 "best key index %d of %zd (exact)", i + 1, entryList.size()));
             return i;
         }
     }
@@ -700,7 +700,7 @@ std::int32_t KeyMap::findBestKey(const KeyEntryList& entryList, KeyModifierMask 
         }
     }
     if (bestIndex != -1) {
-        LOG((CLOG_DEBUG1 "best key index %d of %d (%d modifiers)",
+        LOG((CLOG_DEBUG1 "best key index %d of %zd (%d modifiers)",
              bestIndex + 1, entryList.size(), bestCount));
     }
 

--- a/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
+++ b/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
@@ -359,7 +359,7 @@ std::int32_t PlatformScreenLoggingWrapper::pollActiveGroup() const
 void PlatformScreenLoggingWrapper::pollPressedKeys(KeyButtonSet& pressed_keys) const
 {
     screen_->pollPressedKeys(pressed_keys);
-    LOG((CLOG_DEBUG1 "PlatformScreen::pollPressedKeys() => pressed_keys.size()=%d",
+    LOG((CLOG_DEBUG1 "PlatformScreen::pollPressedKeys() => pressed_keys.size()=%zd",
          pressed_keys.size()));
 }
 

--- a/src/lib/inputleap/StreamChunker.cpp
+++ b/src/lib/inputleap/StreamChunker.cpp
@@ -145,7 +145,7 @@ void StreamChunker::sendClipboard(std::string& data, std::size_t size, Clipboard
     events->add_event(EventType::CLIPBOARD_SENDING, event_target,
                       create_event_data<ClipboardChunk>(end));
 
-    LOG((CLOG_DEBUG "sent clipboard size=%d", sentLength));
+    LOG((CLOG_DEBUG "sent clipboard size=%zd", sentLength));
 }
 
 void

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -117,7 +117,7 @@ void IpcServer::handle_client_disconnected(const Event& e)
     m_clients.remove(proxy);
     deleteClient(proxy);
 
-    LOG((CLOG_DEBUG "ipc client proxy removed, connected=%d", m_clients.size()));
+    LOG((CLOG_DEBUG "ipc client proxy removed, connected=%zd", m_clients.size()));
 }
 
 void IpcServer::handle_message_received(const Event& e)

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -692,7 +692,7 @@ bool SecureSocket::verify_peer_certificate(const inputleap::fs::path& fingerprin
     db.read(fingerprint_db_path);
 
     if (!db.fingerprints().empty()) {
-        LOG((CLOG_NOTE "Read %d fingerprints from: %s", db.fingerprints().size(),
+        LOG((CLOG_NOTE "Read %zd fingerprints from: %s", db.fingerprints().size(),
              fingerprint_db_path.u8string().c_str()));
     } else {
         LOG((CLOG_NOTE "Could not read fingerprints from: %s",

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -275,10 +275,10 @@ KeyID EiKeyState::map_key_from_keyval(uint32_t keyval) const
     // FIXME: That might be a bit crude...?
     xkb_keysym_t xkb_keysym = xkb_state_key_get_one_sym(xkb_state_, keyval);
     KeySym keysym = static_cast<KeySym>(xkb_keysym);
-    LOG((CLOG_DEBUG1 "mapped code=%d to keysym=0x%04x", keyval, keysym));
+    LOG((CLOG_DEBUG1 "mapped code=%d to keysym=0x%04lx", keyval, keysym));
 
     KeyID keyid = XWindowsUtil::mapKeySymToKeyID(keysym);
-    LOG((CLOG_DEBUG1 "mapped keysym=0x%04x to keyID=%d", keysym, keyid));
+    LOG((CLOG_DEBUG1 "mapped keysym=0x%04lx to keyID=%d", keysym, keyid));
 
     return keyid;
 }

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -545,7 +545,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     assert(!std::isnan(x) && !std::isinf(x));
     assert(!std::isnan(y) && !std::isinf(y));
 
-    LOG((CLOG_DEBUG1 "event: xy is (%d, %df)", x, y));
+    LOG((CLOG_DEBUG1 "event: xy is (%.2f, %.2f)", x, y));
 
     // libEI and InputLeap seem to use opposite directions, so we have
     // to send the opposite of the value reported by EI if we want to

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -42,7 +42,7 @@ OSXClipboard::OSXClipboard() :
     OSStatus createErr = PasteboardCreate(kPasteboardClipboard, &m_pboard);
     if (createErr != noErr) {
         LOG((CLOG_DEBUG "failed to create clipboard reference: error %i", createErr));
-        LOG((CLOG_ERR "unable to connect to pasteboard, clipboard sharing disabled", createErr));
+        LOG((CLOG_ERR "unable to connect to pasteboard, clipboard sharing disabled"));
         m_pboard = nullptr;
         return;
 
@@ -95,7 +95,7 @@ void OSXClipboard::add(EFormat format, const std::string& data)
     if (m_pboard == nullptr)
         return;
 
-    LOG((CLOG_DEBUG "add %d bytes to clipboard format: %d", data.size(), format));
+    LOG((CLOG_DEBUG "add %zd bytes to clipboard format: %d", data.size(), format));
     if (format == IClipboard::kText) {
         LOG((CLOG_DEBUG " format of data to be added to clipboard was kText"));
     }
@@ -126,7 +126,7 @@ void OSXClipboard::add(EFormat format, const std::string& data)
                 dataRef,
                 kPasteboardFlavorNoFlags);
 
-            LOG((CLOG_DEBUG "added %d bytes to clipboard format: %d", data.size(), format));
+            LOG((CLOG_DEBUG "added %zd bytes to clipboard format: %d", data.size(), format));
         }
 
     }

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -1063,7 +1063,7 @@ OSXScreen::onMouseMove(CGFloat mx, CGFloat my)
 			 x + bogusZoneSize > m_x + m_w - m_xCenter ||
 			-y + bogusZoneSize > m_yCenter - m_y ||
 			 y + bogusZoneSize > m_y + m_h - m_yCenter) {
-			LOG((CLOG_DEBUG "dropped bogus motion %+d,%+d", x, y));
+			LOG((CLOG_DEBUG "dropped bogus motion %+.2f,%+.2f", x, y));
 		}
 		else {
 			// send motion
@@ -1829,7 +1829,7 @@ OSXScreen::handleCGInputEventSecondary(
 		CGPoint pos = CGEventGetLocation(event);
 		if (pos.x != screen->m_xCenter || pos.y != screen->m_yCenter) {
 
-			LOG((CLOG_DEBUG "show cursor on secondary, type=%d pos=%d,%d",
+			LOG((CLOG_DEBUG "show cursor on secondary, type=%d pos=%.2f,%.2f",
 					type, pos.x, pos.y));
 			screen->showCursor();
 		}

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -336,7 +336,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x + w - 1;
         y2 = y;
-        LOG((CLOG_DEBUG "Barrier (top) %d at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG((CLOG_DEBUG "Barrier (top) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -350,7 +350,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x + w;
         y2 = y + h - 1;
-        LOG((CLOG_DEBUG "Barrier (right) %d at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG((CLOG_DEBUG "Barrier (right) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -364,7 +364,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x;
         y2 = y + h - 1;
-        LOG((CLOG_DEBUG "Barrier (left) %d at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG((CLOG_DEBUG "Barrier (left) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -378,7 +378,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y + h;
         x2 = x + w - 1;
         y2 = y + h;
-        LOG((CLOG_DEBUG "Barrier (bottom) %d at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG((CLOG_DEBUG "Barrier (bottom) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -139,7 +139,7 @@ XWindowsClipboard::addRequest(Window owner, Window requestor,
     // at the given time.
     bool success = false;
     if (owner == m_window) {
-        LOG((CLOG_DEBUG1 "request for clipboard %d, target %s by 0x%08x (property=%s)", m_selection, XWindowsUtil::atomToString(m_display, target).c_str(), requestor, XWindowsUtil::atomToString(m_display, property).c_str()));
+        LOG((CLOG_DEBUG1 "request for clipboard %ld, target %s by 0x%08lx (property=%s)", m_selection, XWindowsUtil::atomToString(m_display, target).c_str(), requestor, XWindowsUtil::atomToString(m_display, property).c_str()));
         if (wasOwnedAtTime(time)) {
             if (target == m_atomMultiple) {
                 // add a multiple request.  property may not be None
@@ -156,7 +156,7 @@ XWindowsClipboard::addRequest(Window owner, Window requestor,
             }
         }
         else {
-            LOG((CLOG_DEBUG1 "failed, not owned at time %d", time));
+            LOG((CLOG_DEBUG1 "failed, not owned at time %ld", time));
         }
     }
 
@@ -232,7 +232,7 @@ XWindowsClipboard::processRequest(Window requestor,
         // unknown requestor window
         return false;
     }
-    LOG((CLOG_DEBUG1 "received property %s delete from 0x08%x", XWindowsUtil::atomToString(m_display, property).c_str(), requestor));
+    LOG((CLOG_DEBUG1 "received property %s delete from 0x08%lx", XWindowsUtil::atomToString(m_display, property).c_str(), requestor));
 
     // find the property in the known requests.  it should be the
     // first property but we'll check 'em all if we have to.
@@ -320,7 +320,7 @@ void XWindowsClipboard::add(EFormat format, const std::string& data)
     assert(m_open);
     assert(m_owner);
 
-    LOG((CLOG_DEBUG "add %d bytes to clipboard %d format: %d", data.size(), m_id, format));
+    LOG((CLOG_DEBUG "add %zd bytes to clipboard %d format: %d", data.size(), m_id, format));
 
     m_data[format]  = data;
     m_added[format] = true;
@@ -586,7 +586,7 @@ XWindowsClipboard::icccmFillCache()
             // add to clipboard and note we've done it
             m_data[format]  = converter->toIClipboard(targetData);
             m_added[format] = true;
-            LOG((CLOG_DEBUG "  added format %d for target %s (%u %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+            LOG((CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
         } else {
             LOG((CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
             m_added[format] = false;
@@ -640,7 +640,7 @@ XWindowsClipboard::motifLockClipboard() const
     // fail if anybody owns the lock (even us, so this is non-recursive)
     Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
     if (lockOwner != None) {
-        LOG((CLOG_DEBUG1 "motif lock owner 0x%08x", lockOwner));
+        LOG((CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner));
         return false;
     }
 
@@ -652,7 +652,7 @@ XWindowsClipboard::motifLockClipboard() const
     m_impl->XSetSelectionOwner(m_display, m_atomMotifClipLock, m_window, time);
     lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
     if (lockOwner != m_window) {
-        LOG((CLOG_DEBUG1 "motif lock owner 0x%08x", lockOwner));
+        LOG((CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner));
         return false;
     }
 
@@ -848,7 +848,7 @@ XWindowsClipboard::motifFillCache()
             // add to clipboard and note we've done it
             m_data[format]  = converter->toIClipboard(targetData);
             m_added[format] = true;
-            LOG((CLOG_DEBUG "  added format %d for target %s (%u %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+            LOG((CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
         } else {
             LOG((CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
             m_added[format] = false;
@@ -1044,14 +1044,14 @@ XWindowsClipboard::sendReply(Reply* reply)
 
     // bail out immediately if reply is done
     if (reply->m_done) {
-        LOG((CLOG_DEBUG1 "clipboard: finished reply to 0x%08x,%d,%d", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG((CLOG_DEBUG1 "clipboard: finished reply to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
         return true;
     }
 
     // start in failed state if property is None
     bool failed = (reply->m_property == None);
     if (!failed) {
-        LOG((CLOG_DEBUG1 "clipboard: setting property on 0x%08x,%d,%d", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG((CLOG_DEBUG1 "clipboard: setting property on 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
 
         // send using INCR if already sending incrementally or if reply
         // is too large, otherwise just send it.
@@ -1100,7 +1100,7 @@ XWindowsClipboard::sendReply(Reply* reply)
     // the final zero-length property.
     // FIXME -- how do you gracefully cancel an incremental transfer?
     if (failed) {
-        LOG((CLOG_DEBUG1 "clipboard: sending failure to 0x%08x,%d,%d", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG((CLOG_DEBUG1 "clipboard: sending failure to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
         reply->m_done = true;
         if (reply->m_property != None) {
             XWindowsUtil::ErrorLock lock(m_display);
@@ -1130,7 +1130,7 @@ XWindowsClipboard::sendReply(Reply* reply)
 
     // send notification if we haven't yet
     if (!reply->m_replied) {
-        LOG((CLOG_DEBUG1 "clipboard: sending notify to 0x%08x,%d,%d", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG((CLOG_DEBUG1 "clipboard: sending notify to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
         reply->m_replied = true;
 
         // dump every property on the requestor window to the debug2
@@ -1142,7 +1142,7 @@ XWindowsClipboard::sendReply(Reply* reply)
             int n;
             Atom* props = m_impl->XListProperties(m_display, reply->m_requestor,
                                                   &n);
-            LOG((CLOG_DEBUG2 "properties of 0x%08x:", reply->m_requestor));
+            LOG((CLOG_DEBUG2 "properties of 0x%08lx:", reply->m_requestor));
             for (int i = 0; i < n; ++i) {
                 Atom target;
                 std::string data;
@@ -1331,7 +1331,7 @@ XWindowsClipboard::CICCCMGetClipboard::readClipboard(Display* display,
     assert(actualTarget != nullptr);
     assert(data != nullptr);
 
-    LOG((CLOG_DEBUG1 "request selection=%s, target=%s, window=%x", XWindowsUtil::atomToString(display, selection).c_str(), XWindowsUtil::atomToString(display, target).c_str(), m_requestor));
+    LOG((CLOG_DEBUG1 "request selection=%s, target=%s, window=%lx", XWindowsUtil::atomToString(display, selection).c_str(), XWindowsUtil::atomToString(display, target).c_str(), m_requestor));
 
     m_atomNone = XInternAtom(display, "NONE", False);
     m_atomIncr = XInternAtom(display, "INCR", False);
@@ -1518,7 +1518,7 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
 
         // note if this is the final chunk
         if (m_data->size() == oldSize) {
-            LOG((CLOG_DEBUG1 "  INCR final chunk: %d bytes total", m_data->size()));
+            LOG((CLOG_DEBUG1 "  INCR final chunk: %zd bytes total", m_data->size()));
             m_done = true;
         }
     }
@@ -1531,7 +1531,7 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
     }
 
     // this event has been processed
-    LOGC(!m_incr, (CLOG_DEBUG1 "  got data, %d bytes", m_data->size()));
+    LOGC(!m_incr, (CLOG_DEBUG1 "  got data, %zd bytes", m_data->size()));
     return true;
 }
 

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -117,7 +117,7 @@ XWindowsKeyState::mapModifiersFromX(unsigned int state) const
         if ((state & (1u << i)) != 0) {
             LOG((CLOG_DEBUG2 "|= modifier: %i", offset + i));
             if (offset + i >= m_modifierFromX.size()) {
-                LOG((CLOG_ERR "m_modifierFromX is too small (%d) for the "
+                LOG((CLOG_ERR "m_modifierFromX is too small (%zd) for the "
                     "requested offset (%d)", m_modifierFromX.size(), offset+i));
             } else {
                 mask |= m_modifierFromX[offset + i];

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -117,7 +117,7 @@ XWindowsScreen::XWindowsScreen(
         m_keyState    = new XWindowsKeyState(m_impl, m_display, m_xkb, events,
                                              m_keyMap);
 		LOG((CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_xinerama ? "(xinerama)" : ""));
-		LOG((CLOG_DEBUG "window is 0x%08x", m_window));
+		LOG((CLOG_DEBUG "window is 0x%08lx", m_window));
 	}
 	catch (...) {
         if (m_display != nullptr) {
@@ -1818,11 +1818,11 @@ XWindowsScreen::mapKeyFromX(XKeyEvent* event) const
         m_impl->XLookupString(event, dummy, 0, &keysym, nullptr);
 	}
 
-	LOG((CLOG_DEBUG2 "mapped code=%d to keysym=0x%04x", event->keycode, keysym));
+	LOG((CLOG_DEBUG2 "mapped code=%d to keysym=0x%04lx", event->keycode, keysym));
 
 	// convert key
 	KeyID result = XWindowsUtil::mapKeySymToKeyID(keysym);
-	LOG((CLOG_DEBUG2 "mapped keysym=0x%04x to keyID=%d", keysym, result));
+	LOG((CLOG_DEBUG2 "mapped keysym=0x%04lx to keyID=%d", keysym, result));
 	return result;
 }
 

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -319,7 +319,7 @@ XWindowsScreenSaver::findXScreenSaver()
 void
 XWindowsScreenSaver::setXScreenSaver(Window window)
 {
-    LOG((CLOG_DEBUG "xscreensaver window: 0x%08x", window));
+    LOG((CLOG_DEBUG "xscreensaver window: 0x%08lx", window));
 
     // save window
     m_xscreensaver = window;
@@ -362,7 +362,7 @@ void
 XWindowsScreenSaver::setXScreenSaverActive(bool activated)
 {
     if (m_xscreensaverActive != activated) {
-        LOG((CLOG_DEBUG "xscreensaver %s on window 0x%08x", activated ? "activated" : "deactivated", m_xscreensaver));
+        LOG((CLOG_DEBUG "xscreensaver %s on window 0x%08lx", activated ? "activated" : "deactivated", m_xscreensaver));
         m_xscreensaverActive = activated;
 
         // if screen saver was activated forcefully (i.e. against
@@ -395,7 +395,7 @@ XWindowsScreenSaver::sendXScreenSaverCommand(Atom cmd, long arg1, long arg2)
     event.xclient.data.l[3]    = 0;
     event.xclient.data.l[4]    = 0;
 
-    LOG((CLOG_DEBUG "send xscreensaver command: %d %d %d", static_cast<long>(cmd), arg1, arg2));
+    LOG((CLOG_DEBUG "send xscreensaver command: %ld %ld %ld", static_cast<long>(cmd), arg1, arg2));
     bool error = false;
     {
         XWindowsUtil::ErrorLock lock(m_display, &error);

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1411,11 +1411,11 @@ bool XWindowsUtil::getWindowProperty(Display* display, Window window, Atom prope
     }
 
     if (okay) {
-        LOG((CLOG_DEBUG2 "read property %d on window 0x%08x: bytes=%d", property, window, (data == nullptr) ? 0 : data->size()));
+        LOG((CLOG_DEBUG2 "read property %ld on window 0x%08lx: bytes=%zd", property, window, (data == nullptr) ? 0 : data->size()));
         return true;
     }
     else {
-        LOG((CLOG_DEBUG2 "can't read property %d on window 0x%08x", property, window));
+        LOG((CLOG_DEBUG2 "can't read property %ld on window 0x%08lx", property, window));
         return false;
     }
 }

--- a/src/lib/server/ClientConnectionLoggingWrapper.cpp
+++ b/src/lib/server/ClientConnectionLoggingWrapper.cpp
@@ -120,7 +120,7 @@ void ClientConnectionLoggingWrapper::send_mouse_wheel_1_6(std::int32_t x_delta, 
 void ClientConnectionLoggingWrapper::send_drag_info_1_6(std::uint32_t file_count,
                                                         const std::string& data)
 {
-    LOG((CLOG_DEBUG2 "send drag info to \"%s\" %d, %d", name_.c_str(), file_count, data.size()));
+    LOG((CLOG_DEBUG2 "send drag info to \"%s\" %d, %zd", name_.c_str(), file_count, data.size()));
     conn_->send_drag_info_1_6(file_count, data);
 }
 
@@ -138,7 +138,7 @@ void ClientConnectionLoggingWrapper::send_reset_options_1_6()
 
 void ClientConnectionLoggingWrapper::send_set_options_1_6(const OptionsList& options)
 {
-    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%d", name_.c_str(), options.size()));
+    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%zd", name_.c_str(), options.size()));
     conn_->send_set_options_1_6(options);
 }
 
@@ -168,7 +168,7 @@ void ClientConnectionLoggingWrapper::send_clipboard_chunk_1_6(const ClipboardChu
         break;
 
     case kDataChunk:
-        LOG((CLOG_DEBUG2 "sending clipboard chunk data: size=%i", chunk.data_.size()));
+        LOG((CLOG_DEBUG2 "sending clipboard chunk data: size=%zi", chunk.data_.size()));
         break;
 
     case kDataEnd:
@@ -188,7 +188,7 @@ void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)
         break;
 
     case kDataChunk:
-        LOG((CLOG_DEBUG2 "sending file chunk: size=%i", chunk.data_.size()));
+        LOG((CLOG_DEBUG2 "sending file chunk: size=%zi", chunk.data_.size()));
         break;
 
     case kDataEnd:

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -196,7 +196,7 @@ bool ClientProxy1_6::parseHandshakeMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
-        LOG((CLOG_DEBUG2 "no-op from", getName().c_str()));
+        LOG((CLOG_DEBUG2 "no-op from %s", getName().c_str()));
         return true;
     }
     else if (memcmp(code, kMsgDInfo, 4) == 0) {
@@ -234,7 +234,7 @@ bool ClientProxy1_6::parseMessage(const std::uint8_t* code)
     }
     else if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
-        LOG((CLOG_DEBUG2 "no-op from", getName().c_str()));
+        LOG((CLOG_DEBUG2 "no-op from %s", getName().c_str()));
         return true;
     }
     else if (memcmp(code, kMsgCClipboard, 4) == 0) {
@@ -462,9 +462,9 @@ bool ClientProxy1_6::recvClipboard()
 
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
-        LOG((CLOG_DEBUG "receiving clipboard %d size=%d", id, size));
+        LOG((CLOG_DEBUG "receiving clipboard %d size=%zd", id, size));
     } else if (r == kFinish) {
-        LOG((CLOG_DEBUG "received client \"%s\" clipboard %d seqnum=%d, size=%d",
+        LOG((CLOG_DEBUG "received client \"%s\" clipboard %d seqnum=%d, size=%zd",
                 getName().c_str(), id, seq, dataCached.size()));
         // save clipboard
         m_clipboard[id].m_clipboard.unmarshall(dataCached, 0);

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1477,7 +1477,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 	// ignore if data hasn't changed
     std::string data = clipboard.m_clipboard.marshall();
 	if (data.size() > m_maximumClipboardSize) {
-		LOG((CLOG_NOTE "not updating clipboard because it's over the size limit (%i KB) configured by the server",
+		LOG((CLOG_NOTE "not updating clipboard because it's over the size limit (%zi KB) configured by the server",
 			m_maximumClipboardSize));
 		return;
 	}
@@ -1806,7 +1806,7 @@ Server::sendDragInfo(BaseClientProxy* newScreen)
 
 		LOG((CLOG_DEBUG2 "sending drag information to client"));
 		LOG((CLOG_DEBUG3 "dragging file list: %s", info));
-		LOG((CLOG_DEBUG3 "dragging file list string size: %i", size));
+		LOG((CLOG_DEBUG3 "dragging file list string size: %zi", size));
 		newScreen->sendDragInfo(fileCount, info, size);
 	}
 }

--- a/src/test/integtests/ipc/IpcTests.cpp
+++ b/src/test/integtests/ipc/IpcTests.cpp
@@ -180,7 +180,7 @@ void IpcTests::sendMessageToServer_serverHandleMessageReceived(const Event& e)
     }
     else if (m.type() == kIpcCommand) {
         const auto& cm = static_cast<const IpcCommandMessage&>(m);
-        LOG((CLOG_DEBUG "got ipc command message, %d", cm.command().c_str()));
+        LOG((CLOG_DEBUG "got ipc command message, %s", cm.command().c_str()));
         m_sendMessageToServer_receivedString = cm.command();
         m_events.raiseQuitEvent();
     }
@@ -201,7 +201,7 @@ void IpcTests::sendMessageToClient_client_handle_message_received(const Event& e
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcLogLine) {
         const auto& llm = static_cast<const IpcLogLineMessage&>(m);
-        LOG((CLOG_DEBUG "got ipc log message, %d", llm.logLine().c_str()));
+        LOG((CLOG_DEBUG "got ipc log message, %s", llm.logLine().c_str()));
         m_sendMessageToClient_receivedString = llm.logLine();
         m_events.raiseQuitEvent();
     }


### PR DESCRIPTION
Wanted to add some log messages for debugging and ended up fixing a whole bunch of annoyances with the log system.

Notably: using `_X_ATTRIBUTE_PRINTF` (stolen from `XFuncproto.h`) and the cmake change means we have `-Wformat` enabled by default now where available which should catch a few errors quickly. I ran into this when I was trying to printf a `std::string` and the compiler didn't tell me.

The last commit simplifies the actual log buffer handling, hopefully to the same result :)


This is on top of #1854 because I didn't want to have to deal with the rebases.
There are some warnings left which are fixed in #1853.