### PR TITLE
Switch to LOG_DEBUG style log macros

### DIFF
--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -102,7 +102,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
     int chdirErr = chdir("/");
     if (chdirErr)
         // NB: file logging actually isn't working at this point!
-        LOG(CLOG_ERR "chdir error: %i", chdirErr);
+        LOG_ERR("chdir error: %i", chdirErr);
 #endif
 
     // mask off permissions for any but owner
@@ -122,7 +122,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
 
     if (dupErr < 0) {
         // NB: file logging actually isn't working at this point!
-        LOG(CLOG_ERR "dup error: %i", dupErr);
+        LOG_ERR("dup error: %i", dupErr);
     }
 
 #ifdef __APPLE__

--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -102,7 +102,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
     int chdirErr = chdir("/");
     if (chdirErr)
         // NB: file logging actually isn't working at this point!
-        LOG((CLOG_ERR "chdir error: %i", chdirErr));
+        LOG(CLOG_ERR "chdir error: %i", chdirErr);
 #endif
 
     // mask off permissions for any but owner
@@ -122,7 +122,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
 
     if (dupErr < 0) {
         // NB: file logging actually isn't working at this point!
-        LOG((CLOG_ERR "dup error: %i", dupErr));
+        LOG(CLOG_ERR "dup error: %i", dupErr);
     }
 
 #ifdef __APPLE__

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -435,7 +435,7 @@ ArchMiscWindows::wasLaunchedAsService()
 {
     std::string name;
     if (!getParentProcessName(name)) {
-        LOG(CLOG_ERR "cannot determine if process was launched as service");
+        LOG_ERR("cannot determine if process was launched as service");
         return false;
     }
 
@@ -446,7 +446,7 @@ bool ArchMiscWindows::getParentProcessName(std::string &name)
 {
     PROCESSENTRY32 parentEntry;
     if (!getParentProcessEntry(parentEntry)) {
-        LOG(CLOG_ERR "could not get entry for parent process");
+        LOG_ERR("could not get entry for parent process");
         return false;
     }
 
@@ -480,7 +480,7 @@ ArchMiscWindows::getProcessEntry(PROCESSENTRY32& entry, DWORD processID)
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG(CLOG_ERR "could not get process snapshot (error: %i)",
+        LOG_ERR("could not get process snapshot (error: %i)",
             GetLastError());
         return FALSE;
     }
@@ -491,7 +491,7 @@ ArchMiscWindows::getProcessEntry(PROCESSENTRY32& entry, DWORD processID)
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG(CLOG_ERR "could not get first process entry (error: %i)",
+        LOG_ERR("could not get first process entry (error: %i)",
             GetLastError());
         return FALSE;
     }

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -435,7 +435,7 @@ ArchMiscWindows::wasLaunchedAsService()
 {
     std::string name;
     if (!getParentProcessName(name)) {
-        LOG((CLOG_ERR "cannot determine if process was launched as service"));
+        LOG(CLOG_ERR "cannot determine if process was launched as service");
         return false;
     }
 
@@ -446,7 +446,7 @@ bool ArchMiscWindows::getParentProcessName(std::string &name)
 {
     PROCESSENTRY32 parentEntry;
     if (!getParentProcessEntry(parentEntry)) {
-        LOG((CLOG_ERR "could not get entry for parent process"));
+        LOG(CLOG_ERR "could not get entry for parent process");
         return false;
     }
 
@@ -480,8 +480,8 @@ ArchMiscWindows::getProcessEntry(PROCESSENTRY32& entry, DWORD processID)
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG((CLOG_ERR "could not get process snapshot (error: %i)",
-            GetLastError()));
+        LOG(CLOG_ERR "could not get process snapshot (error: %i)",
+            GetLastError());
         return FALSE;
     }
 
@@ -491,8 +491,8 @@ ArchMiscWindows::getProcessEntry(PROCESSENTRY32& entry, DWORD processID)
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG((CLOG_ERR "could not get first process entry (error: %i)",
-            GetLastError()));
+        LOG(CLOG_ERR "could not get first process entry (error: %i)",
+            GetLastError());
         return FALSE;
     }
 

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -63,9 +63,9 @@ EventQueue::loop()
         is_ready_ = true;
         ready_cv_.notify_one();
     }
-    LOG(CLOG_DEBUG "event queue is ready");
+    LOG_DEBUG("event queue is ready");
     while (!m_pending.empty()) {
-        LOG(CLOG_DEBUG "add pending events to buffer");
+        LOG_DEBUG("add pending events to buffer");
         Event& event = m_pending.front();
         add_event_to_buffer(std::move(event));
         m_pending.pop();
@@ -84,12 +84,12 @@ void EventQueue::set_buffer(std::unique_ptr<IEventQueueBuffer> buffer)
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    LOG(CLOG_DEBUG "adopting new buffer");
+    LOG_DEBUG("adopting new buffer");
 
     if (m_events.size() != 0) {
         // this can come as a nasty surprise to programmers expecting
         // their events to be raised, only to have them deleted.
-        LOG(CLOG_DEBUG "discarding %zd event(s)", m_events.size());
+        LOG_DEBUG("discarding %zd event(s)", m_events.size());
     }
 
     // discard old buffer and old events

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -63,9 +63,9 @@ EventQueue::loop()
         is_ready_ = true;
         ready_cv_.notify_one();
     }
-    LOG((CLOG_DEBUG "event queue is ready"));
+    LOG(CLOG_DEBUG "event queue is ready");
     while (!m_pending.empty()) {
-        LOG((CLOG_DEBUG "add pending events to buffer"));
+        LOG(CLOG_DEBUG "add pending events to buffer");
         Event& event = m_pending.front();
         add_event_to_buffer(std::move(event));
         m_pending.pop();
@@ -84,12 +84,12 @@ void EventQueue::set_buffer(std::unique_ptr<IEventQueueBuffer> buffer)
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    LOG((CLOG_DEBUG "adopting new buffer"));
+    LOG(CLOG_DEBUG "adopting new buffer");
 
     if (m_events.size() != 0) {
         // this can come as a nasty surprise to programmers expecting
         // their events to be raised, only to have them deleted.
-        LOG((CLOG_DEBUG "discarding %zd event(s)", m_events.size()));
+        LOG(CLOG_DEBUG "discarding %zd event(s)", m_events.size());
     }
 
     // discard old buffer and old events

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -113,21 +113,8 @@ Log::getFilterName(int level) const
 }
 
 void
-Log::print(const char* file, int line, const char* fmt, ...)
+Log::print(ELevel priority, const char* file, int line, const char* fmt, ...)
 {
-    // check if fmt begins with a priority argument
-    ELevel priority = kINFO;
-    if ((strlen(fmt) > 2) && (fmt[0] == '@' && fmt[1] == 'z')) {
-
-        // 060 in octal is 0 (48 in decimal), so subtracting this converts ascii
-        // number it a true number. we could use atoi instead, but this is how
-        // it was done originally.
-        priority = static_cast<ELevel>(fmt[2] - '\060');
-
-        // move the pointer on past the debug priority char
-        fmt += 3;
-    }
-
     // done if below priority threshold
     if (priority > getFilter()) {
         return;

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -143,13 +143,11 @@ private:
 
 /*!
 \def LOG(arg)
-Write to the log.  Because macros cannot accept variable arguments, this
-should be invoked like so:
+Write to the log. This should be invoked like so:
 \code
-LOG((CLOG_XXX "%d and %d are %s", x, y, x == y ? "equal" : "not equal"));
+LOG(CLOG_XXX "%d and %d are %s", x, y, x == y ? "equal" : "not equal");
 \endcode
-In particular, notice the double open and close parentheses.  Also note
-that there is no comma after the \c CLOG_XXX.  The \c XXX should be
+Note that there is no comma after the \c CLOG_XXX.  The \c XXX should be
 replaced by one of enumerants in \c Log::ELevel without the leading
 \c k.  For example, \c CLOG_INFO.  The special \c CLOG_PRINT level will
 not be filtered and is never prefixed by the filename and line number.
@@ -162,13 +160,11 @@ which includes the filename and line number.
 
 /*!
 \def LOGC(expr, arg)
-Write to the log if and only if expr is true.  Because macros cannot accept
-variable arguments, this should be invoked like so:
+Write to the log if and only if expr is true. This should be invoked like so:
 \code
-LOGC(x == y, (CLOG_XXX "%d and %d are equal", x, y));
+LOGC(x == y, CLOG_XXX "%d and %d are equal", x, y);
 \endcode
-In particular, notice the parentheses around everything after the boolean
-expression.    Also note that there is no comma after the \c CLOG_XXX.
+Note that there is no comma after the \c CLOG_XXX.
 The \c XXX should be replaced by one of enumerants in \c Log::ELevel
 without the leading \c k.  For example, \c CLOG_INFO.  The special
 \c CLOG_PRINT level will not be filtered and is never prefixed by the
@@ -181,35 +177,32 @@ otherwise it expands to a call that doesn't.
 */
 
 #if defined(NOLOGGING)
-#define LOG(_a1)
-#define LOGC(_a1, _a2)
-#define CLOG_TRACE
+#define LOG(...)
+#define LOGC(_a1, ...)
 #elif defined(NDEBUG)
-#define LOG(_a1)        CLOG->print _a1
-#define LOGC(_a1, _a2)    if (_a1) CLOG->print _a2
-#define CLOG_TRACE        nullptr, 0,
+#define LOG(...)        CLOG->print(nullptr, 0, __VA_ARGS__)
+#define LOGC(_a1, ...)    if (_a1) CLOG->print(nullptr, 0, __VA_ARGS__)
 #else
-#define LOG(_a1)        CLOG->print _a1
-#define LOGC(_a1, _a2)    if (_a1) CLOG->print _a2
-#define CLOG_TRACE        __FILE__, __LINE__,
+#define LOG(...)        CLOG->print(__FILE__, __LINE__, __VA_ARGS__)
+#define LOGC(_a1, ...)    if (_a1) CLOG->print(__FILE__, __LINE__, __VA_ARGS__)
 #endif
 
-// the CLOG_* defines are line and file plus %z and an octal number (060=0,
-// 071=9), but the limitation is that once we run out of numbers at either
+// the CLOG_* defines %z and an octal number (060=0, 071=9),
+// but the limitation is that once we run out of numbers at either
 // end, then we resort to using non-numerical chars. this still works (since
 // to deduce the number we subtract octal \060, so '/' is -1, and ':' is 10
 
-#define CLOG_PRINT        CLOG_TRACE "@z\057" // char is '/'
-#define CLOG_CRIT        CLOG_TRACE "@z\060" // char is '0'
-#define CLOG_ERR        CLOG_TRACE "@z\061"
-#define CLOG_WARN        CLOG_TRACE "@z\062"
-#define CLOG_NOTE        CLOG_TRACE "@z\063"
-#define CLOG_INFO        CLOG_TRACE "@z\064"
-#define CLOG_DEBUG        CLOG_TRACE "@z\065"
-#define CLOG_DEBUG1        CLOG_TRACE "@z\066"
-#define CLOG_DEBUG2        CLOG_TRACE "@z\067"
-#define CLOG_DEBUG3        CLOG_TRACE "@z\070"
-#define CLOG_DEBUG4        CLOG_TRACE "@z\071" // char is '9'
-#define CLOG_DEBUG5        CLOG_TRACE "@z\072" // char is ':'
+#define CLOG_PRINT        "@z\057" // char is '/'
+#define CLOG_CRIT        "@z\060" // char is '0'
+#define CLOG_ERR        "@z\061"
+#define CLOG_WARN        "@z\062"
+#define CLOG_NOTE        "@z\063"
+#define CLOG_INFO        "@z\064"
+#define CLOG_DEBUG        "@z\065"
+#define CLOG_DEBUG1        "@z\066"
+#define CLOG_DEBUG2        "@z\067"
+#define CLOG_DEBUG3        "@z\070"
+#define CLOG_DEBUG4        "@z\071" // char is '9'
+#define CLOG_DEBUG5        "@z\072" // char is ':'
 
 } // namespace inputleap

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -38,8 +38,8 @@ class Thread;
 /*!
 The logging class;  all console output should go through this class.
 It supports multithread safe operation, several message priority levels,
-filtering by priority, and output redirection.  The macros LOG() and
-LOGC() provide convenient access.
+filtering by priority, and output redirection.  The macros LOG_DEBUG(),
+LOG_INFO() etc. provide convenient access.
 */
 class Log {
 public:
@@ -106,9 +106,10 @@ public:
     preceded by the filename and line number.  If \c file is nullptr then
     neither the file nor the line are printed.
     */
-    _X_ATTRIBUTE_PRINTF(4, 5)
-    void print(const char* file, int line,
-                            const char* format, ...);
+    _X_ATTRIBUTE_PRINTF(5, 6)
+    void print(ELevel priority,
+               const char* file, int line,
+               const char* format, ...);
 
     //! Get the minimum priority level.
     int getFilter() const;
@@ -158,33 +159,12 @@ call to Log::print.  Otherwise it expands to a call to Log::printt,
 which includes the filename and line number.
 */
 
-/*!
-\def LOGC(expr, arg)
-Write to the log if and only if expr is true. This should be invoked like so:
-\code
-LOGC(x == y, CLOG_XXX "%d and %d are equal", x, y);
-\endcode
-Note that there is no comma after the \c CLOG_XXX.
-The \c XXX should be replaced by one of enumerants in \c Log::ELevel
-without the leading \c k.  For example, \c CLOG_INFO.  The special
-\c CLOG_PRINT level will not be filtered and is never prefixed by the
-filename and line number.
-
-If \c NOLOGGING is defined during the build then this macro expands to
-nothing.  If \c NDEBUG is not defined during the build then it expands
-to a call to Log::print that prints the filename and line number,
-otherwise it expands to a call that doesn't.
-*/
-
 #if defined(NOLOGGING)
-#define LOG(...)
-#define LOGC(_a1, ...)
+#define LOG(...) do { } while(0)
 #elif defined(NDEBUG)
-#define LOG(...)        CLOG->print(nullptr, 0, __VA_ARGS__)
-#define LOGC(_a1, ...)    if (_a1) CLOG->print(nullptr, 0, __VA_ARGS__)
+#define LOG(pri_, ...) CLOG->print(pri_, nullptr, 0, __VA_ARGS__)
 #else
-#define LOG(...)        CLOG->print(__FILE__, __LINE__, __VA_ARGS__)
-#define LOGC(_a1, ...)    if (_a1) CLOG->print(__FILE__, __LINE__, __VA_ARGS__)
+#define LOG(pri_, ...) CLOG->print(pri_, __FILE__, __LINE__, __VA_ARGS__)
 #endif
 
 // the CLOG_* defines %z and an octal number (060=0, 071=9),
@@ -192,17 +172,17 @@ otherwise it expands to a call that doesn't.
 // end, then we resort to using non-numerical chars. this still works (since
 // to deduce the number we subtract octal \060, so '/' is -1, and ':' is 10
 
-#define CLOG_PRINT        "@z\057" // char is '/'
-#define CLOG_CRIT        "@z\060" // char is '0'
-#define CLOG_ERR        "@z\061"
-#define CLOG_WARN        "@z\062"
-#define CLOG_NOTE        "@z\063"
-#define CLOG_INFO        "@z\064"
-#define CLOG_DEBUG        "@z\065"
-#define CLOG_DEBUG1        "@z\066"
-#define CLOG_DEBUG2        "@z\067"
-#define CLOG_DEBUG3        "@z\070"
-#define CLOG_DEBUG4        "@z\071" // char is '9'
-#define CLOG_DEBUG5        "@z\072" // char is ':'
+#define LOG_PRINT(...)  LOG(kPRINT, __VA_ARGS__)
+#define LOG_CRIT(...)   LOG(kFATAL, __VA_ARGS__)
+#define LOG_ERR(...)    LOG(kERROR, __VA_ARGS__)
+#define LOG_WARN(...)   LOG(kWARNING, __VA_ARGS__)
+#define LOG_NOTE(...)   LOG(kNOTE, __VA_ARGS__)
+#define LOG_INFO(...)   LOG(kINFO, __VA_ARGS__)
+#define LOG_DEBUG(...)  LOG(kDEBUG, __VA_ARGS__)
+#define LOG_DEBUG1(...) LOG(kDEBUG1, __VA_ARGS__)
+#define LOG_DEBUG2(...) LOG(kDEBUG2, __VA_ARGS__)
+#define LOG_DEBUG3(...) LOG(kDEBUG3, __VA_ARGS__)
+#define LOG_DEBUG4(...) LOG(kDEBUG4, __VA_ARGS__)
+#define LOG_DEBUG5(...) LOG(kDEBUG5, __VA_ARGS__)
 
 } // namespace inputleap

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -133,10 +133,10 @@ Client::connect()
         // m_serverAddress will be null if the hostname address is not reolved
         if (m_serverAddress.getAddress() != nullptr) {
           // to help users troubleshoot, show server host name (issue: 60)
-          LOG((CLOG_NOTE "connecting to '%s': %s:%i",
+          LOG(CLOG_NOTE "connecting to '%s': %s:%i",
           m_serverAddress.getHostname().c_str(),
           ARCH->addrToString(m_serverAddress.getAddress()).c_str(),
-          m_serverAddress.getPort()));
+          m_serverAddress.getPort());
         }
 
         // create the socket
@@ -147,7 +147,7 @@ Client::connect()
         m_stream = new PacketStreamFilter(m_events, std::move(socket));
 
         // connect
-        LOG((CLOG_DEBUG1 "connecting to server"));
+        LOG(CLOG_DEBUG1 "connecting to server");
         setupConnecting();
         setupTimer();
         socket_ptr->connect(m_serverAddress);
@@ -156,7 +156,7 @@ Client::connect()
         cleanupTimer();
         cleanupConnecting();
         cleanupStream();
-        LOG((CLOG_DEBUG1 "connection failed"));
+        LOG(CLOG_DEBUG1 "connection failed");
         sendConnectionFailedEvent(e.what());
         return;
     }
@@ -343,7 +343,7 @@ Client::setOptions(const OptionsList& options)
         if (id == kOptionClipboardSharing) {
             index++;
             if (*index == static_cast<OptionValue>(false)) {
-                LOG((CLOG_NOTE "clipboard sharing is disabled"));
+                LOG(CLOG_NOTE "clipboard sharing is disabled");
             }
             m_enableClipboard = *index;
 
@@ -358,8 +358,8 @@ Client::setOptions(const OptionsList& options)
 
     if (m_enableClipboard && !m_maximumClipboardSize) {
         m_enableClipboard = false;
-        LOG((CLOG_NOTE "clipboard sharing is disabled because the server "
-                       "set the maximum clipboard size to 0"));
+        LOG(CLOG_NOTE "clipboard sharing is disabled because the server "
+                       "set the maximum clipboard size to 0");
     }
 
     m_screen->setOptions(options);
@@ -397,9 +397,9 @@ Client::sendClipboard(ClipboardID id)
         // marshall the data
         std::string data = clipboard.marshall();
         if (data.size() >= m_maximumClipboardSize) {
-            LOG((CLOG_NOTE "Skipping clipboard transfer because the clipboard"
+            LOG(CLOG_NOTE "Skipping clipboard transfer because the clipboard"
                 " contents exceeds the %zi MB size limit set by the server",
-                m_maximumClipboardSize));
+                m_maximumClipboardSize);
             return;
         }
 
@@ -428,7 +428,7 @@ Client::sendConnectionFailedEvent(const char* msg)
 
 void Client::send_file_chunk(const FileChunk& chunk)
 {
-    LOG((CLOG_DEBUG1 "send file chunk"));
+    LOG(CLOG_DEBUG1 "send file chunk");
     assert(m_server != nullptr);
 
     m_server->file_chunk_sending(chunk);
@@ -552,7 +552,7 @@ Client::cleanupStream()
 void
 Client::handle_connected()
 {
-    LOG((CLOG_DEBUG1 "connected;  wait for hello"));
+    LOG(CLOG_DEBUG1 "connected;  wait for hello");
     cleanupConnecting();
     setupConnection();
 
@@ -571,7 +571,7 @@ void Client::handle_connection_failed(const Event& event)
     cleanupTimer();
     cleanupConnecting();
     cleanupStream();
-    LOG((CLOG_DEBUG1 "connection failed"));
+    LOG(CLOG_DEBUG1 "connection failed");
     sendConnectionFailedEvent(info.m_what.c_str());
 }
 
@@ -581,7 +581,7 @@ void Client::handle_connect_timeout()
     cleanupConnecting();
     cleanupConnection();
     cleanupStream();
-    LOG((CLOG_DEBUG1 "connection timed out"));
+    LOG(CLOG_DEBUG1 "connection timed out");
     sendConnectionFailedEvent("Timed out");
 }
 
@@ -590,7 +590,7 @@ void Client::handle_output_error()
     cleanupTimer();
     cleanupScreen();
     cleanupConnection();
-    LOG((CLOG_WARN "error sending to server"));
+    LOG(CLOG_WARN "error sending to server");
     send_event(EventType::CLIENT_DISCONNECTED);
 }
 
@@ -599,13 +599,13 @@ void Client::handle_disconnected()
     cleanupTimer();
     cleanupScreen();
     cleanupConnection();
-    LOG((CLOG_DEBUG1 "disconnected"));
+    LOG(CLOG_DEBUG1 "disconnected");
     send_event(EventType::CLIENT_DISCONNECTED);
 }
 
 void Client::handle_shape_changed()
 {
-    LOG((CLOG_DEBUG "resolution changed"));
+    LOG(CLOG_DEBUG "resolution changed");
     m_server->onInfoChanged();
 }
 
@@ -643,7 +643,7 @@ void Client::handle_hello()
     }
 
     // check versions
-    LOG((CLOG_DEBUG1 "got hello version %d.%d", major, minor));
+    LOG(CLOG_DEBUG1 "got hello version %d.%d", major, minor);
     if (major < kProtocolMajorVersion ||
         (major == kProtocolMajorVersion && minor < kProtocolMinorVersion)) {
         sendConnectionFailedEvent(XIncompatibleClient(major, minor).what());
@@ -653,7 +653,7 @@ void Client::handle_hello()
     }
 
     // say hello back
-    LOG((CLOG_DEBUG1 "say hello version %d.%d", kProtocolMajorVersion, kProtocolMinorVersion));
+    LOG(CLOG_DEBUG1 "say hello version %d.%d", kProtocolMajorVersion, kProtocolMinorVersion);
     ProtocolUtil::writef(m_stream, kMsgHelloBack,
                             kProtocolMajorVersion,
                             kProtocolMinorVersion, &m_name);
@@ -672,7 +672,7 @@ void Client::handle_hello()
 
 void Client::handle_suspend()
 {
-    LOG((CLOG_INFO "suspend"));
+    LOG(CLOG_INFO "suspend");
     m_suspended       = true;
     bool wasConnected = isConnected();
     disconnect(nullptr);
@@ -681,7 +681,7 @@ void Client::handle_suspend()
 
 void Client::handle_resume()
 {
-    LOG((CLOG_INFO "resume"));
+    LOG(CLOG_INFO "resume");
     m_suspended = false;
     if (m_connectOnResume) {
         m_connectOnResume = false;
@@ -716,7 +716,7 @@ void Client::handle_stop_retry()
 
 void Client::write_to_drop_dir_thread()
 {
-    LOG((CLOG_DEBUG "starting write to drop dir thread"));
+    LOG(CLOG_DEBUG "starting write to drop dir thread");
 
     while (m_screen->isFakeDraggingStarted()) {
         inputleap::this_thread_sleep(.1f);
@@ -730,7 +730,7 @@ void Client::dragInfoReceived(std::uint32_t fileNum, std::string data)
 {
     // TODO: fix duplicate function from CServer
     if (!m_args.m_enableDragDrop) {
-        LOG((CLOG_DEBUG "drag drop not enabled, ignoring drag info."));
+        LOG(CLOG_DEBUG "drag drop not enabled, ignoring drag info.");
         return;
     }
 
@@ -761,7 +761,7 @@ void Client::send_file_thread(const char* filename)
         StreamChunker::sendFile(filename, m_events, this);
     }
     catch (std::runtime_error& error) {
-        LOG((CLOG_ERR "failed sending file chunks: %s", error.what()));
+        LOG(CLOG_ERR "failed sending file chunks: %s", error.what());
     }
 
     m_sendFileThread = nullptr;

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -133,7 +133,7 @@ Client::connect()
         // m_serverAddress will be null if the hostname address is not reolved
         if (m_serverAddress.getAddress() != nullptr) {
           // to help users troubleshoot, show server host name (issue: 60)
-          LOG(CLOG_NOTE "connecting to '%s': %s:%i",
+          LOG_NOTE("connecting to '%s': %s:%i",
           m_serverAddress.getHostname().c_str(),
           ARCH->addrToString(m_serverAddress.getAddress()).c_str(),
           m_serverAddress.getPort());
@@ -147,7 +147,7 @@ Client::connect()
         m_stream = new PacketStreamFilter(m_events, std::move(socket));
 
         // connect
-        LOG(CLOG_DEBUG1 "connecting to server");
+        LOG_DEBUG1("connecting to server");
         setupConnecting();
         setupTimer();
         socket_ptr->connect(m_serverAddress);
@@ -156,7 +156,7 @@ Client::connect()
         cleanupTimer();
         cleanupConnecting();
         cleanupStream();
-        LOG(CLOG_DEBUG1 "connection failed");
+        LOG_DEBUG1("connection failed");
         sendConnectionFailedEvent(e.what());
         return;
     }
@@ -343,7 +343,7 @@ Client::setOptions(const OptionsList& options)
         if (id == kOptionClipboardSharing) {
             index++;
             if (*index == static_cast<OptionValue>(false)) {
-                LOG(CLOG_NOTE "clipboard sharing is disabled");
+                LOG_NOTE("clipboard sharing is disabled");
             }
             m_enableClipboard = *index;
 
@@ -358,7 +358,7 @@ Client::setOptions(const OptionsList& options)
 
     if (m_enableClipboard && !m_maximumClipboardSize) {
         m_enableClipboard = false;
-        LOG(CLOG_NOTE "clipboard sharing is disabled because the server "
+        LOG_NOTE("clipboard sharing is disabled because the server "
                        "set the maximum clipboard size to 0");
     }
 
@@ -397,7 +397,7 @@ Client::sendClipboard(ClipboardID id)
         // marshall the data
         std::string data = clipboard.marshall();
         if (data.size() >= m_maximumClipboardSize) {
-            LOG(CLOG_NOTE "Skipping clipboard transfer because the clipboard"
+            LOG_NOTE("Skipping clipboard transfer because the clipboard"
                 " contents exceeds the %zi MB size limit set by the server",
                 m_maximumClipboardSize);
             return;
@@ -428,7 +428,7 @@ Client::sendConnectionFailedEvent(const char* msg)
 
 void Client::send_file_chunk(const FileChunk& chunk)
 {
-    LOG(CLOG_DEBUG1 "send file chunk");
+    LOG_DEBUG1("send file chunk");
     assert(m_server != nullptr);
 
     m_server->file_chunk_sending(chunk);
@@ -552,7 +552,7 @@ Client::cleanupStream()
 void
 Client::handle_connected()
 {
-    LOG(CLOG_DEBUG1 "connected;  wait for hello");
+    LOG_DEBUG1("connected;  wait for hello");
     cleanupConnecting();
     setupConnection();
 
@@ -571,7 +571,7 @@ void Client::handle_connection_failed(const Event& event)
     cleanupTimer();
     cleanupConnecting();
     cleanupStream();
-    LOG(CLOG_DEBUG1 "connection failed");
+    LOG_DEBUG1("connection failed");
     sendConnectionFailedEvent(info.m_what.c_str());
 }
 
@@ -581,7 +581,7 @@ void Client::handle_connect_timeout()
     cleanupConnecting();
     cleanupConnection();
     cleanupStream();
-    LOG(CLOG_DEBUG1 "connection timed out");
+    LOG_DEBUG1("connection timed out");
     sendConnectionFailedEvent("Timed out");
 }
 
@@ -590,7 +590,7 @@ void Client::handle_output_error()
     cleanupTimer();
     cleanupScreen();
     cleanupConnection();
-    LOG(CLOG_WARN "error sending to server");
+    LOG_WARN("error sending to server");
     send_event(EventType::CLIENT_DISCONNECTED);
 }
 
@@ -599,13 +599,13 @@ void Client::handle_disconnected()
     cleanupTimer();
     cleanupScreen();
     cleanupConnection();
-    LOG(CLOG_DEBUG1 "disconnected");
+    LOG_DEBUG1("disconnected");
     send_event(EventType::CLIENT_DISCONNECTED);
 }
 
 void Client::handle_shape_changed()
 {
-    LOG(CLOG_DEBUG "resolution changed");
+    LOG_DEBUG("resolution changed");
     m_server->onInfoChanged();
 }
 
@@ -643,7 +643,7 @@ void Client::handle_hello()
     }
 
     // check versions
-    LOG(CLOG_DEBUG1 "got hello version %d.%d", major, minor);
+    LOG_DEBUG1("got hello version %d.%d", major, minor);
     if (major < kProtocolMajorVersion ||
         (major == kProtocolMajorVersion && minor < kProtocolMinorVersion)) {
         sendConnectionFailedEvent(XIncompatibleClient(major, minor).what());
@@ -653,7 +653,7 @@ void Client::handle_hello()
     }
 
     // say hello back
-    LOG(CLOG_DEBUG1 "say hello version %d.%d", kProtocolMajorVersion, kProtocolMinorVersion);
+    LOG_DEBUG1("say hello version %d.%d", kProtocolMajorVersion, kProtocolMinorVersion);
     ProtocolUtil::writef(m_stream, kMsgHelloBack,
                             kProtocolMajorVersion,
                             kProtocolMinorVersion, &m_name);
@@ -672,7 +672,7 @@ void Client::handle_hello()
 
 void Client::handle_suspend()
 {
-    LOG(CLOG_INFO "suspend");
+    LOG_INFO("suspend");
     m_suspended       = true;
     bool wasConnected = isConnected();
     disconnect(nullptr);
@@ -681,7 +681,7 @@ void Client::handle_suspend()
 
 void Client::handle_resume()
 {
-    LOG(CLOG_INFO "resume");
+    LOG_INFO("resume");
     m_suspended = false;
     if (m_connectOnResume) {
         m_connectOnResume = false;
@@ -716,7 +716,7 @@ void Client::handle_stop_retry()
 
 void Client::write_to_drop_dir_thread()
 {
-    LOG(CLOG_DEBUG "starting write to drop dir thread");
+    LOG_DEBUG("starting write to drop dir thread");
 
     while (m_screen->isFakeDraggingStarted()) {
         inputleap::this_thread_sleep(.1f);
@@ -730,7 +730,7 @@ void Client::dragInfoReceived(std::uint32_t fileNum, std::string data)
 {
     // TODO: fix duplicate function from CServer
     if (!m_args.m_enableDragDrop) {
-        LOG(CLOG_DEBUG "drag drop not enabled, ignoring drag info.");
+        LOG_DEBUG("drag drop not enabled, ignoring drag info.");
         return;
     }
 
@@ -761,7 +761,7 @@ void Client::send_file_thread(const char* filename)
         StreamChunker::sendFile(filename, m_events, this);
     }
     catch (std::runtime_error& error) {
-        LOG(CLOG_ERR "failed sending file chunks: %s", error.what());
+        LOG_ERR("failed sending file chunks: %s", error.what());
     }
 
     m_sendFileThread = nullptr;

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -108,20 +108,20 @@ void ServerProxy::handle_data()
     while (n != 0) {
         // verify we got an entire code
         if (n != 4) {
-            LOG((CLOG_ERR "incomplete message from server: %d bytes", n));
+            LOG(CLOG_ERR "incomplete message from server: %d bytes", n);
             m_client->disconnect("incomplete message from server");
             return;
         }
 
         // parse message
-        LOG((CLOG_DEBUG2 "msg from server: %c%c%c%c", code[0], code[1], code[2], code[3]));
+        LOG(CLOG_DEBUG2 "msg from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
         try {
             switch ((this->*m_parser)(code)) {
             case kOkay:
                 break;
 
             case kUnknown:
-                LOG((CLOG_ERR "invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]));
+                LOG(CLOG_ERR "invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
                 m_client->disconnect("invalid message from server");
                 return;
 
@@ -134,7 +134,7 @@ void ServerProxy::handle_data()
             // TODO: disconnect handling is currently dispersed across both parseMessage() and
             // handleData() functions, we should collect that to a single place
 
-            LOG((CLOG_ERR "protocol error from server: %s", e.what()));
+            LOG(CLOG_ERR "protocol error from server: %s", e.what());
             ProtocolUtil::writef(m_stream, kMsgEBad);
             m_client->disconnect("invalid message from server");
             return;
@@ -181,7 +181,7 @@ ServerProxy::EResult ServerProxy::parseHandshakeMessage(const std::uint8_t* code
 
     else if (memcmp(code, kMsgCClose, 4) == 0) {
         // server wants us to hangup
-        LOG((CLOG_DEBUG1 "recv close"));
+        LOG(CLOG_DEBUG1 "recv close");
         m_client->disconnect(nullptr);
         return kDisconnect;
     }
@@ -190,25 +190,25 @@ ServerProxy::EResult ServerProxy::parseHandshakeMessage(const std::uint8_t* code
         std::int32_t major, minor;
         ProtocolUtil::readf(m_stream,
                         kMsgEIncompatible + 4, &major, &minor);
-        LOG((CLOG_ERR "server has incompatible version %d.%d", major, minor));
+        LOG(CLOG_ERR "server has incompatible version %d.%d", major, minor);
         m_client->disconnect("server has incompatible version");
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEBusy, 4) == 0) {
-        LOG((CLOG_ERR "server already has a connected client with name \"%s\"", m_client->getName().c_str()));
+        LOG(CLOG_ERR "server already has a connected client with name \"%s\"", m_client->getName().c_str());
         m_client->disconnect("server already has a connected client with our name");
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEUnknown, 4) == 0) {
-        LOG((CLOG_ERR "server refused client with name \"%s\"", m_client->getName().c_str()));
+        LOG(CLOG_ERR "server refused client with name \"%s\"", m_client->getName().c_str());
         m_client->disconnect("server refused client with our name");
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEBad, 4) == 0) {
-        LOG((CLOG_ERR "server disconnected due to a protocol error"));
+        LOG(CLOG_ERR "server disconnected due to a protocol error");
         m_client->disconnect("server reported a protocol error");
         return kDisconnect;
     }
@@ -308,12 +308,12 @@ ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
 
     else if (memcmp(code, kMsgCClose, 4) == 0) {
         // server wants us to hangup
-        LOG((CLOG_DEBUG1 "recv close"));
+        LOG(CLOG_DEBUG1 "recv close");
         m_client->disconnect(nullptr);
         return kDisconnect;
     }
     else if (memcmp(code, kMsgEBad, 4) == 0) {
-        LOG((CLOG_ERR "server disconnected due to a protocol error"));
+        LOG(CLOG_ERR "server disconnected due to a protocol error");
         m_client->disconnect("server reported a protocol error");
         return kDisconnect;
     }
@@ -335,7 +335,7 @@ ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
 
 void ServerProxy::handle_keep_alive_alarm()
 {
-    LOG((CLOG_NOTE "server is dead"));
+    LOG(CLOG_NOTE "server is dead");
     m_client->disconnect("server is not responding");
 }
 
@@ -353,7 +353,7 @@ ServerProxy::onInfoChanged()
 bool
 ServerProxy::onGrabClipboard(ClipboardID id)
 {
-    LOG((CLOG_DEBUG1 "sending clipboard %d changed", id));
+    LOG(CLOG_DEBUG1 "sending clipboard %d changed", id);
     ProtocolUtil::writef(m_stream, kMsgCClipboard, id, m_seqNum);
     return true;
 }
@@ -362,7 +362,7 @@ void
 ServerProxy::onClipboardChanged(ClipboardID id, const IClipboard* clipboard)
 {
     std::string data = IClipboard::marshall(clipboard);
-    LOG((CLOG_DEBUG "sending clipboard %d seqnum=%d", id, m_seqNum));
+    LOG(CLOG_DEBUG "sending clipboard %d seqnum=%d", id, m_seqNum);
 
     StreamChunker::sendClipboard(data, data.size(), id, m_seqNum, m_events, this);
 }
@@ -385,7 +385,7 @@ ServerProxy::flushCompressedMouse()
 void
 ServerProxy::sendInfo(const ClientInfo& info)
 {
-    LOG((CLOG_DEBUG1 "sending info shape=%d,%d %dx%d", info.m_x, info.m_y, info.m_w, info.m_h));
+    LOG(CLOG_DEBUG1 "sending info shape=%d,%d %dx%d", info.m_x, info.m_y, info.m_w, info.m_h);
     ProtocolUtil::writef(m_stream, kMsgDInfo,
                                 info.m_x, info.m_y,
                                 info.m_w, info.m_h, 0,
@@ -522,7 +522,7 @@ ServerProxy::enter()
     std::uint16_t mask;
     std::uint32_t seqNum;
     ProtocolUtil::readf(m_stream, kMsgCEnter + 4, &x, &y, &seqNum, &mask);
-    LOG((CLOG_DEBUG1 "recv enter, %d,%d %d %04x", x, y, seqNum, mask));
+    LOG(CLOG_DEBUG1 "recv enter, %d,%d %d %04x", x, y, seqNum, mask);
 
     // discard old compressed mouse motion, if any
     m_compressMouse         = false;
@@ -539,7 +539,7 @@ void
 ServerProxy::leave()
 {
     // parse
-    LOG((CLOG_DEBUG1 "recv leave"));
+    LOG(CLOG_DEBUG1 "recv leave");
 
     // send last mouse motion
     flushCompressedMouse();
@@ -560,17 +560,17 @@ ServerProxy::setClipboard()
 
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
-        LOG((CLOG_DEBUG "receiving clipboard %d size=%zd", id, size));
+        LOG(CLOG_DEBUG "receiving clipboard %d size=%zd", id, size);
     }
     else if (r == kFinish) {
-        LOG((CLOG_DEBUG "received clipboard %d size=%zd", id, dataCached.size()));
+        LOG(CLOG_DEBUG "received clipboard %d size=%zd", id, dataCached.size());
 
         // forward
         Clipboard clipboard;
         clipboard.unmarshall(dataCached, 0);
         m_client->setClipboard(id, &clipboard);
 
-        LOG((CLOG_INFO "clipboard was updated"));
+        LOG(CLOG_INFO "clipboard was updated");
     }
 }
 
@@ -581,7 +581,7 @@ ServerProxy::grabClipboard()
     ClipboardID id;
     std::uint32_t seqNum;
     ProtocolUtil::readf(m_stream, kMsgCClipboard + 4, &id, &seqNum);
-    LOG((CLOG_DEBUG "recv grab clipboard %d", id));
+    LOG(CLOG_DEBUG "recv grab clipboard %d", id);
 
     // validate
     if (id >= kClipboardEnd) {
@@ -601,7 +601,7 @@ ServerProxy::keyDown()
     // parse
     std::uint16_t id, mask, button;
     ProtocolUtil::readf(m_stream, kMsgDKeyDown + 4, &id, &mask, &button);
-    LOG((CLOG_DEBUG1 "recv key down id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button));
+    LOG(CLOG_DEBUG1 "recv key down id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
 
     // translate
     KeyID id2             = translateKey(static_cast<KeyID>(id));
@@ -609,7 +609,7 @@ ServerProxy::keyDown()
                                 static_cast<KeyModifierMask>(mask));
     if (id2   != static_cast<KeyID>(id) ||
         mask2 != static_cast<KeyModifierMask>(mask))
-        LOG((CLOG_DEBUG1 "key down translated to id=0x%08x, mask=0x%04x", id2, mask2));
+        LOG(CLOG_DEBUG1 "key down translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
     m_client->keyDown(id2, mask2, button);
@@ -625,7 +625,7 @@ ServerProxy::keyRepeat()
     std::uint16_t id, mask, count, button;
     ProtocolUtil::readf(m_stream, kMsgDKeyRepeat + 4,
                                 &id, &mask, &count, &button);
-    LOG((CLOG_DEBUG1 "recv key repeat id=0x%08x, mask=0x%04x, count=%d, button=0x%04x", id, mask, count, button));
+    LOG(CLOG_DEBUG1 "recv key repeat id=0x%08x, mask=0x%04x, count=%d, button=0x%04x", id, mask, count, button);
 
     // translate
     KeyID id2             = translateKey(static_cast<KeyID>(id));
@@ -633,7 +633,7 @@ ServerProxy::keyRepeat()
                                 static_cast<KeyModifierMask>(mask));
     if (id2   != static_cast<KeyID>(id) ||
         mask2 != static_cast<KeyModifierMask>(mask))
-        LOG((CLOG_DEBUG1 "key repeat translated to id=0x%08x, mask=0x%04x", id2, mask2));
+        LOG(CLOG_DEBUG1 "key repeat translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
     m_client->keyRepeat(id2, mask2, count, button);
@@ -648,7 +648,7 @@ ServerProxy::keyUp()
     // parse
     std::uint16_t id, mask, button;
     ProtocolUtil::readf(m_stream, kMsgDKeyUp + 4, &id, &mask, &button);
-    LOG((CLOG_DEBUG1 "recv key up id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button));
+    LOG(CLOG_DEBUG1 "recv key up id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
 
     // translate
     KeyID id2             = translateKey(static_cast<KeyID>(id));
@@ -656,7 +656,7 @@ ServerProxy::keyUp()
                                 static_cast<KeyModifierMask>(mask));
     if (id2   != static_cast<KeyID>(id) ||
         mask2 != static_cast<KeyModifierMask>(mask))
-        LOG((CLOG_DEBUG1 "key up translated to id=0x%08x, mask=0x%04x", id2, mask2));
+        LOG(CLOG_DEBUG1 "key up translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
     m_client->keyUp(id2, mask2, button);
@@ -671,7 +671,7 @@ ServerProxy::mouseDown()
     // parse
     std::int8_t id;
     ProtocolUtil::readf(m_stream, kMsgDMouseDown + 4, &id);
-    LOG((CLOG_DEBUG1 "recv mouse down id=%d", id));
+    LOG(CLOG_DEBUG1 "recv mouse down id=%d", id);
 
     // forward
     m_client->mouseDown(static_cast<ButtonID>(id));
@@ -686,7 +686,7 @@ ServerProxy::mouseUp()
     // parse
     std::int8_t id;
     ProtocolUtil::readf(m_stream, kMsgDMouseUp + 4, &id);
-    LOG((CLOG_DEBUG1 "recv mouse up id=%d", id));
+    LOG(CLOG_DEBUG1 "recv mouse up id=%d", id);
 
     // forward
     m_client->mouseUp(static_cast<ButtonID>(id));
@@ -717,7 +717,7 @@ ServerProxy::mouseMove()
         m_dxMouse = 0;
         m_dyMouse = 0;
     }
-    LOG((CLOG_DEBUG2 "recv mouse move %d,%d", x, y));
+    LOG(CLOG_DEBUG2 "recv mouse move %d,%d", x, y);
 
     // forward
     if (!ignore) {
@@ -747,7 +747,7 @@ ServerProxy::mouseRelativeMove()
         m_dxMouse += dx;
         m_dyMouse += dy;
     }
-    LOG((CLOG_DEBUG2 "recv mouse relative move %d,%d", dx, dy));
+    LOG(CLOG_DEBUG2 "recv mouse relative move %d,%d", dx, dy);
 
     // forward
     if (!ignore) {
@@ -764,7 +764,7 @@ ServerProxy::mouseWheel()
     // parse
     std::int16_t xDelta, yDelta;
     ProtocolUtil::readf(m_stream, kMsgDMouseWheel + 4, &xDelta, &yDelta);
-    LOG((CLOG_DEBUG2 "recv mouse wheel %+d,%+d", xDelta, yDelta));
+    LOG(CLOG_DEBUG2 "recv mouse wheel %+d,%+d", xDelta, yDelta);
 
     // forward
     m_client->mouseWheel(xDelta, yDelta);
@@ -776,7 +776,7 @@ ServerProxy::screensaver()
     // parse
     std::int8_t on;
     ProtocolUtil::readf(m_stream, kMsgCScreenSaver + 4, &on);
-    LOG((CLOG_DEBUG1 "recv screen saver on=%d", on));
+    LOG(CLOG_DEBUG1 "recv screen saver on=%d", on);
 
     // forward
     m_client->screensaver(on != 0);
@@ -786,7 +786,7 @@ void
 ServerProxy::resetOptions()
 {
     // parse
-    LOG((CLOG_DEBUG1 "recv reset options"));
+    LOG(CLOG_DEBUG1 "recv reset options");
 
     // forward
     m_client->resetOptions();
@@ -806,7 +806,7 @@ ServerProxy::setOptions()
     // parse
     OptionsList options;
     ProtocolUtil::readf(m_stream, kMsgDSetOptions + 4, &options);
-    LOG((CLOG_DEBUG1 "recv set options size=%zd", options.size()));
+    LOG(CLOG_DEBUG1 "recv set options size=%zd", options.size());
 
     // forward
     m_client->setOptions(options);
@@ -840,7 +840,7 @@ ServerProxy::setOptions()
         if (id != kKeyModifierIDNull) {
             m_modifierTranslationTable[id] =
                 static_cast<KeyModifierID>(options[i + 1]);
-            LOG((CLOG_DEBUG1 "modifier %d mapped to %d", id, m_modifierTranslationTable[id]));
+            LOG(CLOG_DEBUG1 "modifier %d mapped to %d", id, m_modifierTranslationTable[id]);
         }
     }
 }
@@ -857,7 +857,7 @@ ServerProxy::queryInfo()
 void
 ServerProxy::infoAcknowledgment()
 {
-    LOG((CLOG_DEBUG1 "recv info acknowledgment"));
+    LOG(CLOG_DEBUG1 "recv info acknowledgment");
     m_ignoreMouse = false;
 }
 
@@ -875,7 +875,7 @@ ServerProxy::fileChunkReceived()
     else if (result == kStart) {
         if (m_client->getDragFileList().size() > 0) {
             std::string filename = m_client->getDragFileList().at(0).getFilename();
-            LOG((CLOG_DEBUG "start receiving %s", filename.c_str()));
+            LOG(CLOG_DEBUG "start receiving %s", filename.c_str());
         }
     }
 }

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -108,20 +108,20 @@ void ServerProxy::handle_data()
     while (n != 0) {
         // verify we got an entire code
         if (n != 4) {
-            LOG(CLOG_ERR "incomplete message from server: %d bytes", n);
+            LOG_ERR("incomplete message from server: %d bytes", n);
             m_client->disconnect("incomplete message from server");
             return;
         }
 
         // parse message
-        LOG(CLOG_DEBUG2 "msg from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
+        LOG_DEBUG2("msg from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
         try {
             switch ((this->*m_parser)(code)) {
             case kOkay:
                 break;
 
             case kUnknown:
-                LOG(CLOG_ERR "invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
+                LOG_ERR("invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
                 m_client->disconnect("invalid message from server");
                 return;
 
@@ -134,7 +134,7 @@ void ServerProxy::handle_data()
             // TODO: disconnect handling is currently dispersed across both parseMessage() and
             // handleData() functions, we should collect that to a single place
 
-            LOG(CLOG_ERR "protocol error from server: %s", e.what());
+            LOG_ERR("protocol error from server: %s", e.what());
             ProtocolUtil::writef(m_stream, kMsgEBad);
             m_client->disconnect("invalid message from server");
             return;
@@ -181,7 +181,7 @@ ServerProxy::EResult ServerProxy::parseHandshakeMessage(const std::uint8_t* code
 
     else if (memcmp(code, kMsgCClose, 4) == 0) {
         // server wants us to hangup
-        LOG(CLOG_DEBUG1 "recv close");
+        LOG_DEBUG1("recv close");
         m_client->disconnect(nullptr);
         return kDisconnect;
     }
@@ -190,25 +190,25 @@ ServerProxy::EResult ServerProxy::parseHandshakeMessage(const std::uint8_t* code
         std::int32_t major, minor;
         ProtocolUtil::readf(m_stream,
                         kMsgEIncompatible + 4, &major, &minor);
-        LOG(CLOG_ERR "server has incompatible version %d.%d", major, minor);
+        LOG_ERR("server has incompatible version %d.%d", major, minor);
         m_client->disconnect("server has incompatible version");
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEBusy, 4) == 0) {
-        LOG(CLOG_ERR "server already has a connected client with name \"%s\"", m_client->getName().c_str());
+        LOG_ERR("server already has a connected client with name \"%s\"", m_client->getName().c_str());
         m_client->disconnect("server already has a connected client with our name");
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEUnknown, 4) == 0) {
-        LOG(CLOG_ERR "server refused client with name \"%s\"", m_client->getName().c_str());
+        LOG_ERR("server refused client with name \"%s\"", m_client->getName().c_str());
         m_client->disconnect("server refused client with our name");
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEBad, 4) == 0) {
-        LOG(CLOG_ERR "server disconnected due to a protocol error");
+        LOG_ERR("server disconnected due to a protocol error");
         m_client->disconnect("server reported a protocol error");
         return kDisconnect;
     }
@@ -308,12 +308,12 @@ ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
 
     else if (memcmp(code, kMsgCClose, 4) == 0) {
         // server wants us to hangup
-        LOG(CLOG_DEBUG1 "recv close");
+        LOG_DEBUG1("recv close");
         m_client->disconnect(nullptr);
         return kDisconnect;
     }
     else if (memcmp(code, kMsgEBad, 4) == 0) {
-        LOG(CLOG_ERR "server disconnected due to a protocol error");
+        LOG_ERR("server disconnected due to a protocol error");
         m_client->disconnect("server reported a protocol error");
         return kDisconnect;
     }
@@ -335,7 +335,7 @@ ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
 
 void ServerProxy::handle_keep_alive_alarm()
 {
-    LOG(CLOG_NOTE "server is dead");
+    LOG_NOTE("server is dead");
     m_client->disconnect("server is not responding");
 }
 
@@ -353,7 +353,7 @@ ServerProxy::onInfoChanged()
 bool
 ServerProxy::onGrabClipboard(ClipboardID id)
 {
-    LOG(CLOG_DEBUG1 "sending clipboard %d changed", id);
+    LOG_DEBUG1("sending clipboard %d changed", id);
     ProtocolUtil::writef(m_stream, kMsgCClipboard, id, m_seqNum);
     return true;
 }
@@ -362,7 +362,7 @@ void
 ServerProxy::onClipboardChanged(ClipboardID id, const IClipboard* clipboard)
 {
     std::string data = IClipboard::marshall(clipboard);
-    LOG(CLOG_DEBUG "sending clipboard %d seqnum=%d", id, m_seqNum);
+    LOG_DEBUG("sending clipboard %d seqnum=%d", id, m_seqNum);
 
     StreamChunker::sendClipboard(data, data.size(), id, m_seqNum, m_events, this);
 }
@@ -385,7 +385,7 @@ ServerProxy::flushCompressedMouse()
 void
 ServerProxy::sendInfo(const ClientInfo& info)
 {
-    LOG(CLOG_DEBUG1 "sending info shape=%d,%d %dx%d", info.m_x, info.m_y, info.m_w, info.m_h);
+    LOG_DEBUG1("sending info shape=%d,%d %dx%d", info.m_x, info.m_y, info.m_w, info.m_h);
     ProtocolUtil::writef(m_stream, kMsgDInfo,
                                 info.m_x, info.m_y,
                                 info.m_w, info.m_h, 0,
@@ -522,7 +522,7 @@ ServerProxy::enter()
     std::uint16_t mask;
     std::uint32_t seqNum;
     ProtocolUtil::readf(m_stream, kMsgCEnter + 4, &x, &y, &seqNum, &mask);
-    LOG(CLOG_DEBUG1 "recv enter, %d,%d %d %04x", x, y, seqNum, mask);
+    LOG_DEBUG1("recv enter, %d,%d %d %04x", x, y, seqNum, mask);
 
     // discard old compressed mouse motion, if any
     m_compressMouse         = false;
@@ -539,7 +539,7 @@ void
 ServerProxy::leave()
 {
     // parse
-    LOG(CLOG_DEBUG1 "recv leave");
+    LOG_DEBUG1("recv leave");
 
     // send last mouse motion
     flushCompressedMouse();
@@ -560,17 +560,17 @@ ServerProxy::setClipboard()
 
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
-        LOG(CLOG_DEBUG "receiving clipboard %d size=%zd", id, size);
+        LOG_DEBUG("receiving clipboard %d size=%zd", id, size);
     }
     else if (r == kFinish) {
-        LOG(CLOG_DEBUG "received clipboard %d size=%zd", id, dataCached.size());
+        LOG_DEBUG("received clipboard %d size=%zd", id, dataCached.size());
 
         // forward
         Clipboard clipboard;
         clipboard.unmarshall(dataCached, 0);
         m_client->setClipboard(id, &clipboard);
 
-        LOG(CLOG_INFO "clipboard was updated");
+        LOG_INFO("clipboard was updated");
     }
 }
 
@@ -581,7 +581,7 @@ ServerProxy::grabClipboard()
     ClipboardID id;
     std::uint32_t seqNum;
     ProtocolUtil::readf(m_stream, kMsgCClipboard + 4, &id, &seqNum);
-    LOG(CLOG_DEBUG "recv grab clipboard %d", id);
+    LOG_DEBUG("recv grab clipboard %d", id);
 
     // validate
     if (id >= kClipboardEnd) {
@@ -601,7 +601,7 @@ ServerProxy::keyDown()
     // parse
     std::uint16_t id, mask, button;
     ProtocolUtil::readf(m_stream, kMsgDKeyDown + 4, &id, &mask, &button);
-    LOG(CLOG_DEBUG1 "recv key down id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
+    LOG_DEBUG1("recv key down id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
 
     // translate
     KeyID id2             = translateKey(static_cast<KeyID>(id));
@@ -609,7 +609,7 @@ ServerProxy::keyDown()
                                 static_cast<KeyModifierMask>(mask));
     if (id2   != static_cast<KeyID>(id) ||
         mask2 != static_cast<KeyModifierMask>(mask))
-        LOG(CLOG_DEBUG1 "key down translated to id=0x%08x, mask=0x%04x", id2, mask2);
+        LOG_DEBUG1("key down translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
     m_client->keyDown(id2, mask2, button);
@@ -625,7 +625,7 @@ ServerProxy::keyRepeat()
     std::uint16_t id, mask, count, button;
     ProtocolUtil::readf(m_stream, kMsgDKeyRepeat + 4,
                                 &id, &mask, &count, &button);
-    LOG(CLOG_DEBUG1 "recv key repeat id=0x%08x, mask=0x%04x, count=%d, button=0x%04x", id, mask, count, button);
+    LOG_DEBUG1("recv key repeat id=0x%08x, mask=0x%04x, count=%d, button=0x%04x", id, mask, count, button);
 
     // translate
     KeyID id2             = translateKey(static_cast<KeyID>(id));
@@ -633,7 +633,7 @@ ServerProxy::keyRepeat()
                                 static_cast<KeyModifierMask>(mask));
     if (id2   != static_cast<KeyID>(id) ||
         mask2 != static_cast<KeyModifierMask>(mask))
-        LOG(CLOG_DEBUG1 "key repeat translated to id=0x%08x, mask=0x%04x", id2, mask2);
+        LOG_DEBUG1("key repeat translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
     m_client->keyRepeat(id2, mask2, count, button);
@@ -648,7 +648,7 @@ ServerProxy::keyUp()
     // parse
     std::uint16_t id, mask, button;
     ProtocolUtil::readf(m_stream, kMsgDKeyUp + 4, &id, &mask, &button);
-    LOG(CLOG_DEBUG1 "recv key up id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
+    LOG_DEBUG1("recv key up id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
 
     // translate
     KeyID id2             = translateKey(static_cast<KeyID>(id));
@@ -656,7 +656,7 @@ ServerProxy::keyUp()
                                 static_cast<KeyModifierMask>(mask));
     if (id2   != static_cast<KeyID>(id) ||
         mask2 != static_cast<KeyModifierMask>(mask))
-        LOG(CLOG_DEBUG1 "key up translated to id=0x%08x, mask=0x%04x", id2, mask2);
+        LOG_DEBUG1("key up translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
     m_client->keyUp(id2, mask2, button);
@@ -671,7 +671,7 @@ ServerProxy::mouseDown()
     // parse
     std::int8_t id;
     ProtocolUtil::readf(m_stream, kMsgDMouseDown + 4, &id);
-    LOG(CLOG_DEBUG1 "recv mouse down id=%d", id);
+    LOG_DEBUG1("recv mouse down id=%d", id);
 
     // forward
     m_client->mouseDown(static_cast<ButtonID>(id));
@@ -686,7 +686,7 @@ ServerProxy::mouseUp()
     // parse
     std::int8_t id;
     ProtocolUtil::readf(m_stream, kMsgDMouseUp + 4, &id);
-    LOG(CLOG_DEBUG1 "recv mouse up id=%d", id);
+    LOG_DEBUG1("recv mouse up id=%d", id);
 
     // forward
     m_client->mouseUp(static_cast<ButtonID>(id));
@@ -717,7 +717,7 @@ ServerProxy::mouseMove()
         m_dxMouse = 0;
         m_dyMouse = 0;
     }
-    LOG(CLOG_DEBUG2 "recv mouse move %d,%d", x, y);
+    LOG_DEBUG2("recv mouse move %d,%d", x, y);
 
     // forward
     if (!ignore) {
@@ -747,7 +747,7 @@ ServerProxy::mouseRelativeMove()
         m_dxMouse += dx;
         m_dyMouse += dy;
     }
-    LOG(CLOG_DEBUG2 "recv mouse relative move %d,%d", dx, dy);
+    LOG_DEBUG2("recv mouse relative move %d,%d", dx, dy);
 
     // forward
     if (!ignore) {
@@ -764,7 +764,7 @@ ServerProxy::mouseWheel()
     // parse
     std::int16_t xDelta, yDelta;
     ProtocolUtil::readf(m_stream, kMsgDMouseWheel + 4, &xDelta, &yDelta);
-    LOG(CLOG_DEBUG2 "recv mouse wheel %+d,%+d", xDelta, yDelta);
+    LOG_DEBUG2("recv mouse wheel %+d,%+d", xDelta, yDelta);
 
     // forward
     m_client->mouseWheel(xDelta, yDelta);
@@ -776,7 +776,7 @@ ServerProxy::screensaver()
     // parse
     std::int8_t on;
     ProtocolUtil::readf(m_stream, kMsgCScreenSaver + 4, &on);
-    LOG(CLOG_DEBUG1 "recv screen saver on=%d", on);
+    LOG_DEBUG1("recv screen saver on=%d", on);
 
     // forward
     m_client->screensaver(on != 0);
@@ -786,7 +786,7 @@ void
 ServerProxy::resetOptions()
 {
     // parse
-    LOG(CLOG_DEBUG1 "recv reset options");
+    LOG_DEBUG1("recv reset options");
 
     // forward
     m_client->resetOptions();
@@ -806,7 +806,7 @@ ServerProxy::setOptions()
     // parse
     OptionsList options;
     ProtocolUtil::readf(m_stream, kMsgDSetOptions + 4, &options);
-    LOG(CLOG_DEBUG1 "recv set options size=%zd", options.size());
+    LOG_DEBUG1("recv set options size=%zd", options.size());
 
     // forward
     m_client->setOptions(options);
@@ -840,7 +840,7 @@ ServerProxy::setOptions()
         if (id != kKeyModifierIDNull) {
             m_modifierTranslationTable[id] =
                 static_cast<KeyModifierID>(options[i + 1]);
-            LOG(CLOG_DEBUG1 "modifier %d mapped to %d", id, m_modifierTranslationTable[id]);
+            LOG_DEBUG1("modifier %d mapped to %d", id, m_modifierTranslationTable[id]);
         }
     }
 }
@@ -857,7 +857,7 @@ ServerProxy::queryInfo()
 void
 ServerProxy::infoAcknowledgment()
 {
-    LOG(CLOG_DEBUG1 "recv info acknowledgment");
+    LOG_DEBUG1("recv info acknowledgment");
     m_ignoreMouse = false;
 }
 
@@ -875,7 +875,7 @@ ServerProxy::fileChunkReceived()
     else if (result == kStart) {
         if (m_client->getDragFileList().size() > 0) {
             std::string filename = m_client->getDragFileList().at(0).getFilename();
-            LOG(CLOG_DEBUG "start receiving %s", filename.c_str());
+            LOG_DEBUG("start receiving %s", filename.c_str());
         }
     }
 }

--- a/src/lib/inputleap/App.cpp
+++ b/src/lib/inputleap/App.cpp
@@ -112,10 +112,10 @@ App::run(int argc, char** argv)
         result = e.getCode();
     }
     catch (std::exception& e) {
-        LOG((CLOG_CRIT "An error occurred: %s\n", e.what()));
+        LOG(CLOG_CRIT "An error occurred: %s\n", e.what());
     }
     catch (...) {
-        LOG((CLOG_CRIT "An unknown error occurred.\n"));
+        LOG(CLOG_CRIT "An unknown error occurred.\n");
     }
 
     appUtil().beforeAppExit();
@@ -140,7 +140,7 @@ App::setupFileLogging()
     if (argsBase().m_logFile != nullptr) {
         m_fileLog = new FileLogOutputter(argsBase().m_logFile);
         CLOG->insert(m_fileLog);
-        LOG((CLOG_DEBUG1 "logging to file (%s) enabled", argsBase().m_logFile));
+        LOG(CLOG_DEBUG1 "logging to file (%s) enabled", argsBase().m_logFile);
     }
 }
 
@@ -149,8 +149,8 @@ App::loggingFilterWarning()
 {
     if (CLOG->getFilter() > CLOG->getConsoleMaxLevel()) {
         if (argsBase().m_logFile == nullptr) {
-            LOG((CLOG_WARN "log messages above %s are NOT sent to console (use file logging)",
-                CLOG->getFilterName(CLOG->getConsoleMaxLevel())));
+            LOG(CLOG_WARN "log messages above %s are NOT sent to console (use file logging)",
+                CLOG->getFilterName(CLOG->getConsoleMaxLevel()));
         }
     }
 }
@@ -165,16 +165,16 @@ App::initApp(int argc, const char** argv)
 
     // set log filter
     if (!CLOG->setFilter(argsBase().m_logFilter)) {
-        LOG((CLOG_PRINT "%s: unrecognized log level `%s'" BYE,
-            argsBase().m_exename.c_str(), argsBase().m_logFilter, argsBase().m_exename.c_str()));
+        LOG(CLOG_PRINT "%s: unrecognized log level `%s'" BYE,
+            argsBase().m_exename.c_str(), argsBase().m_logFilter, argsBase().m_exename.c_str());
         m_bye(kExitArgs);
     }
     loggingFilterWarning();
 
     if (argsBase().m_enableDragDrop) {
-        LOG((CLOG_INFO "drag and drop enabled"));
+        LOG(CLOG_INFO "drag and drop enabled");
         if (!argsBase().m_dropTarget.empty()) {
-            LOG((CLOG_INFO "drop target: %s", argsBase().m_dropTarget.c_str()));
+            LOG(CLOG_INFO "drop target: %s", argsBase().m_dropTarget.c_str());
         }
     }
 
@@ -220,7 +220,7 @@ void App::handle_ipc_message(const Event& e)
 {
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcShutdown) {
-        LOG((CLOG_INFO "got ipc shutdown message"));
+        LOG(CLOG_INFO "got ipc shutdown message");
         m_events->add_event(EventType::QUIT);
     }
 }

--- a/src/lib/inputleap/App.cpp
+++ b/src/lib/inputleap/App.cpp
@@ -112,10 +112,10 @@ App::run(int argc, char** argv)
         result = e.getCode();
     }
     catch (std::exception& e) {
-        LOG(CLOG_CRIT "An error occurred: %s\n", e.what());
+        LOG_CRIT("An error occurred: %s\n", e.what());
     }
     catch (...) {
-        LOG(CLOG_CRIT "An unknown error occurred.\n");
+        LOG_CRIT("An unknown error occurred.\n");
     }
 
     appUtil().beforeAppExit();
@@ -140,7 +140,7 @@ App::setupFileLogging()
     if (argsBase().m_logFile != nullptr) {
         m_fileLog = new FileLogOutputter(argsBase().m_logFile);
         CLOG->insert(m_fileLog);
-        LOG(CLOG_DEBUG1 "logging to file (%s) enabled", argsBase().m_logFile);
+        LOG_DEBUG1("logging to file (%s) enabled", argsBase().m_logFile);
     }
 }
 
@@ -149,7 +149,7 @@ App::loggingFilterWarning()
 {
     if (CLOG->getFilter() > CLOG->getConsoleMaxLevel()) {
         if (argsBase().m_logFile == nullptr) {
-            LOG(CLOG_WARN "log messages above %s are NOT sent to console (use file logging)",
+            LOG_WARN("log messages above %s are NOT sent to console (use file logging)",
                 CLOG->getFilterName(CLOG->getConsoleMaxLevel()));
         }
     }
@@ -165,16 +165,16 @@ App::initApp(int argc, const char** argv)
 
     // set log filter
     if (!CLOG->setFilter(argsBase().m_logFilter)) {
-        LOG(CLOG_PRINT "%s: unrecognized log level `%s'" BYE,
+        LOG_PRINT("%s: unrecognized log level `%s'" BYE,
             argsBase().m_exename.c_str(), argsBase().m_logFilter, argsBase().m_exename.c_str());
         m_bye(kExitArgs);
     }
     loggingFilterWarning();
 
     if (argsBase().m_enableDragDrop) {
-        LOG(CLOG_INFO "drag and drop enabled");
+        LOG_INFO("drag and drop enabled");
         if (!argsBase().m_dropTarget.empty()) {
-            LOG(CLOG_INFO "drop target: %s", argsBase().m_dropTarget.c_str());
+            LOG_INFO("drop target: %s", argsBase().m_dropTarget.c_str());
         }
     }
 
@@ -220,7 +220,7 @@ void App::handle_ipc_message(const Event& e)
 {
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcShutdown) {
-        LOG(CLOG_INFO "got ipc shutdown message");
+        LOG_INFO("got ipc shutdown message");
         m_events->add_event(EventType::QUIT);
     }
 }

--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -148,7 +148,7 @@ ArgParser::parseServerArgs(ServerArgs& args, int argc, const char* const* argv)
             }
         }
     } catch (XArgvParserError e) {
-        LOG((CLOG_PRINT "%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str()));
+        LOG(CLOG_PRINT "%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str());
         return false;
     }
 
@@ -200,7 +200,7 @@ ArgParser::parseClientArgs(ClientArgs& args, int argc, const char* const* argv)
             throw XArgvParserError("a server address or name is required");
 
     } catch (XArgvParserError e) {
-        LOG((CLOG_PRINT "%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str()));
+        LOG(CLOG_PRINT "%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str());
         return false;
     }
 
@@ -215,7 +215,7 @@ bool
 ArgParser::parseMSWindowsArg(ArgsBase& argsBase, Argv& argv)
 {
     if (argv.shift("--service")) {
-        LOG((CLOG_WARN "obsolete argument --service, use input-leapd instead."));
+        LOG(CLOG_WARN "obsolete argument --service, use input-leapd instead.");
         argsBase.m_shouldExit = true;
     }
     else if (argv.shift("--exit-pause")) {
@@ -255,7 +255,7 @@ ArgParser::parseXWindowsArg(ArgsBase& argsBase, Argv& argv)
         argsBase.m_display = optarg;
     }
     else if (argv.shift("--no-xinitthreads")) {
-        LOG((CLOG_NOTE "--no-xinitthreads is deprecated"));
+        LOG(CLOG_NOTE "--no-xinitthreads is deprecated");
     } else {
         // option not supported here
         return false;
@@ -422,7 +422,7 @@ ArgParser::parseGenericArgs(Argv& argv)
 #ifdef WINAPI_XWINDOWS
 
         useDragDrop = false;
-        LOG((CLOG_INFO "ignoring --enable-drag-drop, not supported on linux."));
+        LOG(CLOG_INFO "ignoring --enable-drag-drop, not supported on linux.");
 
 #endif
 
@@ -434,7 +434,7 @@ ArgParser::parseGenericArgs(Argv& argv)
         argsBase().m_dropTarget = argv.shift();
     }
     else if (argv.shift("--enable-crypto")) {
-        LOG((CLOG_INFO "--enable-crypto is used by default. The option is deprecated."));
+        LOG(CLOG_INFO "--enable-crypto is used by default. The option is deprecated.");
     }
     else if (argv.shift("--disable-crypto")) {
         argsBase().m_enableCrypto = false;

--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -148,7 +148,7 @@ ArgParser::parseServerArgs(ServerArgs& args, int argc, const char* const* argv)
             }
         }
     } catch (XArgvParserError e) {
-        LOG(CLOG_PRINT "%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str());
+        LOG_PRINT("%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str());
         return false;
     }
 
@@ -200,7 +200,7 @@ ArgParser::parseClientArgs(ClientArgs& args, int argc, const char* const* argv)
             throw XArgvParserError("a server address or name is required");
 
     } catch (XArgvParserError e) {
-        LOG(CLOG_PRINT "%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str());
+        LOG_PRINT("%s: %s" BYE, a.exename().c_str(), e.message.c_str(), a.exename().c_str());
         return false;
     }
 
@@ -215,7 +215,7 @@ bool
 ArgParser::parseMSWindowsArg(ArgsBase& argsBase, Argv& argv)
 {
     if (argv.shift("--service")) {
-        LOG(CLOG_WARN "obsolete argument --service, use input-leapd instead.");
+        LOG_WARN("obsolete argument --service, use input-leapd instead.");
         argsBase.m_shouldExit = true;
     }
     else if (argv.shift("--exit-pause")) {
@@ -255,7 +255,7 @@ ArgParser::parseXWindowsArg(ArgsBase& argsBase, Argv& argv)
         argsBase.m_display = optarg;
     }
     else if (argv.shift("--no-xinitthreads")) {
-        LOG(CLOG_NOTE "--no-xinitthreads is deprecated");
+        LOG_NOTE("--no-xinitthreads is deprecated");
     } else {
         // option not supported here
         return false;
@@ -422,7 +422,7 @@ ArgParser::parseGenericArgs(Argv& argv)
 #ifdef WINAPI_XWINDOWS
 
         useDragDrop = false;
-        LOG(CLOG_INFO "ignoring --enable-drag-drop, not supported on linux.");
+        LOG_INFO("ignoring --enable-drag-drop, not supported on linux.");
 
 #endif
 
@@ -434,7 +434,7 @@ ArgParser::parseGenericArgs(Argv& argv)
         argsBase().m_dropTarget = argv.shift();
     }
     else if (argv.shift("--enable-crypto")) {
-        LOG(CLOG_INFO "--enable-crypto is used by default. The option is deprecated.");
+        LOG_INFO("--enable-crypto is used by default. The option is deprecated.");
     }
     else if (argv.shift("--disable-crypto")) {
         argsBase().m_enableCrypto = false;

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -100,7 +100,7 @@ ClientApp::parseArgs(int argc, const char* const* argv)
                 // server.  a bad port will never get better.  patch by Brent
                 // Priddy.
                 if (!args().m_restartable || e.getError() == XSocketAddress::kBadPort) {
-                    LOG(CLOG_PRINT "%s: %s" BYE,
+                    LOG_PRINT("%s: %s" BYE,
                         args().m_exename.c_str(), e.what(), args().m_exename.c_str());
                     m_bye(kExitFailed);
                 }
@@ -148,7 +148,7 @@ ClientApp::help()
            << "an IPv6 address is required when also specifying a port number and \n"
            << "optional otherwise. The default port number is " << kDefaultPort << ".\n";
 
-    LOG(CLOG_PRINT "%s", buffer.str().c_str());
+    LOG_PRINT("%s", buffer.str().c_str());
 }
 
 const char*
@@ -229,7 +229,7 @@ ClientApp::nextRestartTimeout()
 
 void ClientApp::handle_screen_error()
 {
-    LOG(CLOG_CRIT "error on screen");
+    LOG_CRIT("error on screen");
     m_events->add_event(EventType::QUIT);
 }
 
@@ -262,7 +262,7 @@ void
 ClientApp::scheduleClientRestart(double retryTime)
 {
     // install a timer and handler to retry later
-    LOG(CLOG_DEBUG "retry in %.0f seconds", retryTime);
+    LOG_DEBUG("retry in %.0f seconds", retryTime);
     EventQueueTimer* timer = m_events->newOneShotTimer(retryTime, nullptr);
     m_events->add_handler(EventType::TIMER, timer,
                           [this, timer](const Event& event) { handle_client_restart(event, timer); });
@@ -273,7 +273,7 @@ void ClientApp::handle_client_connected()
 {
     // using CLOG_PRINT here allows the GUI to see that the client is connected
     // regardless of which log level is set
-    LOG(CLOG_PRINT "connected to server");
+    LOG_PRINT("connected to server");
     resetRestartTimeout();
     updateStatus();
 }
@@ -285,11 +285,11 @@ void ClientApp::handle_client_failed(const Event& e)
 
     updateStatus(std::string("Failed to connect to server: ") + info.m_what);
     if (!args().m_restartable || !info.m_retry) {
-        LOG(CLOG_ERR "failed to connect to server: %s", info.m_what.c_str());
+        LOG_ERR("failed to connect to server: %s", info.m_what.c_str());
         m_events->add_event(EventType::QUIT);
     }
     else {
-        LOG(CLOG_WARN "failed to connect to server: %s", info.m_what.c_str());
+        LOG_WARN("failed to connect to server: %s", info.m_what.c_str());
         if (!m_suspended) {
             scheduleClientRestart(nextRestartTimeout());
         }
@@ -299,7 +299,7 @@ void ClientApp::handle_client_failed(const Event& e)
 
 void ClientApp::handle_client_disconnected()
 {
-    LOG(CLOG_NOTE "disconnected from server");
+    LOG_NOTE("disconnected from server");
     if (!args().m_restartable) {
         m_events->add_event(EventType::QUIT);
     }
@@ -369,7 +369,7 @@ ClientApp::startClient()
             client_screen = open_client_screen();
             m_client = openClient(args().m_name, *m_serverAddress, client_screen.get());
             m_clientScreen = std::move(client_screen);
-            LOG(CLOG_NOTE "started client");
+            LOG_NOTE("started client");
         }
 
         m_client->connect();
@@ -378,18 +378,18 @@ ClientApp::startClient()
         return true;
     }
     catch (XScreenUnavailable& e) {
-        LOG(CLOG_WARN "secondary screen unavailable: %s", e.what());
+        LOG_WARN("secondary screen unavailable: %s", e.what());
         updateStatus(std::string("secondary screen unavailable: ") + e.what());
         m_clientScreen.reset();
         retryTime = e.getRetryTime();
     }
     catch (XScreenOpenFailure& e) {
-        LOG(CLOG_CRIT "failed to start client: %s", e.what());
+        LOG_CRIT("failed to start client: %s", e.what());
         m_clientScreen.reset();
         return false;
     }
     catch (XBase& e) {
-        LOG(CLOG_CRIT "failed to start client: %s", e.what());
+        LOG_CRIT("failed to start client: %s", e.what());
         m_clientScreen.reset();
         return false;
     }
@@ -452,10 +452,10 @@ ClientApp::mainLoop()
     DAEMON_RUNNING(false);
 
     // close down
-    LOG(CLOG_DEBUG1 "stopping client");
+    LOG_DEBUG1("stopping client");
     stopClient();
     updateStatus();
-    LOG(CLOG_NOTE "stopped client");
+    LOG_NOTE("stopped client");
 
     if (argsBase().m_enableIpc) {
         cleanupIpcClient();
@@ -524,7 +524,7 @@ ClientApp::startNode()
 {
     // start the client.  if this return false then we've failed and
     // we shouldn't retry.
-    LOG(CLOG_DEBUG1 "starting client");
+    LOG_DEBUG1("starting client");
     if (!startClient()) {
         m_bye(kExitFailed);
     }

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -100,8 +100,8 @@ ClientApp::parseArgs(int argc, const char* const* argv)
                 // server.  a bad port will never get better.  patch by Brent
                 // Priddy.
                 if (!args().m_restartable || e.getError() == XSocketAddress::kBadPort) {
-                    LOG((CLOG_PRINT "%s: %s" BYE,
-                        args().m_exename.c_str(), e.what(), args().m_exename.c_str()));
+                    LOG(CLOG_PRINT "%s: %s" BYE,
+                        args().m_exename.c_str(), e.what(), args().m_exename.c_str());
                     m_bye(kExitFailed);
                 }
             }
@@ -148,7 +148,7 @@ ClientApp::help()
            << "an IPv6 address is required when also specifying a port number and \n"
            << "optional otherwise. The default port number is " << kDefaultPort << ".\n";
 
-    LOG((CLOG_PRINT "%s", buffer.str().c_str()));
+    LOG(CLOG_PRINT "%s", buffer.str().c_str());
 }
 
 const char*
@@ -229,7 +229,7 @@ ClientApp::nextRestartTimeout()
 
 void ClientApp::handle_screen_error()
 {
-    LOG((CLOG_CRIT "error on screen"));
+    LOG(CLOG_CRIT "error on screen");
     m_events->add_event(EventType::QUIT);
 }
 
@@ -262,7 +262,7 @@ void
 ClientApp::scheduleClientRestart(double retryTime)
 {
     // install a timer and handler to retry later
-    LOG((CLOG_DEBUG "retry in %.0f seconds", retryTime));
+    LOG(CLOG_DEBUG "retry in %.0f seconds", retryTime);
     EventQueueTimer* timer = m_events->newOneShotTimer(retryTime, nullptr);
     m_events->add_handler(EventType::TIMER, timer,
                           [this, timer](const Event& event) { handle_client_restart(event, timer); });
@@ -273,7 +273,7 @@ void ClientApp::handle_client_connected()
 {
     // using CLOG_PRINT here allows the GUI to see that the client is connected
     // regardless of which log level is set
-    LOG((CLOG_PRINT "connected to server"));
+    LOG(CLOG_PRINT "connected to server");
     resetRestartTimeout();
     updateStatus();
 }
@@ -285,11 +285,11 @@ void ClientApp::handle_client_failed(const Event& e)
 
     updateStatus(std::string("Failed to connect to server: ") + info.m_what);
     if (!args().m_restartable || !info.m_retry) {
-        LOG((CLOG_ERR "failed to connect to server: %s", info.m_what.c_str()));
+        LOG(CLOG_ERR "failed to connect to server: %s", info.m_what.c_str());
         m_events->add_event(EventType::QUIT);
     }
     else {
-        LOG((CLOG_WARN "failed to connect to server: %s", info.m_what.c_str()));
+        LOG(CLOG_WARN "failed to connect to server: %s", info.m_what.c_str());
         if (!m_suspended) {
             scheduleClientRestart(nextRestartTimeout());
         }
@@ -299,7 +299,7 @@ void ClientApp::handle_client_failed(const Event& e)
 
 void ClientApp::handle_client_disconnected()
 {
-    LOG((CLOG_NOTE "disconnected from server"));
+    LOG(CLOG_NOTE "disconnected from server");
     if (!args().m_restartable) {
         m_events->add_event(EventType::QUIT);
     }
@@ -369,7 +369,7 @@ ClientApp::startClient()
             client_screen = open_client_screen();
             m_client = openClient(args().m_name, *m_serverAddress, client_screen.get());
             m_clientScreen = std::move(client_screen);
-            LOG((CLOG_NOTE "started client"));
+            LOG(CLOG_NOTE "started client");
         }
 
         m_client->connect();
@@ -378,18 +378,18 @@ ClientApp::startClient()
         return true;
     }
     catch (XScreenUnavailable& e) {
-        LOG((CLOG_WARN "secondary screen unavailable: %s", e.what()));
+        LOG(CLOG_WARN "secondary screen unavailable: %s", e.what());
         updateStatus(std::string("secondary screen unavailable: ") + e.what());
         m_clientScreen.reset();
         retryTime = e.getRetryTime();
     }
     catch (XScreenOpenFailure& e) {
-        LOG((CLOG_CRIT "failed to start client: %s", e.what()));
+        LOG(CLOG_CRIT "failed to start client: %s", e.what());
         m_clientScreen.reset();
         return false;
     }
     catch (XBase& e) {
-        LOG((CLOG_CRIT "failed to start client: %s", e.what()));
+        LOG(CLOG_CRIT "failed to start client: %s", e.what());
         m_clientScreen.reset();
         return false;
     }
@@ -452,10 +452,10 @@ ClientApp::mainLoop()
     DAEMON_RUNNING(false);
 
     // close down
-    LOG((CLOG_DEBUG1 "stopping client"));
+    LOG(CLOG_DEBUG1 "stopping client");
     stopClient();
     updateStatus();
-    LOG((CLOG_NOTE "stopped client"));
+    LOG(CLOG_NOTE "stopped client");
 
     if (argsBase().m_enableIpc) {
         cleanupIpcClient();
@@ -524,7 +524,7 @@ ClientApp::startNode()
 {
     // start the client.  if this return false then we've failed and
     // we shouldn't retry.
-    LOG((CLOG_DEBUG1 "starting client"));
+    LOG(CLOG_DEBUG1 "starting client");
     if (!startClient()) {
         m_bye(kExitFailed);
     }

--- a/src/lib/inputleap/ClipboardChunk.cpp
+++ b/src/lib/inputleap/ClipboardChunk.cpp
@@ -71,7 +71,7 @@ int ClipboardChunk::assemble(inputleap::IStream* stream, std::string& dataCached
 
     if (mark == kDataStart) {
         s_expectedSize = inputleap::string::stringToSizeType(data);
-        LOG((CLOG_DEBUG "start receiving clipboard data"));
+        LOG(CLOG_DEBUG "start receiving clipboard data");
         dataCached.clear();
         return kStart;
     }
@@ -85,13 +85,13 @@ int ClipboardChunk::assemble(inputleap::IStream* stream, std::string& dataCached
             return kError;
         }
         else if (s_expectedSize != dataCached.size()) {
-            LOG((CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", s_expectedSize, dataCached.size()));
+            LOG(CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", s_expectedSize, dataCached.size());
             return kError;
         }
         return kFinish;
     }
 
-    LOG((CLOG_ERR "clipboard transmission failed: unknown error"));
+    LOG(CLOG_ERR "clipboard transmission failed: unknown error");
     return kError;
 }
 

--- a/src/lib/inputleap/ClipboardChunk.cpp
+++ b/src/lib/inputleap/ClipboardChunk.cpp
@@ -71,7 +71,7 @@ int ClipboardChunk::assemble(inputleap::IStream* stream, std::string& dataCached
 
     if (mark == kDataStart) {
         s_expectedSize = inputleap::string::stringToSizeType(data);
-        LOG(CLOG_DEBUG "start receiving clipboard data");
+        LOG_DEBUG("start receiving clipboard data");
         dataCached.clear();
         return kStart;
     }
@@ -85,13 +85,13 @@ int ClipboardChunk::assemble(inputleap::IStream* stream, std::string& dataCached
             return kError;
         }
         else if (s_expectedSize != dataCached.size()) {
-            LOG(CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", s_expectedSize, dataCached.size());
+            LOG_ERR("corrupted clipboard data, expected size=%zd actual size=%zd", s_expectedSize, dataCached.size());
             return kError;
         }
         return kFinish;
     }
 
-    LOG(CLOG_ERR "clipboard transmission failed: unknown error");
+    LOG_ERR("clipboard transmission failed: unknown error");
     return kError;
 }
 

--- a/src/lib/inputleap/DragInformation.cpp
+++ b/src/lib/inputleap/DragInformation.cpp
@@ -73,11 +73,11 @@ void DragInformation::parseDragInfo(DragFileList& dragFileList, std::uint32_t fi
         ++index;
     }
 
-    LOG(CLOG_DEBUG "drag info received, total drag file number: %zi",
+    LOG_DEBUG("drag info received, total drag file number: %zi",
         dragFileList.size());
 
     for (size_t i = 0; i < dragFileList.size(); ++i) {
-        LOG(CLOG_DEBUG "dragging file %zi name: %s",
+        LOG_DEBUG("dragging file %zi name: %s",
             i + 1,
             dragFileList.at(i).getFilename().c_str());
     }

--- a/src/lib/inputleap/DragInformation.cpp
+++ b/src/lib/inputleap/DragInformation.cpp
@@ -73,13 +73,13 @@ void DragInformation::parseDragInfo(DragFileList& dragFileList, std::uint32_t fi
         ++index;
     }
 
-    LOG((CLOG_DEBUG "drag info received, total drag file number: %zi",
-        dragFileList.size()));
+    LOG(CLOG_DEBUG "drag info received, total drag file number: %zi",
+        dragFileList.size());
 
     for (size_t i = 0; i < dragFileList.size(); ++i) {
-        LOG((CLOG_DEBUG "dragging file %zi name: %s",
+        LOG(CLOG_DEBUG "dragging file %zi name: %s",
             i + 1,
-            dragFileList.at(i).getFilename().c_str()));
+            dragFileList.at(i).getFilename().c_str());
     }
 }
 

--- a/src/lib/inputleap/DropHelper.cpp
+++ b/src/lib/inputleap/DropHelper.cpp
@@ -27,7 +27,7 @@ namespace inputleap {
 void
 DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, std::string& data)
 {
-    LOG((CLOG_DEBUG "dropping file, files=%zi target=%s", fileList.size(), destination.c_str()));
+    LOG(CLOG_DEBUG "dropping file, files=%zi target=%s", fileList.size(), destination.c_str());
 
     if (!destination.empty() && fileList.size() > 0) {
         std::fstream file;
@@ -40,18 +40,18 @@ DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, s
         dropTarget.append(fileList.at(0).getFilename());
         open_utf8_path(file, dropTarget, std::ios::out | std::ios::binary);
         if (!file.is_open()) {
-            LOG((CLOG_ERR "drop file failed: can not open %s", dropTarget.c_str()));
+            LOG(CLOG_ERR "drop file failed: can not open %s", dropTarget.c_str());
         }
 
         file.write(data.c_str(), data.size());
         file.close();
 
-        LOG((CLOG_INFO "dropped file \"%s\" in \"%s\"", fileList.at(0).getFilename().c_str(), destination.c_str()));
+        LOG(CLOG_INFO "dropped file \"%s\" in \"%s\"", fileList.at(0).getFilename().c_str(), destination.c_str());
 
         fileList.clear();
     }
     else {
-        LOG((CLOG_ERR "drop file failed: drop target is empty"));
+        LOG(CLOG_ERR "drop file failed: drop target is empty");
     }
 }
 

--- a/src/lib/inputleap/DropHelper.cpp
+++ b/src/lib/inputleap/DropHelper.cpp
@@ -27,7 +27,7 @@ namespace inputleap {
 void
 DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, std::string& data)
 {
-    LOG(CLOG_DEBUG "dropping file, files=%zi target=%s", fileList.size(), destination.c_str());
+    LOG_DEBUG("dropping file, files=%zi target=%s", fileList.size(), destination.c_str());
 
     if (!destination.empty() && fileList.size() > 0) {
         std::fstream file;
@@ -40,18 +40,18 @@ DropHelper::writeToDir(const std::string& destination, DragFileList& fileList, s
         dropTarget.append(fileList.at(0).getFilename());
         open_utf8_path(file, dropTarget, std::ios::out | std::ios::binary);
         if (!file.is_open()) {
-            LOG(CLOG_ERR "drop file failed: can not open %s", dropTarget.c_str());
+            LOG_ERR("drop file failed: can not open %s", dropTarget.c_str());
         }
 
         file.write(data.c_str(), data.size());
         file.close();
 
-        LOG(CLOG_INFO "dropped file \"%s\" in \"%s\"", fileList.at(0).getFilename().c_str(), destination.c_str());
+        LOG_INFO("dropped file \"%s\" in \"%s\"", fileList.at(0).getFilename().c_str(), destination.c_str());
 
         fileList.clear();
     }
     else {
-        LOG(CLOG_ERR "drop file failed: drop target is empty");
+        LOG_ERR("drop file failed: drop target is empty");
     }
 }
 

--- a/src/lib/inputleap/FileChunk.cpp
+++ b/src/lib/inputleap/FileChunk.cpp
@@ -73,7 +73,7 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
         stopwatch.reset();
 
         if (CLOG->getFilter() >= kDEBUG2) {
-            LOG((CLOG_DEBUG2 "recv file size=%s", content.c_str()));
+            LOG(CLOG_DEBUG2 "recv file size=%s", content.c_str());
             stopwatch.start();
         }
         return kStart;
@@ -81,13 +81,13 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
     case kDataChunk:
         dataReceived.append(content);
         if (CLOG->getFilter() >= kDEBUG2) {
-                LOG((CLOG_DEBUG2 "recv file chunk size=%zi", content.size()));
+                LOG(CLOG_DEBUG2 "recv file chunk size=%zi", content.size());
                 double interval = stopwatch.getTime();
                 receivedDataSize += content.size();
-                LOG((CLOG_DEBUG2 "recv file interval=%f s", interval));
+                LOG(CLOG_DEBUG2 "recv file interval=%f s", interval);
                 if (interval >= kIntervalThreshold) {
                     double averageSpeed = receivedDataSize / interval / 1000;
-                    LOG((CLOG_DEBUG2 "recv file average speed=%f kb/s", averageSpeed));
+                    LOG(CLOG_DEBUG2 "recv file average speed=%f kb/s", averageSpeed);
 
                     receivedDataSize = 0;
                     elapsedTime += interval;
@@ -98,17 +98,17 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
 
     case kDataEnd:
         if (expectedSize != dataReceived.size()) {
-            LOG((CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", expectedSize, dataReceived.size()));
+            LOG(CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", expectedSize, dataReceived.size());
             return kError;
         }
 
         if (CLOG->getFilter() >= kDEBUG2) {
-            LOG((CLOG_DEBUG2 "file transfer finished"));
+            LOG(CLOG_DEBUG2 "file transfer finished");
             elapsedTime += stopwatch.getTime();
             double averageSpeed = expectedSize / elapsedTime / 1000;
-            LOG((CLOG_DEBUG2 "file transfer finished: total time consumed=%f s", elapsedTime));
-            LOG((CLOG_DEBUG2 "file transfer finished: total data received=%zi kb", expectedSize / 1000));
-            LOG((CLOG_DEBUG2 "file transfer finished: total average speed=%f kb/s", averageSpeed));
+            LOG(CLOG_DEBUG2 "file transfer finished: total time consumed=%f s", elapsedTime);
+            LOG(CLOG_DEBUG2 "file transfer finished: total data received=%zi kb", expectedSize / 1000);
+            LOG(CLOG_DEBUG2 "file transfer finished: total average speed=%f kb/s", averageSpeed);
         }
         return kFinish;
         default:

--- a/src/lib/inputleap/FileChunk.cpp
+++ b/src/lib/inputleap/FileChunk.cpp
@@ -73,7 +73,7 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
         stopwatch.reset();
 
         if (CLOG->getFilter() >= kDEBUG2) {
-            LOG(CLOG_DEBUG2 "recv file size=%s", content.c_str());
+            LOG_DEBUG2("recv file size=%s", content.c_str());
             stopwatch.start();
         }
         return kStart;
@@ -81,13 +81,13 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
     case kDataChunk:
         dataReceived.append(content);
         if (CLOG->getFilter() >= kDEBUG2) {
-                LOG(CLOG_DEBUG2 "recv file chunk size=%zi", content.size());
+                LOG_DEBUG2("recv file chunk size=%zi", content.size());
                 double interval = stopwatch.getTime();
                 receivedDataSize += content.size();
-                LOG(CLOG_DEBUG2 "recv file interval=%f s", interval);
+                LOG_DEBUG2("recv file interval=%f s", interval);
                 if (interval >= kIntervalThreshold) {
                     double averageSpeed = receivedDataSize / interval / 1000;
-                    LOG(CLOG_DEBUG2 "recv file average speed=%f kb/s", averageSpeed);
+                    LOG_DEBUG2("recv file average speed=%f kb/s", averageSpeed);
 
                     receivedDataSize = 0;
                     elapsedTime += interval;
@@ -98,17 +98,17 @@ int FileChunk::assemble(inputleap::IStream* stream, std::string& dataReceived, s
 
     case kDataEnd:
         if (expectedSize != dataReceived.size()) {
-            LOG(CLOG_ERR "corrupted clipboard data, expected size=%zd actual size=%zd", expectedSize, dataReceived.size());
+            LOG_ERR("corrupted clipboard data, expected size=%zd actual size=%zd", expectedSize, dataReceived.size());
             return kError;
         }
 
         if (CLOG->getFilter() >= kDEBUG2) {
-            LOG(CLOG_DEBUG2 "file transfer finished");
+            LOG_DEBUG2("file transfer finished");
             elapsedTime += stopwatch.getTime();
             double averageSpeed = expectedSize / elapsedTime / 1000;
-            LOG(CLOG_DEBUG2 "file transfer finished: total time consumed=%f s", elapsedTime);
-            LOG(CLOG_DEBUG2 "file transfer finished: total data received=%zi kb", expectedSize / 1000);
-            LOG(CLOG_DEBUG2 "file transfer finished: total average speed=%f kb/s", averageSpeed);
+            LOG_DEBUG2("file transfer finished: total time consumed=%f s", elapsedTime);
+            LOG_DEBUG2("file transfer finished: total data received=%zi kb", expectedSize / 1000);
+            LOG_DEBUG2("file transfer finished: total average speed=%f kb/s", averageSpeed);
         }
         return kFinish;
         default:

--- a/src/lib/inputleap/KeyMap.cpp
+++ b/src/lib/inputleap/KeyMap.cpp
@@ -105,7 +105,7 @@ KeyMap::addKeyEntry(const KeyItem& item)
 
     // add item list
     entries.push_back(items);
-    LOG((CLOG_DEBUG5 "add key: %04x %d %03x %04x (%04x %04x %04x)%s", newItem.m_id, newItem.m_group, newItem.m_button, newItem.m_client, newItem.m_required, newItem.m_sensitive, newItem.m_generates, newItem.m_dead ? " dead" : ""));
+    LOG(CLOG_DEBUG5 "add key: %04x %d %03x %04x (%04x %04x %04x)%s", newItem.m_id, newItem.m_group, newItem.m_button, newItem.m_client, newItem.m_required, newItem.m_sensitive, newItem.m_generates, newItem.m_dead ? " dead" : "");
 }
 
 void KeyMap::addKeyAliasEntry(KeyID targetID, std::int32_t group, KeyModifierMask targetRequired,
@@ -257,7 +257,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
                                       KeyModifierMask& currentState, KeyModifierMask desiredMask,
                                       bool isAutoRepeat) const
 {
-    LOG((CLOG_DEBUG1 "mapKey %04x (%d) with mask %04x, start state: %04x", id, id, desiredMask, currentState));
+    LOG(CLOG_DEBUG1 "mapKey %04x (%d) with mask %04x, start state: %04x", id, id, desiredMask, currentState);
 
     // handle group change
     if (id == kKeyNextGroup) {
@@ -292,7 +292,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
     case kKeySetModifiers:
         if (!keysForModifierState(0, group, activeModifiers, currentState,
                                 desiredMask, desiredMask, 0, keys)) {
-            LOG((CLOG_DEBUG1 "unable to set modifiers %04x", desiredMask));
+            LOG(CLOG_DEBUG1 "unable to set modifiers %04x", desiredMask);
             return nullptr;
         }
         return &m_modifierKeyItem;
@@ -301,7 +301,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
         if (!keysForModifierState(0, group, activeModifiers, currentState,
                                 currentState & ~desiredMask,
                                 desiredMask, 0, keys)) {
-            LOG((CLOG_DEBUG1 "unable to clear modifiers %04x", desiredMask));
+            LOG(CLOG_DEBUG1 "unable to clear modifiers %04x", desiredMask);
             return nullptr;
         }
         return &m_modifierKeyItem;
@@ -319,7 +319,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
     }
 
     if (item != nullptr) {
-        LOG((CLOG_DEBUG1 "mapped to %03x, new state %04x", item->m_button, currentState));
+        LOG(CLOG_DEBUG1 "mapped to %03x, new state %04x", item->m_button, currentState);
     }
     return item;
 }
@@ -506,7 +506,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     KeyIDMap::const_iterator it = m_keyIDMap.find(id);
     if (it == m_keyIDMap.end()) {
         // unknown key
-        LOG((CLOG_DEBUG1 "key %04x is not on keyboard", id));
+        LOG(CLOG_DEBUG1 "key %04x is not on keyboard", id);
         return nullptr;
     }
     const KeyGroupTable& keyGroupTable = it->second;
@@ -533,7 +533,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
             KeyModifierMask requiredIgnoreShiftMask = item.m_required & ~KeyModifierShift;
             if ((item.m_required & desiredShiftMask) == (item.m_sensitive & desiredShiftMask) &&
                 ((requiredIgnoreShiftMask & desiredMask) == requiredIgnoreShiftMask)) {
-                LOG((CLOG_INFO "found key in group %d", effectiveGroup));
+                LOG(CLOG_INFO "found key in group %d", effectiveGroup);
                 keyItem = &item;
                 break;
             }
@@ -544,7 +544,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     }
     if (keyItem == nullptr) {
         // no mapping for this keysym
-        LOG((CLOG_DEBUG1 "no mapping for key %04x", id));
+        LOG(CLOG_DEBUG1 "no mapping for key %04x", id);
         return nullptr;
     }
 
@@ -561,7 +561,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     if (!keysForKeyItem(*keyItem, newGroup, newModifiers,
                             newState, desiredMask,
                             s_overrideModifiers, isAutoRepeat, keys)) {
-        LOG((CLOG_DEBUG1 "can't map key"));
+        LOG(CLOG_DEBUG1 "can't map key");
         keys.clear();
         return nullptr;
     }
@@ -569,7 +569,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     // add keystrokes to restore modifier keys
     if (!keysToRestoreModifiers(*keyItem, group, newModifiers, newState,
                                 activeModifiers, keys)) {
-        LOG((CLOG_DEBUG1 "failed to restore modifiers"));
+        LOG(CLOG_DEBUG1 "failed to restore modifiers");
         keys.clear();
         return nullptr;
     }
@@ -595,7 +595,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
     KeyIDMap::const_iterator i = m_keyIDMap.find(id);
     if (i == m_keyIDMap.end()) {
         // unknown key
-        LOG((CLOG_DEBUG1 "key %04x is not on keyboard", id));
+        LOG(CLOG_DEBUG1 "key %04x is not on keyboard", id);
         return nullptr;
     }
     const KeyGroupTable& keyGroupTable = i->second;
@@ -604,19 +604,19 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
     std::int32_t keyIndex  = -1;
     std::int32_t numGroups = getNumGroups();
     std::int32_t groupOffset;
-    LOG((CLOG_DEBUG1 "find best:  %04x %04x", currentState, desiredMask));
+    LOG(CLOG_DEBUG1 "find best:  %04x %04x", currentState, desiredMask);
     for (groupOffset = 0; groupOffset < numGroups; ++groupOffset) {
         std::int32_t effectiveGroup = getEffectiveGroup(group, groupOffset);
         keyIndex = findBestKey(keyGroupTable[effectiveGroup],
                                 currentState, desiredMask);
         if (keyIndex != -1) {
-            LOG((CLOG_DEBUG1 "found key in group %d", effectiveGroup));
+            LOG(CLOG_DEBUG1 "found key in group %d", effectiveGroup);
             break;
         }
     }
     if (keyIndex == -1) {
         // no mapping for this keysym
-        LOG((CLOG_DEBUG1 "no mapping for key %04x", id));
+        LOG(CLOG_DEBUG1 "no mapping for key %04x", id);
         return nullptr;
     }
 
@@ -638,7 +638,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
         if (!keysForKeyItem(itemList[j], newGroup, newModifiers,
                             newState, desiredMask,
                             0, isAutoRepeat, keys)) {
-            LOG((CLOG_DEBUG1 "can't map key"));
+            LOG(CLOG_DEBUG1 "can't map key");
             keys.clear();
             return nullptr;
         }
@@ -647,7 +647,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
     // add keystrokes to restore modifier keys
     if (!keysToRestoreModifiers(keyItem, group, newModifiers, newState,
                                 activeModifiers, keys)) {
-        LOG((CLOG_DEBUG1 "failed to restore modifiers"));
+        LOG(CLOG_DEBUG1 "failed to restore modifiers");
         keys.clear();
         return nullptr;
     }
@@ -681,7 +681,7 @@ std::int32_t KeyMap::findBestKey(const KeyEntryList& entryList, KeyModifierMask 
         const KeyItem& item = entryList[i].back();
         if ((item.m_required & desiredState) == item.m_required &&
             (item.m_required & desiredState) == (item.m_sensitive & desiredState)) {
-            LOG((CLOG_DEBUG1 "best key index %d of %zd (exact)", i + 1, entryList.size()));
+            LOG(CLOG_DEBUG1 "best key index %d of %zd (exact)", i + 1, entryList.size());
             return i;
         }
     }
@@ -700,8 +700,8 @@ std::int32_t KeyMap::findBestKey(const KeyEntryList& entryList, KeyModifierMask 
         }
     }
     if (bestIndex != -1) {
-        LOG((CLOG_DEBUG1 "best key index %d of %zd (%d modifiers)",
-             bestIndex + 1, entryList.size(), bestCount));
+        LOG(CLOG_DEBUG1 "best key index %d of %zd (%d modifiers)",
+             bestIndex + 1, entryList.size(), bestCount);
     }
 
     return bestIndex;
@@ -751,7 +751,7 @@ bool KeyMap::keysForKeyItem(const KeyItem& keyItem, std::int32_t& group,
                                 activeModifiers, currentState,
                                 keyItem.m_required, keyItem.m_sensitive,
                                 0, keystrokes)) {
-            LOG((CLOG_DEBUG1 "unable to match modifier state for dead key %d", keyItem.m_button));
+            LOG(CLOG_DEBUG1 "unable to match modifier state for dead key %d", keyItem.m_button);
             return false;
         }
 
@@ -770,25 +770,25 @@ bool KeyMap::keysForKeyItem(const KeyItem& keyItem, std::int32_t& group,
         // button (any other button) mapped to the shift modifier and then
         // the Shift_L button.
         // match key's required state
-        LOG((CLOG_DEBUG1 "state: %04x,%04x,%04x", currentState, keyItem.m_required, sensitive));
+        LOG(CLOG_DEBUG1 "state: %04x,%04x,%04x", currentState, keyItem.m_required, sensitive);
         if (!keysForModifierState(keyItem.m_button, group,
                                 activeModifiers, currentState,
                                 keyItem.m_required, sensitive,
                                 0, keystrokes)) {
-            LOG((CLOG_DEBUG1 "unable to match modifier state (%04x,%04x) for key %d", keyItem.m_required, keyItem.m_sensitive, keyItem.m_button));
+            LOG(CLOG_DEBUG1 "unable to match modifier state (%04x,%04x) for key %d", keyItem.m_required, keyItem.m_sensitive, keyItem.m_button);
             return false;
         }
 
         // match desiredState as closely as possible.  we must not
         // change any modifiers in keyItem.m_sensitive.  and if the key
         // is a modifier, we don't want to change that modifier.
-        LOG((CLOG_DEBUG1 "desired state: %04x %04x,%04x,%04x", desiredState, currentState, keyItem.m_required, keyItem.m_sensitive));
+        LOG(CLOG_DEBUG1 "desired state: %04x %04x,%04x,%04x", desiredState, currentState, keyItem.m_required, keyItem.m_sensitive);
         if (!keysForModifierState(keyItem.m_button, group,
                                 activeModifiers, currentState,
                                 desiredState,
                                 ~(sensitive | keyItem.m_generates),
                                 s_notRequiredMask, keystrokes)) {
-            LOG((CLOG_DEBUG1 "unable to match desired modifier state (%04x,%04x) for key %d", desiredState, ~keyItem.m_sensitive & 0xffffu, keyItem.m_button));
+            LOG(CLOG_DEBUG1 "unable to match desired modifier state (%04x,%04x) for key %d", desiredState, ~keyItem.m_sensitive & 0xffffu, keyItem.m_button);
             return false;
         }
 
@@ -858,7 +858,7 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
     // to work if the key itself is a modifier (the numlock toggle can
     // interfere) so we don't try to match at all.
     flipMask &= ~notRequiredMask;
-    LOG((CLOG_DEBUG1 "flip: %04x (%04x vs %04x in %04x - %04x)", flipMask, currentState, requiredState, sensitiveMask & 0xffffu, notRequiredMask & 0xffffu));
+    LOG(CLOG_DEBUG1 "flip: %04x (%04x vs %04x in %04x - %04x)", flipMask, currentState, requiredState, sensitiveMask & 0xffffu, notRequiredMask & 0xffffu);
     if (flipMask == 0) {
         return true;
     }
@@ -883,7 +883,7 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
         const KeyItem* keyItem = keyForModifier(button, group, bit);
         if (keyItem == nullptr) {
             if ((mask & notRequiredMask) == 0) {
-                LOG((CLOG_DEBUG1 "no key for modifier %04x", mask));
+                LOG(CLOG_DEBUG1 "no key for modifier %04x", mask);
                 return false;
             }
             else {
@@ -898,13 +898,13 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
         if ((sensitive & mask) != 0) {
             // modifier is sensitive to itself.  that makes no sense
             // so ignore it.
-            LOG((CLOG_DEBUG1 "modifier %04x modified by itself", mask));
+            LOG(CLOG_DEBUG1 "modifier %04x modified by itself", mask);
             sensitive &= ~mask;
         }
         if (sensitive != 0) {
             if (sensitive > mask) {
                 // our assumption is incorrect
-                LOG((CLOG_DEBUG1 "modifier %04x modified by %04x", mask, sensitive));
+                LOG(CLOG_DEBUG1 "modifier %04x modified by %04x", mask, sensitive);
                 return false;
             }
             if (active && !keysForModifierState(button, group,
@@ -924,7 +924,7 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
 
         // current state should match required state
         if ((currentState & sensitive) != (keyItem->m_required & sensitive)) {
-            LOG((CLOG_DEBUG1 "unable to match modifier state for modifier %04x (%04x vs %04x in %04x)", mask, currentState, keyItem->m_required, sensitive));
+            LOG(CLOG_DEBUG1 "unable to match modifier state for modifier %04x (%04x vs %04x in %04x)", mask, currentState, keyItem->m_required, sensitive);
             return false;
         }
 

--- a/src/lib/inputleap/KeyMap.cpp
+++ b/src/lib/inputleap/KeyMap.cpp
@@ -105,7 +105,7 @@ KeyMap::addKeyEntry(const KeyItem& item)
 
     // add item list
     entries.push_back(items);
-    LOG(CLOG_DEBUG5 "add key: %04x %d %03x %04x (%04x %04x %04x)%s", newItem.m_id, newItem.m_group, newItem.m_button, newItem.m_client, newItem.m_required, newItem.m_sensitive, newItem.m_generates, newItem.m_dead ? " dead" : "");
+    LOG_DEBUG5("add key: %04x %d %03x %04x (%04x %04x %04x)%s", newItem.m_id, newItem.m_group, newItem.m_button, newItem.m_client, newItem.m_required, newItem.m_sensitive, newItem.m_generates, newItem.m_dead ? " dead" : "");
 }
 
 void KeyMap::addKeyAliasEntry(KeyID targetID, std::int32_t group, KeyModifierMask targetRequired,
@@ -257,7 +257,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
                                       KeyModifierMask& currentState, KeyModifierMask desiredMask,
                                       bool isAutoRepeat) const
 {
-    LOG(CLOG_DEBUG1 "mapKey %04x (%d) with mask %04x, start state: %04x", id, id, desiredMask, currentState);
+    LOG_DEBUG1("mapKey %04x (%d) with mask %04x, start state: %04x", id, id, desiredMask, currentState);
 
     // handle group change
     if (id == kKeyNextGroup) {
@@ -292,7 +292,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
     case kKeySetModifiers:
         if (!keysForModifierState(0, group, activeModifiers, currentState,
                                 desiredMask, desiredMask, 0, keys)) {
-            LOG(CLOG_DEBUG1 "unable to set modifiers %04x", desiredMask);
+            LOG_DEBUG1("unable to set modifiers %04x", desiredMask);
             return nullptr;
         }
         return &m_modifierKeyItem;
@@ -301,7 +301,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
         if (!keysForModifierState(0, group, activeModifiers, currentState,
                                 currentState & ~desiredMask,
                                 desiredMask, 0, keys)) {
-            LOG(CLOG_DEBUG1 "unable to clear modifiers %04x", desiredMask);
+            LOG_DEBUG1("unable to clear modifiers %04x", desiredMask);
             return nullptr;
         }
         return &m_modifierKeyItem;
@@ -319,7 +319,7 @@ const KeyMap::KeyItem* KeyMap::mapKey(Keystrokes& keys, KeyID id, std::int32_t g
     }
 
     if (item != nullptr) {
-        LOG(CLOG_DEBUG1 "mapped to %03x, new state %04x", item->m_button, currentState);
+        LOG_DEBUG1("mapped to %03x, new state %04x", item->m_button, currentState);
     }
     return item;
 }
@@ -506,7 +506,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     KeyIDMap::const_iterator it = m_keyIDMap.find(id);
     if (it == m_keyIDMap.end()) {
         // unknown key
-        LOG(CLOG_DEBUG1 "key %04x is not on keyboard", id);
+        LOG_DEBUG1("key %04x is not on keyboard", id);
         return nullptr;
     }
     const KeyGroupTable& keyGroupTable = it->second;
@@ -533,7 +533,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
             KeyModifierMask requiredIgnoreShiftMask = item.m_required & ~KeyModifierShift;
             if ((item.m_required & desiredShiftMask) == (item.m_sensitive & desiredShiftMask) &&
                 ((requiredIgnoreShiftMask & desiredMask) == requiredIgnoreShiftMask)) {
-                LOG(CLOG_INFO "found key in group %d", effectiveGroup);
+                LOG_INFO("found key in group %d", effectiveGroup);
                 keyItem = &item;
                 break;
             }
@@ -544,7 +544,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     }
     if (keyItem == nullptr) {
         // no mapping for this keysym
-        LOG(CLOG_DEBUG1 "no mapping for key %04x", id);
+        LOG_DEBUG1("no mapping for key %04x", id);
         return nullptr;
     }
 
@@ -561,7 +561,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     if (!keysForKeyItem(*keyItem, newGroup, newModifiers,
                             newState, desiredMask,
                             s_overrideModifiers, isAutoRepeat, keys)) {
-        LOG(CLOG_DEBUG1 "can't map key");
+        LOG_DEBUG1("can't map key");
         keys.clear();
         return nullptr;
     }
@@ -569,7 +569,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     // add keystrokes to restore modifier keys
     if (!keysToRestoreModifiers(*keyItem, group, newModifiers, newState,
                                 activeModifiers, keys)) {
-        LOG(CLOG_DEBUG1 "failed to restore modifiers");
+        LOG_DEBUG1("failed to restore modifiers");
         keys.clear();
         return nullptr;
     }
@@ -595,7 +595,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
     KeyIDMap::const_iterator i = m_keyIDMap.find(id);
     if (i == m_keyIDMap.end()) {
         // unknown key
-        LOG(CLOG_DEBUG1 "key %04x is not on keyboard", id);
+        LOG_DEBUG1("key %04x is not on keyboard", id);
         return nullptr;
     }
     const KeyGroupTable& keyGroupTable = i->second;
@@ -604,19 +604,19 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
     std::int32_t keyIndex  = -1;
     std::int32_t numGroups = getNumGroups();
     std::int32_t groupOffset;
-    LOG(CLOG_DEBUG1 "find best:  %04x %04x", currentState, desiredMask);
+    LOG_DEBUG1("find best:  %04x %04x", currentState, desiredMask);
     for (groupOffset = 0; groupOffset < numGroups; ++groupOffset) {
         std::int32_t effectiveGroup = getEffectiveGroup(group, groupOffset);
         keyIndex = findBestKey(keyGroupTable[effectiveGroup],
                                 currentState, desiredMask);
         if (keyIndex != -1) {
-            LOG(CLOG_DEBUG1 "found key in group %d", effectiveGroup);
+            LOG_DEBUG1("found key in group %d", effectiveGroup);
             break;
         }
     }
     if (keyIndex == -1) {
         // no mapping for this keysym
-        LOG(CLOG_DEBUG1 "no mapping for key %04x", id);
+        LOG_DEBUG1("no mapping for key %04x", id);
         return nullptr;
     }
 
@@ -638,7 +638,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
         if (!keysForKeyItem(itemList[j], newGroup, newModifiers,
                             newState, desiredMask,
                             0, isAutoRepeat, keys)) {
-            LOG(CLOG_DEBUG1 "can't map key");
+            LOG_DEBUG1("can't map key");
             keys.clear();
             return nullptr;
         }
@@ -647,7 +647,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
     // add keystrokes to restore modifier keys
     if (!keysToRestoreModifiers(keyItem, group, newModifiers, newState,
                                 activeModifiers, keys)) {
-        LOG(CLOG_DEBUG1 "failed to restore modifiers");
+        LOG_DEBUG1("failed to restore modifiers");
         keys.clear();
         return nullptr;
     }
@@ -681,7 +681,7 @@ std::int32_t KeyMap::findBestKey(const KeyEntryList& entryList, KeyModifierMask 
         const KeyItem& item = entryList[i].back();
         if ((item.m_required & desiredState) == item.m_required &&
             (item.m_required & desiredState) == (item.m_sensitive & desiredState)) {
-            LOG(CLOG_DEBUG1 "best key index %d of %zd (exact)", i + 1, entryList.size());
+            LOG_DEBUG1("best key index %d of %zd (exact)", i + 1, entryList.size());
             return i;
         }
     }
@@ -700,7 +700,7 @@ std::int32_t KeyMap::findBestKey(const KeyEntryList& entryList, KeyModifierMask 
         }
     }
     if (bestIndex != -1) {
-        LOG(CLOG_DEBUG1 "best key index %d of %zd (%d modifiers)",
+        LOG_DEBUG1("best key index %d of %zd (%d modifiers)",
              bestIndex + 1, entryList.size(), bestCount);
     }
 
@@ -751,7 +751,7 @@ bool KeyMap::keysForKeyItem(const KeyItem& keyItem, std::int32_t& group,
                                 activeModifiers, currentState,
                                 keyItem.m_required, keyItem.m_sensitive,
                                 0, keystrokes)) {
-            LOG(CLOG_DEBUG1 "unable to match modifier state for dead key %d", keyItem.m_button);
+            LOG_DEBUG1("unable to match modifier state for dead key %d", keyItem.m_button);
             return false;
         }
 
@@ -770,25 +770,25 @@ bool KeyMap::keysForKeyItem(const KeyItem& keyItem, std::int32_t& group,
         // button (any other button) mapped to the shift modifier and then
         // the Shift_L button.
         // match key's required state
-        LOG(CLOG_DEBUG1 "state: %04x,%04x,%04x", currentState, keyItem.m_required, sensitive);
+        LOG_DEBUG1("state: %04x,%04x,%04x", currentState, keyItem.m_required, sensitive);
         if (!keysForModifierState(keyItem.m_button, group,
                                 activeModifiers, currentState,
                                 keyItem.m_required, sensitive,
                                 0, keystrokes)) {
-            LOG(CLOG_DEBUG1 "unable to match modifier state (%04x,%04x) for key %d", keyItem.m_required, keyItem.m_sensitive, keyItem.m_button);
+            LOG_DEBUG1("unable to match modifier state (%04x,%04x) for key %d", keyItem.m_required, keyItem.m_sensitive, keyItem.m_button);
             return false;
         }
 
         // match desiredState as closely as possible.  we must not
         // change any modifiers in keyItem.m_sensitive.  and if the key
         // is a modifier, we don't want to change that modifier.
-        LOG(CLOG_DEBUG1 "desired state: %04x %04x,%04x,%04x", desiredState, currentState, keyItem.m_required, keyItem.m_sensitive);
+        LOG_DEBUG1("desired state: %04x %04x,%04x,%04x", desiredState, currentState, keyItem.m_required, keyItem.m_sensitive);
         if (!keysForModifierState(keyItem.m_button, group,
                                 activeModifiers, currentState,
                                 desiredState,
                                 ~(sensitive | keyItem.m_generates),
                                 s_notRequiredMask, keystrokes)) {
-            LOG(CLOG_DEBUG1 "unable to match desired modifier state (%04x,%04x) for key %d", desiredState, ~keyItem.m_sensitive & 0xffffu, keyItem.m_button);
+            LOG_DEBUG1("unable to match desired modifier state (%04x,%04x) for key %d", desiredState, ~keyItem.m_sensitive & 0xffffu, keyItem.m_button);
             return false;
         }
 
@@ -858,7 +858,7 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
     // to work if the key itself is a modifier (the numlock toggle can
     // interfere) so we don't try to match at all.
     flipMask &= ~notRequiredMask;
-    LOG(CLOG_DEBUG1 "flip: %04x (%04x vs %04x in %04x - %04x)", flipMask, currentState, requiredState, sensitiveMask & 0xffffu, notRequiredMask & 0xffffu);
+    LOG_DEBUG1("flip: %04x (%04x vs %04x in %04x - %04x)", flipMask, currentState, requiredState, sensitiveMask & 0xffffu, notRequiredMask & 0xffffu);
     if (flipMask == 0) {
         return true;
     }
@@ -883,7 +883,7 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
         const KeyItem* keyItem = keyForModifier(button, group, bit);
         if (keyItem == nullptr) {
             if ((mask & notRequiredMask) == 0) {
-                LOG(CLOG_DEBUG1 "no key for modifier %04x", mask);
+                LOG_DEBUG1("no key for modifier %04x", mask);
                 return false;
             }
             else {
@@ -898,13 +898,13 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
         if ((sensitive & mask) != 0) {
             // modifier is sensitive to itself.  that makes no sense
             // so ignore it.
-            LOG(CLOG_DEBUG1 "modifier %04x modified by itself", mask);
+            LOG_DEBUG1("modifier %04x modified by itself", mask);
             sensitive &= ~mask;
         }
         if (sensitive != 0) {
             if (sensitive > mask) {
                 // our assumption is incorrect
-                LOG(CLOG_DEBUG1 "modifier %04x modified by %04x", mask, sensitive);
+                LOG_DEBUG1("modifier %04x modified by %04x", mask, sensitive);
                 return false;
             }
             if (active && !keysForModifierState(button, group,
@@ -924,7 +924,7 @@ bool KeyMap::keysForModifierState(KeyButton button, std::int32_t group,
 
         // current state should match required state
         if ((currentState & sensitive) != (keyItem->m_required & sensitive)) {
-            LOG(CLOG_DEBUG1 "unable to match modifier state for modifier %04x (%04x vs %04x in %04x)", mask, currentState, keyItem->m_required, sensitive);
+            LOG_DEBUG1("unable to match modifier state for modifier %04x (%04x vs %04x in %04x)", mask, currentState, keyItem->m_required, sensitive);
             return false;
         }
 

--- a/src/lib/inputleap/KeyState.cpp
+++ b/src/lib/inputleap/KeyState.cpp
@@ -423,7 +423,7 @@ KeyState::onKey(KeyButton button, bool down, KeyModifierMask newState)
 {
     // update modifier state
     m_mask = newState;
-    LOG(CLOG_DEBUG1 "new mask: 0x%04x", m_mask);
+    LOG_DEBUG1("new mask: 0x%04x", m_mask);
 
     // ignore bogus buttons
     button &= kButtonMask;
@@ -513,7 +513,7 @@ KeyState::updateKeyState()
                                                 m_activeModifiers);
     m_keyMap.foreachKey(&KeyState::addActiveModifierCB, &addModifierContext);
 
-    LOG(CLOG_DEBUG1 "modifiers on update: 0x%04x", m_mask);
+    LOG_DEBUG1("modifiers on update: 0x%04x", m_mask);
 }
 
 void KeyState::addActiveModifierCB(KeyID, std::int32_t group, inputleap::KeyMap::KeyItem& keyItem,
@@ -556,7 +556,7 @@ KeyState::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton serverID)
 
     // ignore certain keys
     if (isIgnoredKey(id, mask)) {
-        LOG(CLOG_DEBUG1 "ignored key %04x %04x", id, mask);
+        LOG_DEBUG1("ignored key %04x %04x", id, mask);
         return;
     }
 
@@ -574,7 +574,7 @@ KeyState::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton serverID)
             id == kKeyAudioPrev || id == kKeyAudioNext ||
             id == kKeyBrightnessDown || id == kKeyBrightnessUp
             ) {
-            LOG(CLOG_DEBUG1 "emulating media key");
+            LOG_DEBUG1("emulating media key");
             fakeMediaKey(id);
         }
 
@@ -686,7 +686,7 @@ KeyState::fakeKeyUp(KeyButton serverID)
             if (m_activeModifiers.count(mask) == 0) {
                 // no key for modifier is down so deactivate modifier
                 m_mask &= ~mask;
-                LOG(CLOG_DEBUG1 "new state %04x", m_mask);
+                LOG_DEBUG1("new state %04x", m_mask);
             }
         }
         else {
@@ -840,7 +840,7 @@ void KeyState::fakeKeys(const Keystrokes& keys, std::uint32_t count)
     }
 
     // generate key events
-    LOG(CLOG_DEBUG1 "keystrokes:");
+    LOG_DEBUG1("keystrokes:");
     for (Keystrokes::const_iterator k = keys.begin(); k != keys.end(); ) {
         if (k->m_type == Keystroke::kButton && k->m_data.m_button.m_repeat) {
             // repeat from here up to but not including the next key

--- a/src/lib/inputleap/KeyState.cpp
+++ b/src/lib/inputleap/KeyState.cpp
@@ -423,7 +423,7 @@ KeyState::onKey(KeyButton button, bool down, KeyModifierMask newState)
 {
     // update modifier state
     m_mask = newState;
-    LOG((CLOG_DEBUG1 "new mask: 0x%04x", m_mask));
+    LOG(CLOG_DEBUG1 "new mask: 0x%04x", m_mask);
 
     // ignore bogus buttons
     button &= kButtonMask;
@@ -513,7 +513,7 @@ KeyState::updateKeyState()
                                                 m_activeModifiers);
     m_keyMap.foreachKey(&KeyState::addActiveModifierCB, &addModifierContext);
 
-    LOG((CLOG_DEBUG1 "modifiers on update: 0x%04x", m_mask));
+    LOG(CLOG_DEBUG1 "modifiers on update: 0x%04x", m_mask);
 }
 
 void KeyState::addActiveModifierCB(KeyID, std::int32_t group, inputleap::KeyMap::KeyItem& keyItem,
@@ -556,7 +556,7 @@ KeyState::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton serverID)
 
     // ignore certain keys
     if (isIgnoredKey(id, mask)) {
-        LOG((CLOG_DEBUG1 "ignored key %04x %04x", id, mask));
+        LOG(CLOG_DEBUG1 "ignored key %04x %04x", id, mask);
         return;
     }
 
@@ -574,7 +574,7 @@ KeyState::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton serverID)
             id == kKeyAudioPrev || id == kKeyAudioNext ||
             id == kKeyBrightnessDown || id == kKeyBrightnessUp
             ) {
-            LOG((CLOG_DEBUG1 "emulating media key"));
+            LOG(CLOG_DEBUG1 "emulating media key");
             fakeMediaKey(id);
         }
 
@@ -686,7 +686,7 @@ KeyState::fakeKeyUp(KeyButton serverID)
             if (m_activeModifiers.count(mask) == 0) {
                 // no key for modifier is down so deactivate modifier
                 m_mask &= ~mask;
-                LOG((CLOG_DEBUG1 "new state %04x", m_mask));
+                LOG(CLOG_DEBUG1 "new state %04x", m_mask);
             }
         }
         else {
@@ -840,7 +840,7 @@ void KeyState::fakeKeys(const Keystrokes& keys, std::uint32_t count)
     }
 
     // generate key events
-    LOG((CLOG_DEBUG1 "keystrokes:"));
+    LOG(CLOG_DEBUG1 "keystrokes:");
     for (Keystrokes::const_iterator k = keys.begin(); k != keys.end(); ) {
         if (k->m_type == Keystroke::kButton && k->m_data.m_button.m_repeat) {
             // repeat from here up to but not including the next key

--- a/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
+++ b/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
@@ -25,123 +25,123 @@ PlatformScreenLoggingWrapper::PlatformScreenLoggingWrapper(std::unique_ptr<IPlat
 
 void PlatformScreenLoggingWrapper::enable()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::enable()");
+    LOG_DEBUG1("PlatformScreen::enable()");
     screen_->enable();
 }
 
 void PlatformScreenLoggingWrapper::disable()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::disable()");
+    LOG_DEBUG1("PlatformScreen::disable()");
     screen_->disable();
 }
 
 void PlatformScreenLoggingWrapper::enter()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::enter()");
+    LOG_DEBUG1("PlatformScreen::enter()");
     screen_->enter();
 }
 
 bool PlatformScreenLoggingWrapper::leave()
 {
     auto result = screen_->leave();
-    LOG(CLOG_DEBUG1 "PlatformScreen::leave() => %d", result);
+    LOG_DEBUG1("PlatformScreen::leave() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::setClipboard(ClipboardID id, const IClipboard* clipboard)
 {
     bool result = screen_->setClipboard(id, clipboard);
-    LOG(CLOG_DEBUG1 "PlatformScreen::setClipboard() id=%d clipboard=%p => %d",
+    LOG_DEBUG1("PlatformScreen::setClipboard() id=%d clipboard=%p => %d",
          id, clipboard, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::checkClipboards()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::checkClipboards()");
+    LOG_DEBUG1("PlatformScreen::checkClipboards()");
     screen_->checkClipboards();
 }
 
 void PlatformScreenLoggingWrapper::openScreensaver(bool notify)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::openScreensaver() notify=%d", notify);
+    LOG_DEBUG1("PlatformScreen::openScreensaver() notify=%d", notify);
     screen_->openScreensaver(notify);
 }
 
 void PlatformScreenLoggingWrapper::closeScreensaver()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::closeScreensaver()");
+    LOG_DEBUG1("PlatformScreen::closeScreensaver()");
     screen_->closeScreensaver();
 }
 
 void PlatformScreenLoggingWrapper::screensaver(bool activate)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::screensaver() activate=%d", activate);
+    LOG_DEBUG1("PlatformScreen::screensaver() activate=%d", activate);
     screen_->screensaver(activate);
 }
 
 void PlatformScreenLoggingWrapper::resetOptions()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::resetOptions()");
+    LOG_DEBUG1("PlatformScreen::resetOptions()");
     screen_->resetOptions();
 }
 
 void PlatformScreenLoggingWrapper::setOptions(const OptionsList& options)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::setOptions() options.size()=%d",
+    LOG_DEBUG1("PlatformScreen::setOptions() options.size()=%d",
          static_cast<int>(options.size()));
     screen_->setOptions(options);
 }
 
 void PlatformScreenLoggingWrapper::setSequenceNumber(std::uint32_t seq_num)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::setSequenceNumber() seq_num=%d", seq_num);
+    LOG_DEBUG1("PlatformScreen::setSequenceNumber() seq_num=%d", seq_num);
     screen_->setSequenceNumber(seq_num);
 }
 
 void PlatformScreenLoggingWrapper::setDraggingStarted(bool started)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::setDraggingStarted() started=%d", started);
+    LOG_DEBUG1("PlatformScreen::setDraggingStarted() started=%d", started);
     screen_->setDraggingStarted(started);
 }
 
 bool PlatformScreenLoggingWrapper::isPrimary() const
 {
     auto result = screen_->isPrimary();
-    LOG(CLOG_DEBUG1 "PlatformScreen::isPrimary() => %d", result);
+    LOG_DEBUG1("PlatformScreen::isPrimary() => %d", result);
     return result;
 }
 
 std::string& PlatformScreenLoggingWrapper::getDraggingFilename()
 {
     auto& result = screen_->getDraggingFilename();
-    LOG(CLOG_DEBUG1 "PlatformScreen::getDraggingFilename() => %s", result.c_str());
+    LOG_DEBUG1("PlatformScreen::getDraggingFilename() => %s", result.c_str());
     return result;
 }
 
 void PlatformScreenLoggingWrapper::clearDraggingFilename()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::clearDraggingFilename()");
+    LOG_DEBUG1("PlatformScreen::clearDraggingFilename()");
     screen_->clearDraggingFilename();
 }
 
 bool PlatformScreenLoggingWrapper::isDraggingStarted()
 {
     auto result = screen_->isDraggingStarted();
-    LOG(CLOG_DEBUG1 "PlatformScreen::isDraggingStarted() => %d", result);
+    LOG_DEBUG1("PlatformScreen::isDraggingStarted() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::isFakeDraggingStarted()
 {
     auto result = screen_->isFakeDraggingStarted();
-    LOG(CLOG_DEBUG1 "PlatformScreen::isFakeDraggingStarted() => %d", result);
+    LOG_DEBUG1("PlatformScreen::isFakeDraggingStarted() => %d", result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::fakeDraggingFiles(DragFileList file_list)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeDraggingFiles() file_list.size()=%d",
+    LOG_DEBUG1("PlatformScreen::fakeDraggingFiles() file_list.size()=%d",
          static_cast<int>(file_list.size()));
     screen_->fakeDraggingFiles(file_list);
 }
@@ -149,13 +149,13 @@ void PlatformScreenLoggingWrapper::fakeDraggingFiles(DragFileList file_list)
 const std::string& PlatformScreenLoggingWrapper::getDropTarget() const
 {
     const auto& result = screen_->getDropTarget();
-    LOG(CLOG_DEBUG1 "PlatformScreen::getDropTarget() => %s", result.c_str());
+    LOG_DEBUG1("PlatformScreen::getDropTarget() => %s", result.c_str());
     return result;
 }
 
 void PlatformScreenLoggingWrapper::setDropTarget(const std::string& target)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::setDropTarget() target=%s", target.c_str());
+    LOG_DEBUG1("PlatformScreen::setDropTarget() target=%s", target.c_str());
     screen_->setDropTarget(target);
 }
 
@@ -167,7 +167,7 @@ const EventTarget* PlatformScreenLoggingWrapper::get_event_target() const
 bool PlatformScreenLoggingWrapper::getClipboard(ClipboardID id, IClipboard* clipboard) const
 {
     auto result = screen_->getClipboard(id, clipboard);
-    LOG(CLOG_DEBUG1 "PlatformScreen::getClipboard() id=%d clipboard=%p => %d",
+    LOG_DEBUG1("PlatformScreen::getClipboard() id=%d clipboard=%p => %d",
          id, clipboard, result);
     return result;
 }
@@ -176,64 +176,64 @@ void PlatformScreenLoggingWrapper::getShape(std::int32_t& x, std::int32_t& y,
                                             std::int32_t& width, std::int32_t& height) const
 {
     screen_->getShape(x, y, width, height);
-    LOG(CLOG_DEBUG1 "PlatformScreen::getShape() => x=%d y=%d width=%d height=%d",
+    LOG_DEBUG1("PlatformScreen::getShape() => x=%d y=%d width=%d height=%d",
          x, y, width, height);
 }
 
 void PlatformScreenLoggingWrapper::getCursorPos(std::int32_t& x, std::int32_t& y) const
 {
     screen_->getCursorPos(x, y);
-    LOG(CLOG_DEBUG1 "PlatformScreen::getCursorPos() => x=%d y=%d", x, y);
+    LOG_DEBUG1("PlatformScreen::getCursorPos() => x=%d y=%d", x, y);
 }
 
 void PlatformScreenLoggingWrapper::reconfigure(std::uint32_t active_sides)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::reconfigure() active_sides=%d", active_sides);
+    LOG_DEBUG1("PlatformScreen::reconfigure() active_sides=%d", active_sides);
     screen_->reconfigure(active_sides);
 }
 
 void PlatformScreenLoggingWrapper::warpCursor(std::int32_t x, std::int32_t y)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::warpCursor() x=%d y=%d", x, y);
+    LOG_DEBUG1("PlatformScreen::warpCursor() x=%d y=%d", x, y);
     screen_->warpCursor(x, y);
 }
 
 std::uint32_t PlatformScreenLoggingWrapper::registerHotKey(KeyID key, KeyModifierMask mask)
 {
     auto result = screen_->registerHotKey(key, mask);
-    LOG(CLOG_DEBUG1 "PlatformScreen::registerHotKey() key=%d mask=%x => %d", key, mask, result);
+    LOG_DEBUG1("PlatformScreen::registerHotKey() key=%d mask=%x => %d", key, mask, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::unregisterHotKey(std::uint32_t id)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::unregisterHotKey() id=%d", id);
+    LOG_DEBUG1("PlatformScreen::unregisterHotKey() id=%d", id);
     screen_->unregisterHotKey(id);
 }
 
 void PlatformScreenLoggingWrapper::fakeInputBegin()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeInputBegin()");
+    LOG_DEBUG1("PlatformScreen::fakeInputBegin()");
     screen_->fakeInputBegin();
 }
 
 void PlatformScreenLoggingWrapper::fakeInputEnd()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeInputEnd()");
+    LOG_DEBUG1("PlatformScreen::fakeInputEnd()");
     screen_->fakeInputEnd();
 }
 
 std::int32_t PlatformScreenLoggingWrapper::getJumpZoneSize() const
 {
     auto result = screen_->getJumpZoneSize();
-    LOG(CLOG_DEBUG1 "PlatformScreen::getJumpZoneSize() => %d", result);
+    LOG_DEBUG1("PlatformScreen::getJumpZoneSize() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::isAnyMouseButtonDown(std::uint32_t& button_id) const
 {
     auto result = screen_->isAnyMouseButtonDown(button_id);
-    LOG(CLOG_DEBUG1 "PlatformScreen::isAnyMouseButtonDown() => button_id=%d %d",
+    LOG_DEBUG1("PlatformScreen::isAnyMouseButtonDown() => button_id=%d %d",
          button_id, result);
     return result;
 }
@@ -241,54 +241,54 @@ bool PlatformScreenLoggingWrapper::isAnyMouseButtonDown(std::uint32_t& button_id
 void PlatformScreenLoggingWrapper::getCursorCenter(std::int32_t& x, std::int32_t& y) const
 {
     screen_->getCursorCenter(x, y);
-    LOG(CLOG_DEBUG1 "PlatformScreen::getCursorCenter() => x=%d y=%d", x, y);
+    LOG_DEBUG1("PlatformScreen::getCursorCenter() => x=%d y=%d", x, y);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseButton(ButtonID id, bool press)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseButton() id=%d press=%d", id, press);
+    LOG_DEBUG1("PlatformScreen::fakeMouseButton() id=%d press=%d", id, press);
     screen_->fakeMouseButton(id, press);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseMove(std::int32_t x, std::int32_t y)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseMove() x=%d y=%d", x, y);
+    LOG_DEBUG1("PlatformScreen::fakeMouseMove() x=%d y=%d", x, y);
     screen_->fakeMouseMove(x, y);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseRelativeMove(std::int32_t dx, std::int32_t dy) const
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseRelativeMove() dx=%d dy=%d", dx, dy);
+    LOG_DEBUG1("PlatformScreen::fakeMouseRelativeMove() dx=%d dy=%d", dx, dy);
     screen_->fakeMouseRelativeMove(dx, dy);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseWheel(std::int32_t x_delta, std::int32_t y_delta) const
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseWheel() x_delta=%d y_delta=%d", x_delta, y_delta);
+    LOG_DEBUG1("PlatformScreen::fakeMouseWheel() x_delta=%d y_delta=%d", x_delta, y_delta);
     screen_->fakeMouseWheel(x_delta, y_delta);
 }
 
 void PlatformScreenLoggingWrapper::updateKeyMap()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::updateKeyMap()");
+    LOG_DEBUG1("PlatformScreen::updateKeyMap()");
     screen_->updateKeyMap();
 }
 
 void PlatformScreenLoggingWrapper::updateKeyState()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::updateKeyMap()");
+    LOG_DEBUG1("PlatformScreen::updateKeyMap()");
     screen_->updateKeyState();
 }
 
 void PlatformScreenLoggingWrapper::setHalfDuplexMask(KeyModifierMask mask)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::setHalfDuplexMask() mask=%x", mask);
+    LOG_DEBUG1("PlatformScreen::setHalfDuplexMask() mask=%x", mask);
     screen_->setHalfDuplexMask(mask);
 }
 
 void PlatformScreenLoggingWrapper::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button)
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeKeyDown() id=%d mask=%x button=%d", id, mask, button);
+    LOG_DEBUG1("PlatformScreen::fakeKeyDown() id=%d mask=%x button=%d", id, mask, button);
     screen_->fakeKeyDown(id, mask, button);
 }
 
@@ -296,7 +296,7 @@ bool PlatformScreenLoggingWrapper::fakeKeyRepeat(KeyID id, KeyModifierMask mask,
                                                  KeyButton button)
 {
     auto result = screen_->fakeKeyRepeat(id, mask, count, button);
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeKeyRepeat() id=%d mask=%d count=%d button=%d => %d",
+    LOG_DEBUG1("PlatformScreen::fakeKeyRepeat() id=%d mask=%d count=%d button=%d => %d",
          id, mask, count, button, result);
     return result;
 }
@@ -304,62 +304,62 @@ bool PlatformScreenLoggingWrapper::fakeKeyRepeat(KeyID id, KeyModifierMask mask,
 bool PlatformScreenLoggingWrapper::fakeKeyUp(KeyButton button)
 {
     auto result = screen_->fakeKeyUp(button);
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeKeyUp() button=%d => %d", button, result);
+    LOG_DEBUG1("PlatformScreen::fakeKeyUp() button=%d => %d", button, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::fakeAllKeysUp()
 {
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeAllKeysUp()");
+    LOG_DEBUG1("PlatformScreen::fakeAllKeysUp()");
     screen_->fakeAllKeysUp();
 }
 
 bool PlatformScreenLoggingWrapper::fakeCtrlAltDel()
 {
     auto result = screen_->fakeCtrlAltDel();
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeCtrlAltDel() => %d", result);
+    LOG_DEBUG1("PlatformScreen::fakeCtrlAltDel() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::fakeMediaKey(KeyID id)
 {
     auto result = screen_->fakeMediaKey(id);
-    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMediaKey() id=%d => %d", id, result);
+    LOG_DEBUG1("PlatformScreen::fakeMediaKey() id=%d => %d", id, result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::isKeyDown(KeyButton key) const
 {
     auto result = screen_->isKeyDown(key);
-    LOG(CLOG_DEBUG1 "PlatformScreen::isKeyDown() key=%d => %d", key, result);
+    LOG_DEBUG1("PlatformScreen::isKeyDown() key=%d => %d", key, result);
     return result;
 }
 
 KeyModifierMask PlatformScreenLoggingWrapper::getActiveModifiers() const
 {
     auto result = screen_->getActiveModifiers();
-    LOG(CLOG_DEBUG1 "PlatformScreen::getActiveModifiers() => %d", result);
+    LOG_DEBUG1("PlatformScreen::getActiveModifiers() => %d", result);
     return result;
 }
 
 KeyModifierMask PlatformScreenLoggingWrapper::pollActiveModifiers() const
 {
     auto result = screen_->pollActiveModifiers();
-    LOG(CLOG_DEBUG1 "PlatformScreen::pollActiveModifiers() => %d", result);
+    LOG_DEBUG1("PlatformScreen::pollActiveModifiers() => %d", result);
     return result;
 }
 
 std::int32_t PlatformScreenLoggingWrapper::pollActiveGroup() const
 {
     auto result = screen_->pollActiveGroup();
-    LOG(CLOG_DEBUG1 "PlatformScreen::pollActiveGroup() => %d", result);
+    LOG_DEBUG1("PlatformScreen::pollActiveGroup() => %d", result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::pollPressedKeys(KeyButtonSet& pressed_keys) const
 {
     screen_->pollPressedKeys(pressed_keys);
-    LOG(CLOG_DEBUG1 "PlatformScreen::pollPressedKeys() => pressed_keys.size()=%zd",
+    LOG_DEBUG1("PlatformScreen::pollPressedKeys() => pressed_keys.size()=%zd",
          pressed_keys.size());
 }
 

--- a/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
+++ b/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
@@ -25,137 +25,137 @@ PlatformScreenLoggingWrapper::PlatformScreenLoggingWrapper(std::unique_ptr<IPlat
 
 void PlatformScreenLoggingWrapper::enable()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::enable()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::enable()");
     screen_->enable();
 }
 
 void PlatformScreenLoggingWrapper::disable()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::disable()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::disable()");
     screen_->disable();
 }
 
 void PlatformScreenLoggingWrapper::enter()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::enter()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::enter()");
     screen_->enter();
 }
 
 bool PlatformScreenLoggingWrapper::leave()
 {
     auto result = screen_->leave();
-    LOG((CLOG_DEBUG1 "PlatformScreen::leave() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::leave() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::setClipboard(ClipboardID id, const IClipboard* clipboard)
 {
     bool result = screen_->setClipboard(id, clipboard);
-    LOG((CLOG_DEBUG1 "PlatformScreen::setClipboard() id=%d clipboard=%p => %d",
-         id, clipboard, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::setClipboard() id=%d clipboard=%p => %d",
+         id, clipboard, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::checkClipboards()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::checkClipboards()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::checkClipboards()");
     screen_->checkClipboards();
 }
 
 void PlatformScreenLoggingWrapper::openScreensaver(bool notify)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::openScreensaver() notify=%d", notify));
+    LOG(CLOG_DEBUG1 "PlatformScreen::openScreensaver() notify=%d", notify);
     screen_->openScreensaver(notify);
 }
 
 void PlatformScreenLoggingWrapper::closeScreensaver()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::closeScreensaver()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::closeScreensaver()");
     screen_->closeScreensaver();
 }
 
 void PlatformScreenLoggingWrapper::screensaver(bool activate)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::screensaver() activate=%d", activate));
+    LOG(CLOG_DEBUG1 "PlatformScreen::screensaver() activate=%d", activate);
     screen_->screensaver(activate);
 }
 
 void PlatformScreenLoggingWrapper::resetOptions()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::resetOptions()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::resetOptions()");
     screen_->resetOptions();
 }
 
 void PlatformScreenLoggingWrapper::setOptions(const OptionsList& options)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::setOptions() options.size()=%d",
-         static_cast<int>(options.size())));
+    LOG(CLOG_DEBUG1 "PlatformScreen::setOptions() options.size()=%d",
+         static_cast<int>(options.size()));
     screen_->setOptions(options);
 }
 
 void PlatformScreenLoggingWrapper::setSequenceNumber(std::uint32_t seq_num)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::setSequenceNumber() seq_num=%d", seq_num));
+    LOG(CLOG_DEBUG1 "PlatformScreen::setSequenceNumber() seq_num=%d", seq_num);
     screen_->setSequenceNumber(seq_num);
 }
 
 void PlatformScreenLoggingWrapper::setDraggingStarted(bool started)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::setDraggingStarted() started=%d", started));
+    LOG(CLOG_DEBUG1 "PlatformScreen::setDraggingStarted() started=%d", started);
     screen_->setDraggingStarted(started);
 }
 
 bool PlatformScreenLoggingWrapper::isPrimary() const
 {
     auto result = screen_->isPrimary();
-    LOG((CLOG_DEBUG1 "PlatformScreen::isPrimary() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::isPrimary() => %d", result);
     return result;
 }
 
 std::string& PlatformScreenLoggingWrapper::getDraggingFilename()
 {
     auto& result = screen_->getDraggingFilename();
-    LOG((CLOG_DEBUG1 "PlatformScreen::getDraggingFilename() => %s", result.c_str()));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getDraggingFilename() => %s", result.c_str());
     return result;
 }
 
 void PlatformScreenLoggingWrapper::clearDraggingFilename()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::clearDraggingFilename()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::clearDraggingFilename()");
     screen_->clearDraggingFilename();
 }
 
 bool PlatformScreenLoggingWrapper::isDraggingStarted()
 {
     auto result = screen_->isDraggingStarted();
-    LOG((CLOG_DEBUG1 "PlatformScreen::isDraggingStarted() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::isDraggingStarted() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::isFakeDraggingStarted()
 {
     auto result = screen_->isFakeDraggingStarted();
-    LOG((CLOG_DEBUG1 "PlatformScreen::isFakeDraggingStarted() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::isFakeDraggingStarted() => %d", result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::fakeDraggingFiles(DragFileList file_list)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeDraggingFiles() file_list.size()=%d",
-         static_cast<int>(file_list.size())));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeDraggingFiles() file_list.size()=%d",
+         static_cast<int>(file_list.size()));
     screen_->fakeDraggingFiles(file_list);
 }
 
 const std::string& PlatformScreenLoggingWrapper::getDropTarget() const
 {
     const auto& result = screen_->getDropTarget();
-    LOG((CLOG_DEBUG1 "PlatformScreen::getDropTarget() => %s", result.c_str()));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getDropTarget() => %s", result.c_str());
     return result;
 }
 
 void PlatformScreenLoggingWrapper::setDropTarget(const std::string& target)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::setDropTarget() target=%s", target.c_str()));
+    LOG(CLOG_DEBUG1 "PlatformScreen::setDropTarget() target=%s", target.c_str());
     screen_->setDropTarget(target);
 }
 
@@ -167,8 +167,8 @@ const EventTarget* PlatformScreenLoggingWrapper::get_event_target() const
 bool PlatformScreenLoggingWrapper::getClipboard(ClipboardID id, IClipboard* clipboard) const
 {
     auto result = screen_->getClipboard(id, clipboard);
-    LOG((CLOG_DEBUG1 "PlatformScreen::getClipboard() id=%d clipboard=%p => %d",
-         id, clipboard, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getClipboard() id=%d clipboard=%p => %d",
+         id, clipboard, result);
     return result;
 }
 
@@ -176,119 +176,119 @@ void PlatformScreenLoggingWrapper::getShape(std::int32_t& x, std::int32_t& y,
                                             std::int32_t& width, std::int32_t& height) const
 {
     screen_->getShape(x, y, width, height);
-    LOG((CLOG_DEBUG1 "PlatformScreen::getShape() => x=%d y=%d width=%d height=%d",
-         x, y, width, height));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getShape() => x=%d y=%d width=%d height=%d",
+         x, y, width, height);
 }
 
 void PlatformScreenLoggingWrapper::getCursorPos(std::int32_t& x, std::int32_t& y) const
 {
     screen_->getCursorPos(x, y);
-    LOG((CLOG_DEBUG1 "PlatformScreen::getCursorPos() => x=%d y=%d", x, y));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getCursorPos() => x=%d y=%d", x, y);
 }
 
 void PlatformScreenLoggingWrapper::reconfigure(std::uint32_t active_sides)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::reconfigure() active_sides=%d", active_sides));
+    LOG(CLOG_DEBUG1 "PlatformScreen::reconfigure() active_sides=%d", active_sides);
     screen_->reconfigure(active_sides);
 }
 
 void PlatformScreenLoggingWrapper::warpCursor(std::int32_t x, std::int32_t y)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::warpCursor() x=%d y=%d", x, y));
+    LOG(CLOG_DEBUG1 "PlatformScreen::warpCursor() x=%d y=%d", x, y);
     screen_->warpCursor(x, y);
 }
 
 std::uint32_t PlatformScreenLoggingWrapper::registerHotKey(KeyID key, KeyModifierMask mask)
 {
     auto result = screen_->registerHotKey(key, mask);
-    LOG((CLOG_DEBUG1 "PlatformScreen::registerHotKey() key=%d mask=%x => %d", key, mask, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::registerHotKey() key=%d mask=%x => %d", key, mask, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::unregisterHotKey(std::uint32_t id)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::unregisterHotKey() id=%d", id));
+    LOG(CLOG_DEBUG1 "PlatformScreen::unregisterHotKey() id=%d", id);
     screen_->unregisterHotKey(id);
 }
 
 void PlatformScreenLoggingWrapper::fakeInputBegin()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeInputBegin()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeInputBegin()");
     screen_->fakeInputBegin();
 }
 
 void PlatformScreenLoggingWrapper::fakeInputEnd()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeInputEnd()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeInputEnd()");
     screen_->fakeInputEnd();
 }
 
 std::int32_t PlatformScreenLoggingWrapper::getJumpZoneSize() const
 {
     auto result = screen_->getJumpZoneSize();
-    LOG((CLOG_DEBUG1 "PlatformScreen::getJumpZoneSize() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getJumpZoneSize() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::isAnyMouseButtonDown(std::uint32_t& button_id) const
 {
     auto result = screen_->isAnyMouseButtonDown(button_id);
-    LOG((CLOG_DEBUG1 "PlatformScreen::isAnyMouseButtonDown() => button_id=%d %d",
-         button_id, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::isAnyMouseButtonDown() => button_id=%d %d",
+         button_id, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::getCursorCenter(std::int32_t& x, std::int32_t& y) const
 {
     screen_->getCursorCenter(x, y);
-    LOG((CLOG_DEBUG1 "PlatformScreen::getCursorCenter() => x=%d y=%d", x, y));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getCursorCenter() => x=%d y=%d", x, y);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseButton(ButtonID id, bool press)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeMouseButton() id=%d press=%d", id, press));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseButton() id=%d press=%d", id, press);
     screen_->fakeMouseButton(id, press);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseMove(std::int32_t x, std::int32_t y)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeMouseMove() x=%d y=%d", x, y));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseMove() x=%d y=%d", x, y);
     screen_->fakeMouseMove(x, y);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseRelativeMove(std::int32_t dx, std::int32_t dy) const
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeMouseRelativeMove() dx=%d dy=%d", dx, dy));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseRelativeMove() dx=%d dy=%d", dx, dy);
     screen_->fakeMouseRelativeMove(dx, dy);
 }
 
 void PlatformScreenLoggingWrapper::fakeMouseWheel(std::int32_t x_delta, std::int32_t y_delta) const
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeMouseWheel() x_delta=%d y_delta=%d", x_delta, y_delta));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMouseWheel() x_delta=%d y_delta=%d", x_delta, y_delta);
     screen_->fakeMouseWheel(x_delta, y_delta);
 }
 
 void PlatformScreenLoggingWrapper::updateKeyMap()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::updateKeyMap()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::updateKeyMap()");
     screen_->updateKeyMap();
 }
 
 void PlatformScreenLoggingWrapper::updateKeyState()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::updateKeyMap()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::updateKeyMap()");
     screen_->updateKeyState();
 }
 
 void PlatformScreenLoggingWrapper::setHalfDuplexMask(KeyModifierMask mask)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::setHalfDuplexMask() mask=%x", mask));
+    LOG(CLOG_DEBUG1 "PlatformScreen::setHalfDuplexMask() mask=%x", mask);
     screen_->setHalfDuplexMask(mask);
 }
 
 void PlatformScreenLoggingWrapper::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeKeyDown() id=%d mask=%x button=%d", id, mask, button));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeKeyDown() id=%d mask=%x button=%d", id, mask, button);
     screen_->fakeKeyDown(id, mask, button);
 }
 
@@ -296,71 +296,71 @@ bool PlatformScreenLoggingWrapper::fakeKeyRepeat(KeyID id, KeyModifierMask mask,
                                                  KeyButton button)
 {
     auto result = screen_->fakeKeyRepeat(id, mask, count, button);
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeKeyRepeat() id=%d mask=%d count=%d button=%d => %d",
-         id, mask, count, button, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeKeyRepeat() id=%d mask=%d count=%d button=%d => %d",
+         id, mask, count, button, result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::fakeKeyUp(KeyButton button)
 {
     auto result = screen_->fakeKeyUp(button);
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeKeyUp() button=%d => %d", button, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeKeyUp() button=%d => %d", button, result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::fakeAllKeysUp()
 {
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeAllKeysUp()"));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeAllKeysUp()");
     screen_->fakeAllKeysUp();
 }
 
 bool PlatformScreenLoggingWrapper::fakeCtrlAltDel()
 {
     auto result = screen_->fakeCtrlAltDel();
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeCtrlAltDel() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeCtrlAltDel() => %d", result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::fakeMediaKey(KeyID id)
 {
     auto result = screen_->fakeMediaKey(id);
-    LOG((CLOG_DEBUG1 "PlatformScreen::fakeMediaKey() id=%d => %d", id, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::fakeMediaKey() id=%d => %d", id, result);
     return result;
 }
 
 bool PlatformScreenLoggingWrapper::isKeyDown(KeyButton key) const
 {
     auto result = screen_->isKeyDown(key);
-    LOG((CLOG_DEBUG1 "PlatformScreen::isKeyDown() key=%d => %d", key, result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::isKeyDown() key=%d => %d", key, result);
     return result;
 }
 
 KeyModifierMask PlatformScreenLoggingWrapper::getActiveModifiers() const
 {
     auto result = screen_->getActiveModifiers();
-    LOG((CLOG_DEBUG1 "PlatformScreen::getActiveModifiers() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::getActiveModifiers() => %d", result);
     return result;
 }
 
 KeyModifierMask PlatformScreenLoggingWrapper::pollActiveModifiers() const
 {
     auto result = screen_->pollActiveModifiers();
-    LOG((CLOG_DEBUG1 "PlatformScreen::pollActiveModifiers() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::pollActiveModifiers() => %d", result);
     return result;
 }
 
 std::int32_t PlatformScreenLoggingWrapper::pollActiveGroup() const
 {
     auto result = screen_->pollActiveGroup();
-    LOG((CLOG_DEBUG1 "PlatformScreen::pollActiveGroup() => %d", result));
+    LOG(CLOG_DEBUG1 "PlatformScreen::pollActiveGroup() => %d", result);
     return result;
 }
 
 void PlatformScreenLoggingWrapper::pollPressedKeys(KeyButtonSet& pressed_keys) const
 {
     screen_->pollPressedKeys(pressed_keys);
-    LOG((CLOG_DEBUG1 "PlatformScreen::pollPressedKeys() => pressed_keys.size()=%zd",
-         pressed_keys.size()));
+    LOG(CLOG_DEBUG1 "PlatformScreen::pollPressedKeys() => pressed_keys.size()=%zd",
+         pressed_keys.size());
 }
 
 void PlatformScreenLoggingWrapper::handle_system_event(const Event& event)

--- a/src/lib/inputleap/ProtocolUtil.cpp
+++ b/src/lib/inputleap/ProtocolUtil.cpp
@@ -33,7 +33,7 @@ ProtocolUtil::writef(inputleap::IStream* stream, const char* fmt, ...)
 {
     assert(stream != nullptr);
     assert(fmt != nullptr);
-    LOG(CLOG_DEBUG2 "writef(%s)", fmt);
+    LOG_DEBUG2("writef(%s)", fmt);
 
     va_list args;
     va_start(args, fmt);
@@ -49,7 +49,7 @@ ProtocolUtil::readf(inputleap::IStream* stream, const char* fmt, ...)
 {
     assert(stream != nullptr);
     assert(fmt != nullptr);
-    LOG(CLOG_DEBUG2 "readf(%s)", fmt);
+    LOG_DEBUG2("readf(%s)", fmt);
 
     bool result;
     va_list args;
@@ -83,7 +83,7 @@ void ProtocolUtil::vwritef(inputleap::IStream* stream, const char* fmt, std::uin
     try {
         // write buffer
         stream->write(buffer, size);
-        LOG(CLOG_DEBUG2 "wrote %d bytes", size);
+        LOG_DEBUG2("wrote %d bytes", size);
 
         delete[] buffer;
     }
@@ -120,7 +120,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                 case 1:
                     // 1 byte integer
                     *static_cast<std::uint8_t*>(v) = buffer[0];
-                    LOG(CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
+                    LOG_DEBUG2("readf: read %d byte integer: %d (0x%x)", len,
                          *static_cast<std::uint8_t*>(v), *static_cast<std::uint8_t*>(v));
                     break;
 
@@ -130,7 +130,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         static_cast<std::uint16_t>(
                         (static_cast<std::uint16_t>(buffer[0]) << 8) |
                          static_cast<std::uint16_t>(buffer[1]));
-                    LOG(CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
+                    LOG_DEBUG2("readf: read %d byte integer: %d (0x%x)", len,
                          *static_cast<std::uint16_t*>(v), *static_cast<std::uint16_t*>(v));
                     break;
 
@@ -141,7 +141,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         (static_cast<std::uint32_t>(buffer[1]) << 16) |
                         (static_cast<std::uint32_t>(buffer[2]) <<  8) |
                          static_cast<std::uint32_t>(buffer[3]);
-                    LOG(CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
+                    LOG_DEBUG2("readf: read %d byte integer: %d (0x%x)", len,
                          *static_cast<std::uint32_t*>(v), *static_cast<std::uint32_t*>(v));
                     break;
                 default:
@@ -175,7 +175,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         read(stream, buffer, 1);
                         static_cast<std::vector<std::uint8_t>*>(v)->push_back(
                             buffer[0]);
-                        LOG(CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG_DEBUG2("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint8_t>*>(v)->back(),
                              static_cast<std::vector<std::uint8_t>*>(v)->back());
                     }
@@ -189,7 +189,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                             static_cast<std::uint16_t>(
                             (static_cast<std::uint16_t>(buffer[0]) << 8) |
                              static_cast<std::uint16_t>(buffer[1])));
-                        LOG(CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG_DEBUG2("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint16_t>*>(v)->back(),
                              static_cast<std::vector<std::uint16_t>*>(v)->back());
                     }
@@ -204,7 +204,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                             (static_cast<std::uint32_t>(buffer[1]) << 16) |
                             (static_cast<std::uint32_t>(buffer[2]) <<  8) |
                              static_cast<std::uint32_t>(buffer[3]));
-                        LOG(CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG_DEBUG2("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint32_t>*>(v)->back(),
                              static_cast<std::vector<std::uint32_t>*>(v)->back());
                     }
@@ -250,7 +250,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                     throw;
                 }
 
-                LOG(CLOG_DEBUG2 "readf: read %d byte string", str_len);
+                LOG_DEBUG2("readf: read %d byte string", str_len);
 
                 // save the data
                 std::string* dst = va_arg(args, std::string*);
@@ -281,7 +281,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
 
             // verify match
             if (buffer[0] != *fmt) {
-                LOG(CLOG_DEBUG2 "readf: format mismatch: %c vs %c", *fmt, buffer[0]);
+                LOG_DEBUG2("readf: format mismatch: %c vs %c", *fmt, buffer[0]);
                 throw XIOReadMismatch();
             }
 
@@ -545,7 +545,7 @@ void ProtocolUtil::read(inputleap::IStream* stream, void* vbuffer, std::uint32_t
 
         // bail if stream has hungup
         if (n == 0) {
-            LOG(CLOG_DEBUG2 "unexpected disconnect in readf(), %d bytes left", count);
+            LOG_DEBUG2("unexpected disconnect in readf(), %d bytes left", count);
             throw XIOEndOfStream();
         }
 

--- a/src/lib/inputleap/ProtocolUtil.cpp
+++ b/src/lib/inputleap/ProtocolUtil.cpp
@@ -33,7 +33,7 @@ ProtocolUtil::writef(inputleap::IStream* stream, const char* fmt, ...)
 {
     assert(stream != nullptr);
     assert(fmt != nullptr);
-    LOG((CLOG_DEBUG2 "writef(%s)", fmt));
+    LOG(CLOG_DEBUG2 "writef(%s)", fmt);
 
     va_list args;
     va_start(args, fmt);
@@ -49,7 +49,7 @@ ProtocolUtil::readf(inputleap::IStream* stream, const char* fmt, ...)
 {
     assert(stream != nullptr);
     assert(fmt != nullptr);
-    LOG((CLOG_DEBUG2 "readf(%s)", fmt));
+    LOG(CLOG_DEBUG2 "readf(%s)", fmt);
 
     bool result;
     va_list args;
@@ -83,7 +83,7 @@ void ProtocolUtil::vwritef(inputleap::IStream* stream, const char* fmt, std::uin
     try {
         // write buffer
         stream->write(buffer, size);
-        LOG((CLOG_DEBUG2 "wrote %d bytes", size));
+        LOG(CLOG_DEBUG2 "wrote %d bytes", size);
 
         delete[] buffer;
     }
@@ -120,8 +120,8 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                 case 1:
                     // 1 byte integer
                     *static_cast<std::uint8_t*>(v) = buffer[0];
-                    LOG((CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
-                         *static_cast<std::uint8_t*>(v), *static_cast<std::uint8_t*>(v)));
+                    LOG(CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
+                         *static_cast<std::uint8_t*>(v), *static_cast<std::uint8_t*>(v));
                     break;
 
                 case 2:
@@ -130,8 +130,8 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         static_cast<std::uint16_t>(
                         (static_cast<std::uint16_t>(buffer[0]) << 8) |
                          static_cast<std::uint16_t>(buffer[1]));
-                    LOG((CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
-                         *static_cast<std::uint16_t*>(v), *static_cast<std::uint16_t*>(v)));
+                    LOG(CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
+                         *static_cast<std::uint16_t*>(v), *static_cast<std::uint16_t*>(v));
                     break;
 
                 case 4:
@@ -141,8 +141,8 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         (static_cast<std::uint32_t>(buffer[1]) << 16) |
                         (static_cast<std::uint32_t>(buffer[2]) <<  8) |
                          static_cast<std::uint32_t>(buffer[3]);
-                    LOG((CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
-                         *static_cast<std::uint32_t*>(v), *static_cast<std::uint32_t*>(v)));
+                    LOG(CLOG_DEBUG2 "readf: read %d byte integer: %d (0x%x)", len,
+                         *static_cast<std::uint32_t*>(v), *static_cast<std::uint32_t*>(v));
                     break;
                 default:
                     break;
@@ -175,9 +175,9 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         read(stream, buffer, 1);
                         static_cast<std::vector<std::uint8_t>*>(v)->push_back(
                             buffer[0]);
-                        LOG((CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG(CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint8_t>*>(v)->back(),
-                             static_cast<std::vector<std::uint8_t>*>(v)->back()));
+                             static_cast<std::vector<std::uint8_t>*>(v)->back());
                     }
                     break;
 
@@ -189,9 +189,9 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                             static_cast<std::uint16_t>(
                             (static_cast<std::uint16_t>(buffer[0]) << 8) |
                              static_cast<std::uint16_t>(buffer[1])));
-                        LOG((CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG(CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint16_t>*>(v)->back(),
-                             static_cast<std::vector<std::uint16_t>*>(v)->back()));
+                             static_cast<std::vector<std::uint16_t>*>(v)->back());
                     }
                     break;
 
@@ -204,9 +204,9 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                             (static_cast<std::uint32_t>(buffer[1]) << 16) |
                             (static_cast<std::uint32_t>(buffer[2]) <<  8) |
                              static_cast<std::uint32_t>(buffer[3]));
-                        LOG((CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG(CLOG_DEBUG2 "readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint32_t>*>(v)->back(),
-                             static_cast<std::vector<std::uint32_t>*>(v)->back()));
+                             static_cast<std::vector<std::uint32_t>*>(v)->back());
                     }
                     break;
                 default:
@@ -250,7 +250,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                     throw;
                 }
 
-                LOG((CLOG_DEBUG2 "readf: read %d byte string", str_len));
+                LOG(CLOG_DEBUG2 "readf: read %d byte string", str_len);
 
                 // save the data
                 std::string* dst = va_arg(args, std::string*);
@@ -281,7 +281,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
 
             // verify match
             if (buffer[0] != *fmt) {
-                LOG((CLOG_DEBUG2 "readf: format mismatch: %c vs %c", *fmt, buffer[0]));
+                LOG(CLOG_DEBUG2 "readf: format mismatch: %c vs %c", *fmt, buffer[0]);
                 throw XIOReadMismatch();
             }
 
@@ -545,7 +545,7 @@ void ProtocolUtil::read(inputleap::IStream* stream, void* vbuffer, std::uint32_t
 
         // bail if stream has hungup
         if (n == 0) {
-            LOG((CLOG_DEBUG2 "unexpected disconnect in readf(), %d bytes left", count));
+            LOG(CLOG_DEBUG2 "unexpected disconnect in readf(), %d bytes left", count);
             throw XIOEndOfStream();
         }
 

--- a/src/lib/inputleap/Screen.cpp
+++ b/src/lib/inputleap/Screen.cpp
@@ -39,7 +39,7 @@ Screen::Screen(std::unique_ptr<IPlatformScreen> platform_screen, IEventQueue* ev
     // reset options
     resetOptions();
 
-    LOG(CLOG_DEBUG "opened display");
+    LOG_DEBUG("opened display");
 }
 
 Screen::~Screen()
@@ -53,7 +53,7 @@ Screen::~Screen()
     }
     assert(!m_enabled);
     assert(m_entered == m_isPrimary);
-    LOG(CLOG_DEBUG "closed display");
+    LOG_DEBUG("closed display");
 }
 
 void
@@ -102,7 +102,7 @@ void
 Screen::enter(KeyModifierMask toggleMask)
 {
     assert(m_entered == false);
-    LOG(CLOG_INFO "entering screen");
+    LOG_INFO("entering screen");
 
     // now on screen
     m_entered = true;
@@ -120,7 +120,7 @@ bool
 Screen::leave()
 {
     assert(m_entered == true);
-    LOG(CLOG_INFO "leaving screen");
+    LOG_INFO("leaving screen");
 
     if (!m_screen->leave()) {
         return false;
@@ -183,7 +183,7 @@ Screen::keyDown(KeyID id, KeyModifierMask mask, KeyButton button)
     if (id == kKeyDelete &&
         (mask & (KeyModifierControl | KeyModifierAlt)) ==
                 (KeyModifierControl | KeyModifierAlt)) {
-        LOG(CLOG_DEBUG "emulating ctrl+alt+del press");
+        LOG_DEBUG("emulating ctrl+alt+del press");
         if (m_screen->fakeCtrlAltDel()) {
             return;
         }
@@ -260,7 +260,7 @@ Screen::setOptions(const OptionsList& options)
     for (std::uint32_t i = 0, n = static_cast<std::uint32_t>(options.size()); i < n; i += 2) {
         if (options[i] == kOptionScreenSaverSync) {
             m_screenSaverSync = (options[i + 1] != 0);
-            LOG(CLOG_DEBUG1 "screen saver synchronization %s", m_screenSaverSync ? "on" : "off");
+            LOG_DEBUG1("screen saver synchronization %s", m_screenSaverSync ? "on" : "off");
         }
         else if (options[i] == kOptionHalfDuplexCapsLock) {
             if (options[i + 1] != 0) {
@@ -269,7 +269,7 @@ Screen::setOptions(const OptionsList& options)
             else {
                 m_halfDuplex &= ~KeyModifierCapsLock;
             }
-            LOG(CLOG_DEBUG1 "half-duplex caps-lock %s", ((m_halfDuplex & KeyModifierCapsLock) != 0) ? "on" : "off");
+            LOG_DEBUG1("half-duplex caps-lock %s", ((m_halfDuplex & KeyModifierCapsLock) != 0) ? "on" : "off");
         }
         else if (options[i] == kOptionHalfDuplexNumLock) {
             if (options[i + 1] != 0) {
@@ -278,7 +278,7 @@ Screen::setOptions(const OptionsList& options)
             else {
                 m_halfDuplex &= ~KeyModifierNumLock;
             }
-            LOG(CLOG_DEBUG1 "half-duplex num-lock %s", ((m_halfDuplex & KeyModifierNumLock) != 0) ? "on" : "off");
+            LOG_DEBUG1("half-duplex num-lock %s", ((m_halfDuplex & KeyModifierNumLock) != 0) ? "on" : "off");
         }
         else if (options[i] == kOptionHalfDuplexScrollLock) {
             if (options[i + 1] != 0) {
@@ -287,7 +287,7 @@ Screen::setOptions(const OptionsList& options)
             else {
                 m_halfDuplex &= ~KeyModifierScrollLock;
             }
-            LOG(CLOG_DEBUG1 "half-duplex scroll-lock %s", ((m_halfDuplex & KeyModifierScrollLock) != 0) ? "on" : "off");
+            LOG_DEBUG1("half-duplex scroll-lock %s", ((m_halfDuplex & KeyModifierScrollLock) != 0) ? "on" : "off");
         }
     }
 
@@ -356,7 +356,7 @@ Screen::isLockedToScreen() const
 
     if (m_screen->isAnyMouseButtonDown(buttonID)) {
         if (buttonID != kButtonLeft) {
-            LOG(CLOG_DEBUG "locked by mouse buttonID: %d", buttonID);
+            LOG_DEBUG("locked by mouse buttonID: %d", buttonID);
         }
 
         if (m_enableDragDrop) {

--- a/src/lib/inputleap/Screen.cpp
+++ b/src/lib/inputleap/Screen.cpp
@@ -39,7 +39,7 @@ Screen::Screen(std::unique_ptr<IPlatformScreen> platform_screen, IEventQueue* ev
     // reset options
     resetOptions();
 
-    LOG((CLOG_DEBUG "opened display"));
+    LOG(CLOG_DEBUG "opened display");
 }
 
 Screen::~Screen()
@@ -53,7 +53,7 @@ Screen::~Screen()
     }
     assert(!m_enabled);
     assert(m_entered == m_isPrimary);
-    LOG((CLOG_DEBUG "closed display"));
+    LOG(CLOG_DEBUG "closed display");
 }
 
 void
@@ -102,7 +102,7 @@ void
 Screen::enter(KeyModifierMask toggleMask)
 {
     assert(m_entered == false);
-    LOG((CLOG_INFO "entering screen"));
+    LOG(CLOG_INFO "entering screen");
 
     // now on screen
     m_entered = true;
@@ -120,7 +120,7 @@ bool
 Screen::leave()
 {
     assert(m_entered == true);
-    LOG((CLOG_INFO "leaving screen"));
+    LOG(CLOG_INFO "leaving screen");
 
     if (!m_screen->leave()) {
         return false;
@@ -183,7 +183,7 @@ Screen::keyDown(KeyID id, KeyModifierMask mask, KeyButton button)
     if (id == kKeyDelete &&
         (mask & (KeyModifierControl | KeyModifierAlt)) ==
                 (KeyModifierControl | KeyModifierAlt)) {
-        LOG((CLOG_DEBUG "emulating ctrl+alt+del press"));
+        LOG(CLOG_DEBUG "emulating ctrl+alt+del press");
         if (m_screen->fakeCtrlAltDel()) {
             return;
         }
@@ -260,7 +260,7 @@ Screen::setOptions(const OptionsList& options)
     for (std::uint32_t i = 0, n = static_cast<std::uint32_t>(options.size()); i < n; i += 2) {
         if (options[i] == kOptionScreenSaverSync) {
             m_screenSaverSync = (options[i + 1] != 0);
-            LOG((CLOG_DEBUG1 "screen saver synchronization %s", m_screenSaverSync ? "on" : "off"));
+            LOG(CLOG_DEBUG1 "screen saver synchronization %s", m_screenSaverSync ? "on" : "off");
         }
         else if (options[i] == kOptionHalfDuplexCapsLock) {
             if (options[i + 1] != 0) {
@@ -269,7 +269,7 @@ Screen::setOptions(const OptionsList& options)
             else {
                 m_halfDuplex &= ~KeyModifierCapsLock;
             }
-            LOG((CLOG_DEBUG1 "half-duplex caps-lock %s", ((m_halfDuplex & KeyModifierCapsLock) != 0) ? "on" : "off"));
+            LOG(CLOG_DEBUG1 "half-duplex caps-lock %s", ((m_halfDuplex & KeyModifierCapsLock) != 0) ? "on" : "off");
         }
         else if (options[i] == kOptionHalfDuplexNumLock) {
             if (options[i + 1] != 0) {
@@ -278,7 +278,7 @@ Screen::setOptions(const OptionsList& options)
             else {
                 m_halfDuplex &= ~KeyModifierNumLock;
             }
-            LOG((CLOG_DEBUG1 "half-duplex num-lock %s", ((m_halfDuplex & KeyModifierNumLock) != 0) ? "on" : "off"));
+            LOG(CLOG_DEBUG1 "half-duplex num-lock %s", ((m_halfDuplex & KeyModifierNumLock) != 0) ? "on" : "off");
         }
         else if (options[i] == kOptionHalfDuplexScrollLock) {
             if (options[i + 1] != 0) {
@@ -287,7 +287,7 @@ Screen::setOptions(const OptionsList& options)
             else {
                 m_halfDuplex &= ~KeyModifierScrollLock;
             }
-            LOG((CLOG_DEBUG1 "half-duplex scroll-lock %s", ((m_halfDuplex & KeyModifierScrollLock) != 0) ? "on" : "off"));
+            LOG(CLOG_DEBUG1 "half-duplex scroll-lock %s", ((m_halfDuplex & KeyModifierScrollLock) != 0) ? "on" : "off");
         }
     }
 
@@ -356,7 +356,7 @@ Screen::isLockedToScreen() const
 
     if (m_screen->isAnyMouseButtonDown(buttonID)) {
         if (buttonID != kButtonLeft) {
-            LOG((CLOG_DEBUG "locked by mouse buttonID: %d", buttonID));
+            LOG(CLOG_DEBUG "locked by mouse buttonID: %d", buttonID);
         }
 
         if (m_enableDragDrop) {

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -101,8 +101,8 @@ ServerApp::parseArgs(int argc, const char* const* argv)
                 listen_address_->resolve();
             }
             catch (XSocketAddress& e) {
-                LOG((CLOG_PRINT "%s: %s" BYE,
-                    args().m_exename.c_str(), e.what(), args().m_exename.c_str()));
+                LOG(CLOG_PRINT "%s: %s" BYE,
+                    args().m_exename.c_str(), e.what(), args().m_exename.c_str());
                 m_bye(kExitArgs);
             }
         }
@@ -172,7 +172,7 @@ ServerApp::help()
            << "  " << usr_config_path << "\n"
            << "  " << sys_config_path << "\n";
 
-    LOG((CLOG_PRINT "%s", buffer.str().c_str()));
+    LOG(CLOG_PRINT "%s", buffer.str().c_str());
 }
 
 void
@@ -184,12 +184,12 @@ ServerApp::reloadSignalHandler(Arch::ESignal, void*)
 
 void ServerApp::reload_config()
 {
-    LOG((CLOG_DEBUG "reload configuration"));
+    LOG(CLOG_DEBUG "reload configuration");
     if (loadConfig(args().m_configFile)) {
         if (server_) {
             server_->setConfig(*args().m_config);
         }
-        LOG((CLOG_NOTE "reloaded configuration"));
+        LOG(CLOG_NOTE "reloaded configuration");
     }
 }
 
@@ -230,7 +230,7 @@ ServerApp::loadConfig()
     }
 
     if (!loaded) {
-        LOG((CLOG_PRINT "%s: no configuration available", args().m_exename.c_str()));
+        LOG(CLOG_PRINT "%s: no configuration available", args().m_exename.c_str());
         m_bye(kExitConfig);
     }
 }
@@ -239,24 +239,24 @@ bool ServerApp::loadConfig(const std::string& pathname)
 {
     try {
         // load configuration
-        LOG((CLOG_DEBUG "opening configuration \"%s\"", pathname.c_str()));
+        LOG(CLOG_DEBUG "opening configuration \"%s\"", pathname.c_str());
         std::ifstream configStream(pathname.c_str());
         if (!configStream.is_open()) {
             // report failure to open configuration as a debug message
             // since we try several paths and we expect some to be
             // missing.
-            LOG((CLOG_DEBUG "cannot open configuration \"%s\"",
-                pathname.c_str()));
+            LOG(CLOG_DEBUG "cannot open configuration \"%s\"",
+                pathname.c_str());
             return false;
         }
         configStream >> *args().m_config;
-        LOG((CLOG_DEBUG "configuration read successfully"));
+        LOG(CLOG_DEBUG "configuration read successfully");
         return true;
     }
     catch (XConfigRead& e) {
         // report error in configuration file
-        LOG((CLOG_ERR "cannot read configuration \"%s\": %s",
-            pathname.c_str(), e.what()));
+        LOG(CLOG_ERR "cannot read configuration \"%s\": %s",
+            pathname.c_str(), e.what());
     }
     return false;
 }
@@ -398,7 +398,7 @@ void ServerApp::handle_retry()
         break;
 
     case kInitializing:
-        LOG((CLOG_DEBUG1 "retry server initialization"));
+        LOG(CLOG_DEBUG1 "retry server initialization");
         m_serverState = kUninitialized;
         if (!initServer()) {
             m_events->add_event(EventType::QUIT);
@@ -406,13 +406,13 @@ void ServerApp::handle_retry()
         break;
 
     case kInitializingToStart:
-        LOG((CLOG_DEBUG1 "retry server initialization"));
+        LOG(CLOG_DEBUG1 "retry server initialization");
         m_serverState = kUninitialized;
         if (!initServer()) {
             m_events->add_event(EventType::QUIT);
         }
         else if (m_serverState == kInitialized) {
-            LOG((CLOG_DEBUG1 "starting server"));
+            LOG(CLOG_DEBUG1 "starting server");
             if (!startServer()) {
                 m_events->add_event(EventType::QUIT);
             }
@@ -420,7 +420,7 @@ void ServerApp::handle_retry()
         break;
 
     case kStarting:
-        LOG((CLOG_DEBUG1 "retry starting server"));
+        LOG(CLOG_DEBUG1 "retry starting server");
         m_serverState = kInitialized;
         if (!startServer()) {
             m_events->add_event(EventType::QUIT);
@@ -451,18 +451,18 @@ bool ServerApp::initServer()
         return true;
     }
     catch (XScreenUnavailable& e) {
-        LOG((CLOG_WARN "primary screen unavailable: %s", e.what()));
+        LOG(CLOG_WARN "primary screen unavailable: %s", e.what());
         closePrimaryClient(primaryClient);
         updateStatus(std::string("primary screen unavailable: ") + e.what());
         retryTime = e.getRetryTime();
     }
     catch (XScreenOpenFailure& e) {
-        LOG((CLOG_CRIT "failed to start server: %s", e.what()));
+        LOG(CLOG_CRIT "failed to start server: %s", e.what());
         closePrimaryClient(primaryClient);
         return false;
     }
     catch (XBase& e) {
-        LOG((CLOG_CRIT "failed to start server: %s", e.what()));
+        LOG(CLOG_CRIT "failed to start server: %s", e.what());
         closePrimaryClient(primaryClient);
         return false;
     }
@@ -470,7 +470,7 @@ bool ServerApp::initServer()
     if (args().m_restartable) {
         // install a timer and handler to retry later
         assert(m_timer == nullptr);
-        LOG((CLOG_DEBUG "retry in %.0f seconds", retryTime));
+        LOG(CLOG_DEBUG "retry in %.0f seconds", retryTime);
         m_timer = m_events->newOneShotTimer(retryTime, nullptr);
         m_events->add_handler(EventType::TIMER, m_timer,
                               [this](const auto& e){ handle_retry(); });
@@ -545,18 +545,18 @@ ServerApp::startServer()
 
         // using CLOG_PRINT here allows the GUI to see that the server is started
         // regardless of which log level is set
-        LOG((CLOG_PRINT "started server (%s), waiting for clients", family));
+        LOG(CLOG_PRINT "started server (%s), waiting for clients", family);
         m_serverState = kStarted;
         return true;
     }
     catch (XSocketAddressInUse& e) {
-        LOG((CLOG_ERR "cannot listen for clients: %s", e.what()));
+        LOG(CLOG_ERR "cannot listen for clients: %s", e.what());
         closeClientListener(listener);
         updateStatus(std::string("cannot listen for clients: ") + e.what());
         retryTime = 1.0;
     }
     catch (XBase& e) {
-        LOG((CLOG_CRIT "failed to start server: %s", e.what()));
+        LOG(CLOG_CRIT "failed to start server: %s", e.what());
         closeClientListener(listener);
         return false;
     }
@@ -564,7 +564,7 @@ ServerApp::startServer()
     if (args().m_restartable) {
         // install a timer and handler to retry later
         assert(m_timer == nullptr);
-        LOG((CLOG_DEBUG "retry in %.0f seconds", retryTime));
+        LOG(CLOG_DEBUG "retry in %.0f seconds", retryTime);
         m_timer = m_events->newOneShotTimer(retryTime, nullptr);
         m_events->add_handler(EventType::TIMER, m_timer,
                               [this](const auto& e){ handle_retry(); });
@@ -588,21 +588,21 @@ std::unique_ptr<Screen> ServerApp::create_screen()
 
 PrimaryClient* ServerApp::openPrimaryClient(const std::string& name, inputleap::Screen* screen)
 {
-    LOG((CLOG_DEBUG1 "creating primary screen"));
+    LOG(CLOG_DEBUG1 "creating primary screen");
     return new PrimaryClient(name, screen);
 
 }
 
 void ServerApp::handle_screen_error()
 {
-    LOG((CLOG_CRIT "error on screen"));
+    LOG(CLOG_CRIT "error on screen");
     m_events->add_event(EventType::QUIT);
 }
 
 void ServerApp::handle_suspend()
 {
     if (!m_suspended) {
-        LOG((CLOG_INFO "suspend"));
+        LOG(CLOG_INFO "suspend");
         stopServer();
         m_suspended = true;
     }
@@ -611,7 +611,7 @@ void ServerApp::handle_suspend()
 void ServerApp::handle_resume()
 {
     if (m_suspended) {
-        LOG((CLOG_INFO "resume"));
+        LOG(CLOG_INFO "resume");
         startServer();
         m_suspended = false;
     }
@@ -663,7 +663,7 @@ void ServerApp::handle_screen_switched(const Event& e)
         const auto& info = e.get_data_as<Server::SwitchToScreenInfo>();
 
         if (!args().m_screenChangeScript.empty()) {
-            LOG((CLOG_INFO "Running shell script for screen \"%s\"", info.m_screen.c_str()));
+            LOG(CLOG_INFO "Running shell script for screen \"%s\"", info.m_screen.c_str());
 
             signal(SIGCHLD, SIG_IGN);
 
@@ -674,11 +674,11 @@ void ServerApp::handle_screen_switched(const Event& e)
                           info.m_screen.c_str(),nullptr);
                     exit(0);
                 } else if (pid < 0) {
-                    LOG((CLOG_ERR "Script forking error"));
+                    LOG(CLOG_ERR "Script forking error");
                     exit(1);
                 }
             } else {
-                LOG((CLOG_ERR "Script not accessible \"%s\"", args().m_screenChangeScript.c_str()));
+                LOG(CLOG_ERR "Script not accessible \"%s\"", args().m_screenChangeScript.c_str());
             }
         }
     #endif
@@ -710,7 +710,7 @@ ServerApp::mainLoop()
     // canonicalize the primary screen name
     std::string primaryName = args().m_config->getCanonicalName(args().m_name);
     if (primaryName.empty()) {
-        LOG((CLOG_CRIT "unknown screen name `%s'", args().m_name.c_str()));
+        LOG(CLOG_CRIT "unknown screen name `%s'", args().m_name.c_str());
         return kExitFailed;
     }
 
@@ -760,12 +760,12 @@ ServerApp::mainLoop()
     DAEMON_RUNNING(false);
 
     // close down
-    LOG((CLOG_DEBUG1 "stopping server"));
+    LOG(CLOG_DEBUG1 "stopping server");
     m_events->remove_handler(EventType::SERVER_APP_FORCE_RECONNECT, m_events->getSystemTarget());
     m_events->remove_handler(EventType::SERVER_APP_RELOAD_CONFIG, m_events->getSystemTarget());
     cleanupServer();
     updateStatus();
-    LOG((CLOG_NOTE "stopped server"));
+    LOG(CLOG_NOTE "stopped server");
 
     if (argsBase().m_enableIpc) {
         cleanupIpcClient();
@@ -776,7 +776,7 @@ ServerApp::mainLoop()
 
 void ServerApp::reset_server()
 {
-    LOG((CLOG_DEBUG1 "resetting server"));
+    LOG(CLOG_DEBUG1 "resetting server");
     stopServer();
     cleanupServer();
     startServer();
@@ -861,7 +861,7 @@ ServerApp::startNode()
 {
     // start the server.  if this return false then we've failed and
     // we shouldn't retry.
-    LOG((CLOG_DEBUG1 "starting server"));
+    LOG(CLOG_DEBUG1 "starting server");
     if (!startServer()) {
         m_bye(kExitFailed);
     }

--- a/src/lib/inputleap/StreamChunker.cpp
+++ b/src/lib/inputleap/StreamChunker.cpp
@@ -66,7 +66,7 @@ void StreamChunker::sendFile(const char* filename, IEventQueue* events,
     while (true) {
         if (s_interruptFile) {
             s_interruptFile = false;
-            LOG(CLOG_DEBUG "file transmission interrupted");
+            LOG_DEBUG("file transmission interrupted");
             break;
         }
 
@@ -145,7 +145,7 @@ void StreamChunker::sendClipboard(std::string& data, std::size_t size, Clipboard
     events->add_event(EventType::CLIPBOARD_SENDING, event_target,
                       create_event_data<ClipboardChunk>(end));
 
-    LOG(CLOG_DEBUG "sent clipboard size=%zd", sentLength);
+    LOG_DEBUG("sent clipboard size=%zd", sentLength);
 }
 
 void
@@ -153,7 +153,7 @@ StreamChunker::interruptFile()
 {
     if (s_isChunkingFile) {
         s_interruptFile = true;
-        LOG(CLOG_INFO "previous dragged file has become invalid");
+        LOG_INFO("previous dragged file has become invalid");
     }
 }
 

--- a/src/lib/inputleap/StreamChunker.cpp
+++ b/src/lib/inputleap/StreamChunker.cpp
@@ -66,7 +66,7 @@ void StreamChunker::sendFile(const char* filename, IEventQueue* events,
     while (true) {
         if (s_interruptFile) {
             s_interruptFile = false;
-            LOG((CLOG_DEBUG "file transmission interrupted"));
+            LOG(CLOG_DEBUG "file transmission interrupted");
             break;
         }
 
@@ -145,7 +145,7 @@ void StreamChunker::sendClipboard(std::string& data, std::size_t size, Clipboard
     events->add_event(EventType::CLIPBOARD_SENDING, event_target,
                       create_event_data<ClipboardChunk>(end));
 
-    LOG((CLOG_DEBUG "sent clipboard size=%zd", sentLength));
+    LOG(CLOG_DEBUG "sent clipboard size=%zd", sentLength);
 }
 
 void
@@ -153,7 +153,7 @@ StreamChunker::interruptFile()
 {
     if (s_isChunkingFile) {
         s_interruptFile = true;
-        LOG((CLOG_INFO "previous dragged file has become invalid"));
+        LOG(CLOG_INFO "previous dragged file has become invalid");
     }
 }
 

--- a/src/lib/inputleap/win32/AppUtilWindows.cpp
+++ b/src/lib/inputleap/win32/AppUtilWindows.cpp
@@ -56,7 +56,7 @@ AppUtilWindows::~AppUtilWindows()
 
 BOOL WINAPI AppUtilWindows::consoleHandler(DWORD)
 {
-    LOG((CLOG_INFO "got shutdown signal"));
+    LOG(CLOG_INFO "got shutdown signal");
     IEventQueue* events = AppUtil::instance().app().getEvents();
     events->add_event(EventType::QUIT);
     return TRUE;
@@ -176,7 +176,7 @@ AppUtilWindows::debugServiceWait()
             // used). to debug, set a breakpoint on this line so that
             // execution is delayed until the debugger is attached.
             inputleap::this_thread_sleep(1);
-            LOG((CLOG_INFO "waiting for debugger to attach"));
+            LOG(CLOG_INFO "waiting for debugger to attach");
         }
     }
 }

--- a/src/lib/inputleap/win32/AppUtilWindows.cpp
+++ b/src/lib/inputleap/win32/AppUtilWindows.cpp
@@ -56,7 +56,7 @@ AppUtilWindows::~AppUtilWindows()
 
 BOOL WINAPI AppUtilWindows::consoleHandler(DWORD)
 {
-    LOG(CLOG_INFO "got shutdown signal");
+    LOG_INFO("got shutdown signal");
     IEventQueue* events = AppUtil::instance().app().getEvents();
     events->add_event(EventType::QUIT);
     return TRUE;
@@ -176,7 +176,7 @@ AppUtilWindows::debugServiceWait()
             // used). to debug, set a breakpoint on this line so that
             // execution is delayed until the debugger is attached.
             inputleap::this_thread_sleep(1);
-            LOG(CLOG_INFO "waiting for debugger to attach");
+            LOG_INFO("waiting for debugger to attach");
         }
     }
 }

--- a/src/lib/inputleap/win32/DaemonApp.cpp
+++ b/src/lib/inputleap/win32/DaemonApp.cpp
@@ -202,7 +202,7 @@ DaemonApp::mainLoop(bool daemonized)
         std::string command = ARCH->setting("Command");
         bool elevate = ARCH->setting("Elevate") == "1";
         if (command != "") {
-            LOG(CLOG_INFO "using last known command: %s", command.c_str());
+            LOG_INFO("using last known command: %s", command.c_str());
             m_watchdog->setCommand(command, elevate);
         }
 
@@ -222,10 +222,10 @@ DaemonApp::mainLoop(bool daemonized)
         DAEMON_RUNNING(false);
     }
     catch (std::exception& e) {
-        LOG(CLOG_CRIT "An error occurred: %s", e.what());
+        LOG_CRIT("An error occurred: %s", e.what());
     }
     catch (...) {
-        LOG(CLOG_CRIT "An unknown error occurred.\n");
+        LOG_CRIT("An unknown error occurred.\n");
     }
 }
 
@@ -259,7 +259,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
             }
 
             if (!command.empty()) {
-                LOG(CLOG_DEBUG "new command, elevate=%d command=%s", cm.elevate(), command.c_str());
+                LOG_DEBUG("new command, elevate=%d command=%s", cm.elevate(), command.c_str());
 
                 std::vector<std::string> argsArray;
                 ArgParser::splitCommandString(command, argsArray);
@@ -291,7 +291,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
                         CLOG->setFilter(logLevel.c_str());
                     }
                     catch (std::runtime_error& e) {
-                        LOG(CLOG_ERR "failed to save LogLevel setting, %s", e.what());
+                        LOG_ERR("failed to save LogLevel setting, %s", e.what());
                     }
                 }
 
@@ -303,8 +303,8 @@ void DaemonApp::handle_ipc_message(const Event& e)
                         ARCH->setting("LogFilename", logFilename);
                         m_watchdog->setFileLogOutputter(m_fileLogOutputter);
                         command = ArgParser::assembleCommand(argsArray, "--log", 1);
-                        LOG(CLOG_DEBUG "removed log file argument and filename %s from command ", logFilename.c_str());
-                        LOG(CLOG_DEBUG "new command, elevate=%d command=%s", cm.elevate(), command.c_str());
+                        LOG_DEBUG("removed log file argument and filename %s from command ", logFilename.c_str());
+                        LOG_DEBUG("new command, elevate=%d command=%s", cm.elevate(), command.c_str());
                     } else {
                         m_watchdog->setFileLogOutputter(nullptr);
                     }
@@ -312,7 +312,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
                 }
             }
             else {
-                LOG(CLOG_DEBUG "empty command, elevate=%d", cm.elevate());
+                LOG_DEBUG("empty command, elevate=%d", cm.elevate());
             }
 
             try {
@@ -324,7 +324,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
                 ARCH->setting("Elevate", std::string(cm.elevate() ? "1" : "0"));
             }
             catch (std::runtime_error& e) {
-                LOG(CLOG_ERR "failed to save settings, %s", e.what());
+                LOG_ERR("failed to save settings, %s", e.what());
             }
 
             // tell the relauncher about the new command. this causes the
@@ -344,13 +344,13 @@ void DaemonApp::handle_ipc_message(const Event& e)
                 default: type = "unknown"; break;
             }
 
-            LOG(CLOG_DEBUG "ipc hello, type=%s", type.c_str());
+            LOG_DEBUG("ipc hello, type=%s", type.c_str());
 
             const char * serverstatus = m_watchdog->isProcessActive() ? "active" : "not active";
 
             // using CLOG_PRINT here allows the GUI to see that the server status
             // regardless of which log level is set
-            LOG(CLOG_PRINT "server status: %s", serverstatus);
+            LOG_PRINT("server status: %s", serverstatus);
 
             m_ipcLogOutputter->notifyBuffer();
             break;

--- a/src/lib/inputleap/win32/DaemonApp.cpp
+++ b/src/lib/inputleap/win32/DaemonApp.cpp
@@ -202,7 +202,7 @@ DaemonApp::mainLoop(bool daemonized)
         std::string command = ARCH->setting("Command");
         bool elevate = ARCH->setting("Elevate") == "1";
         if (command != "") {
-            LOG((CLOG_INFO "using last known command: %s", command.c_str()));
+            LOG(CLOG_INFO "using last known command: %s", command.c_str());
             m_watchdog->setCommand(command, elevate);
         }
 
@@ -222,10 +222,10 @@ DaemonApp::mainLoop(bool daemonized)
         DAEMON_RUNNING(false);
     }
     catch (std::exception& e) {
-        LOG((CLOG_CRIT "An error occurred: %s", e.what()));
+        LOG(CLOG_CRIT "An error occurred: %s", e.what());
     }
     catch (...) {
-        LOG((CLOG_CRIT "An unknown error occurred.\n"));
+        LOG(CLOG_CRIT "An unknown error occurred.\n");
     }
 }
 
@@ -259,7 +259,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
             }
 
             if (!command.empty()) {
-                LOG((CLOG_DEBUG "new command, elevate=%d command=%s", cm.elevate(), command.c_str()));
+                LOG(CLOG_DEBUG "new command, elevate=%d command=%s", cm.elevate(), command.c_str());
 
                 std::vector<std::string> argsArray;
                 ArgParser::splitCommandString(command, argsArray);
@@ -291,7 +291,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
                         CLOG->setFilter(logLevel.c_str());
                     }
                     catch (std::runtime_error& e) {
-                        LOG((CLOG_ERR "failed to save LogLevel setting, %s", e.what()));
+                        LOG(CLOG_ERR "failed to save LogLevel setting, %s", e.what());
                     }
                 }
 
@@ -303,8 +303,8 @@ void DaemonApp::handle_ipc_message(const Event& e)
                         ARCH->setting("LogFilename", logFilename);
                         m_watchdog->setFileLogOutputter(m_fileLogOutputter);
                         command = ArgParser::assembleCommand(argsArray, "--log", 1);
-                        LOG((CLOG_DEBUG "removed log file argument and filename %s from command ", logFilename.c_str()));
-                        LOG((CLOG_DEBUG "new command, elevate=%d command=%s", cm.elevate(), command.c_str()));
+                        LOG(CLOG_DEBUG "removed log file argument and filename %s from command ", logFilename.c_str());
+                        LOG(CLOG_DEBUG "new command, elevate=%d command=%s", cm.elevate(), command.c_str());
                     } else {
                         m_watchdog->setFileLogOutputter(nullptr);
                     }
@@ -312,7 +312,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
                 }
             }
             else {
-                LOG((CLOG_DEBUG "empty command, elevate=%d", cm.elevate()));
+                LOG(CLOG_DEBUG "empty command, elevate=%d", cm.elevate());
             }
 
             try {
@@ -324,7 +324,7 @@ void DaemonApp::handle_ipc_message(const Event& e)
                 ARCH->setting("Elevate", std::string(cm.elevate() ? "1" : "0"));
             }
             catch (std::runtime_error& e) {
-                LOG((CLOG_ERR "failed to save settings, %s", e.what()));
+                LOG(CLOG_ERR "failed to save settings, %s", e.what());
             }
 
             // tell the relauncher about the new command. this causes the
@@ -344,13 +344,13 @@ void DaemonApp::handle_ipc_message(const Event& e)
                 default: type = "unknown"; break;
             }
 
-            LOG((CLOG_DEBUG "ipc hello, type=%s", type.c_str()));
+            LOG(CLOG_DEBUG "ipc hello, type=%s", type.c_str());
 
             const char * serverstatus = m_watchdog->isProcessActive() ? "active" : "not active";
 
             // using CLOG_PRINT here allows the GUI to see that the server status
             // regardless of which log level is set
-            LOG((CLOG_PRINT "server status: %s", serverstatus));
+            LOG(CLOG_PRINT "server status: %s", serverstatus);
 
             m_ipcLogOutputter->notifyBuffer();
             break;

--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -60,13 +60,13 @@ IpcClientProxy::~IpcClientProxy()
 void IpcClientProxy::handle_disconnect()
 {
     disconnect();
-    LOG((CLOG_DEBUG "ipc client disconnected"));
+    LOG(CLOG_DEBUG "ipc client disconnected");
 }
 
 void IpcClientProxy::handle_write_error()
 {
     disconnect();
-    LOG((CLOG_DEBUG "ipc client write error"));
+    LOG(CLOG_DEBUG "ipc client write error");
 }
 
 void IpcClientProxy::handle_data()
@@ -74,14 +74,14 @@ void IpcClientProxy::handle_data()
     // don't allow the dtor to destroy the stream while we're using it.
     std::lock_guard<std::mutex> lock(m_readMutex);
 
-    LOG((CLOG_DEBUG "start ipc handle data"));
+    LOG(CLOG_DEBUG "start ipc handle data");
 
     std::uint8_t code[4];
     std::uint32_t n = stream_->read(code, 4);
     while (n != 0) {
 
-        LOG((CLOG_DEBUG "ipc read: %c%c%c%c",
-            code[0], code[1], code[2], code[3]));
+        LOG(CLOG_DEBUG "ipc read: %c%c%c%c",
+            code[0], code[1], code[2], code[3]);
 
         EventDataBase* event_data = nullptr;
         if (memcmp(code, kIpcMsgHello, 4) == 0) {
@@ -91,7 +91,7 @@ void IpcClientProxy::handle_data()
             event_data = create_event_data<IpcCommandMessage>(parseCommand());
         }
         else {
-            LOG((CLOG_ERR "invalid ipc message"));
+            LOG(CLOG_ERR "invalid ipc message");
             disconnect();
         }
 
@@ -100,7 +100,7 @@ void IpcClientProxy::handle_data()
         n = stream_->read(code, 4);
     }
 
-    LOG((CLOG_DEBUG "finished ipc handle data"));
+    LOG(CLOG_DEBUG "finished ipc handle data");
 }
 
 void
@@ -111,7 +111,7 @@ IpcClientProxy::send(const IpcMessage& message)
     // also, don't allow the dtor to destroy the stream while we're using it.
     std::lock_guard<std::mutex> lock(m_writeMutex);
 
-    LOG((CLOG_DEBUG4 "ipc write: %d", message.type()));
+    LOG(CLOG_DEBUG4 "ipc write: %d", message.type());
 
     switch (message.type()) {
     case kIpcLogLine: {
@@ -126,7 +126,7 @@ IpcClientProxy::send(const IpcMessage& message)
         break;
 
     default:
-        LOG((CLOG_ERR "ipc message not supported: %d", message.type()));
+        LOG(CLOG_ERR "ipc message not supported: %d", message.type());
         break;
     }
 }
@@ -155,7 +155,7 @@ IpcCommandMessage IpcClientProxy::parseCommand()
 void
 IpcClientProxy::disconnect()
 {
-    LOG((CLOG_DEBUG "ipc disconnect, closing stream"));
+    LOG(CLOG_DEBUG "ipc disconnect, closing stream");
     m_disconnecting = true;
     stream_->close();
     m_events->add_event(EventType::IPC_CLIENT_PROXY_DISCONNECTED, this);

--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -60,13 +60,13 @@ IpcClientProxy::~IpcClientProxy()
 void IpcClientProxy::handle_disconnect()
 {
     disconnect();
-    LOG(CLOG_DEBUG "ipc client disconnected");
+    LOG_DEBUG("ipc client disconnected");
 }
 
 void IpcClientProxy::handle_write_error()
 {
     disconnect();
-    LOG(CLOG_DEBUG "ipc client write error");
+    LOG_DEBUG("ipc client write error");
 }
 
 void IpcClientProxy::handle_data()
@@ -74,13 +74,13 @@ void IpcClientProxy::handle_data()
     // don't allow the dtor to destroy the stream while we're using it.
     std::lock_guard<std::mutex> lock(m_readMutex);
 
-    LOG(CLOG_DEBUG "start ipc handle data");
+    LOG_DEBUG("start ipc handle data");
 
     std::uint8_t code[4];
     std::uint32_t n = stream_->read(code, 4);
     while (n != 0) {
 
-        LOG(CLOG_DEBUG "ipc read: %c%c%c%c",
+        LOG_DEBUG("ipc read: %c%c%c%c",
             code[0], code[1], code[2], code[3]);
 
         EventDataBase* event_data = nullptr;
@@ -91,7 +91,7 @@ void IpcClientProxy::handle_data()
             event_data = create_event_data<IpcCommandMessage>(parseCommand());
         }
         else {
-            LOG(CLOG_ERR "invalid ipc message");
+            LOG_ERR("invalid ipc message");
             disconnect();
         }
 
@@ -100,7 +100,7 @@ void IpcClientProxy::handle_data()
         n = stream_->read(code, 4);
     }
 
-    LOG(CLOG_DEBUG "finished ipc handle data");
+    LOG_DEBUG("finished ipc handle data");
 }
 
 void
@@ -111,7 +111,7 @@ IpcClientProxy::send(const IpcMessage& message)
     // also, don't allow the dtor to destroy the stream while we're using it.
     std::lock_guard<std::mutex> lock(m_writeMutex);
 
-    LOG(CLOG_DEBUG4 "ipc write: %d", message.type());
+    LOG_DEBUG4("ipc write: %d", message.type());
 
     switch (message.type()) {
     case kIpcLogLine: {
@@ -126,7 +126,7 @@ IpcClientProxy::send(const IpcMessage& message)
         break;
 
     default:
-        LOG(CLOG_ERR "ipc message not supported: %d", message.type());
+        LOG_ERR("ipc message not supported: %d", message.type());
         break;
     }
 }
@@ -155,7 +155,7 @@ IpcCommandMessage IpcClientProxy::parseCommand()
 void
 IpcClientProxy::disconnect()
 {
-    LOG(CLOG_DEBUG "ipc disconnect, closing stream");
+    LOG_DEBUG("ipc disconnect, closing stream");
     m_disconnecting = true;
     stream_->close();
     m_events->add_event(EventType::IPC_CLIENT_PROXY_DISCONNECTED, this);

--- a/src/lib/ipc/IpcLogOutputter.cpp
+++ b/src/lib/ipc/IpcLogOutputter.cpp
@@ -155,10 +155,10 @@ void IpcLogOutputter::buffer_thread()
         }
     }
     catch (std::runtime_error& e) {
-        LOG(CLOG_ERR "ipc log buffer thread error, %s", e.what());
+        LOG_ERR("ipc log buffer thread error, %s", e.what());
     }
 
-    LOG(CLOG_DEBUG "ipc log buffer thread finished");
+    LOG_DEBUG("ipc log buffer thread finished");
 }
 
 void

--- a/src/lib/ipc/IpcLogOutputter.cpp
+++ b/src/lib/ipc/IpcLogOutputter.cpp
@@ -155,10 +155,10 @@ void IpcLogOutputter::buffer_thread()
         }
     }
     catch (std::runtime_error& e) {
-        LOG((CLOG_ERR "ipc log buffer thread error, %s", e.what()));
+        LOG(CLOG_ERR "ipc log buffer thread error, %s", e.what());
     }
 
-    LOG((CLOG_DEBUG "ipc log buffer thread finished"));
+    LOG(CLOG_DEBUG "ipc log buffer thread finished");
 }
 
 void

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -90,7 +90,7 @@ void IpcServer::handle_client_connecting()
         return;
     }
 
-    LOG((CLOG_DEBUG "accepted ipc client connection"));
+    LOG(CLOG_DEBUG "accepted ipc client connection");
 
     IpcClientProxy* proxy = nullptr;
     {
@@ -117,7 +117,7 @@ void IpcServer::handle_client_disconnected(const Event& e)
     m_clients.remove(proxy);
     deleteClient(proxy);
 
-    LOG((CLOG_DEBUG "ipc client proxy removed, connected=%zd", m_clients.size()));
+    LOG(CLOG_DEBUG "ipc client proxy removed, connected=%zd", m_clients.size());
 }
 
 void IpcServer::handle_message_received(const Event& e)

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -90,7 +90,7 @@ void IpcServer::handle_client_connecting()
         return;
     }
 
-    LOG(CLOG_DEBUG "accepted ipc client connection");
+    LOG_DEBUG("accepted ipc client connection");
 
     IpcClientProxy* proxy = nullptr;
     {
@@ -117,7 +117,7 @@ void IpcServer::handle_client_disconnected(const Event& e)
     m_clients.remove(proxy);
     deleteClient(proxy);
 
-    LOG(CLOG_DEBUG "ipc client proxy removed, connected=%zd", m_clients.size());
+    LOG_DEBUG("ipc client proxy removed, connected=%zd", m_clients.size());
 }
 
 void IpcServer::handle_message_received(const Event& e)

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -41,14 +41,14 @@ IpcServerProxy::~IpcServerProxy()
 
 void IpcServerProxy::handle_data()
 {
-    LOG((CLOG_DEBUG "start ipc handle data"));
+    LOG(CLOG_DEBUG "start ipc handle data");
 
     std::uint8_t code[4];
     std::uint32_t n = m_stream.read(code, 4);
     while (n != 0) {
 
-        LOG((CLOG_DEBUG "ipc read: %c%c%c%c",
-            code[0], code[1], code[2], code[3]));
+        LOG(CLOG_DEBUG "ipc read: %c%c%c%c",
+            code[0], code[1], code[2], code[3]);
 
         EventDataBase* event_data = nullptr;
         if (memcmp(code, kIpcMsgLogLine, 4) == 0) {
@@ -58,7 +58,7 @@ void IpcServerProxy::handle_data()
             event_data = create_event_data<IpcShutdownMessage>(IpcShutdownMessage{});
         }
         else {
-            LOG((CLOG_ERR "invalid ipc message"));
+            LOG(CLOG_ERR "invalid ipc message");
             disconnect();
         }
 
@@ -67,13 +67,13 @@ void IpcServerProxy::handle_data()
         n = m_stream.read(code, 4);
     }
 
-    LOG((CLOG_DEBUG "finished ipc handle data"));
+    LOG(CLOG_DEBUG "finished ipc handle data");
 }
 
 void
 IpcServerProxy::send(const IpcMessage& message)
 {
-    LOG((CLOG_DEBUG4 "ipc write: %d", message.type()));
+    LOG(CLOG_DEBUG4 "ipc write: %d", message.type());
 
     switch (message.type()) {
     case kIpcHello: {
@@ -90,7 +90,7 @@ IpcServerProxy::send(const IpcMessage& message)
     }
 
     default:
-        LOG((CLOG_ERR "ipc message not supported: %d", message.type()));
+        LOG(CLOG_ERR "ipc message not supported: %d", message.type());
         break;
     }
 }
@@ -107,7 +107,7 @@ IpcLogLineMessage IpcServerProxy::parseLogLine()
 void
 IpcServerProxy::disconnect()
 {
-    LOG((CLOG_DEBUG "ipc disconnect, closing stream"));
+    LOG(CLOG_DEBUG "ipc disconnect, closing stream");
     m_stream.close();
 }
 

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -41,13 +41,13 @@ IpcServerProxy::~IpcServerProxy()
 
 void IpcServerProxy::handle_data()
 {
-    LOG(CLOG_DEBUG "start ipc handle data");
+    LOG_DEBUG("start ipc handle data");
 
     std::uint8_t code[4];
     std::uint32_t n = m_stream.read(code, 4);
     while (n != 0) {
 
-        LOG(CLOG_DEBUG "ipc read: %c%c%c%c",
+        LOG_DEBUG("ipc read: %c%c%c%c",
             code[0], code[1], code[2], code[3]);
 
         EventDataBase* event_data = nullptr;
@@ -58,7 +58,7 @@ void IpcServerProxy::handle_data()
             event_data = create_event_data<IpcShutdownMessage>(IpcShutdownMessage{});
         }
         else {
-            LOG(CLOG_ERR "invalid ipc message");
+            LOG_ERR("invalid ipc message");
             disconnect();
         }
 
@@ -67,13 +67,13 @@ void IpcServerProxy::handle_data()
         n = m_stream.read(code, 4);
     }
 
-    LOG(CLOG_DEBUG "finished ipc handle data");
+    LOG_DEBUG("finished ipc handle data");
 }
 
 void
 IpcServerProxy::send(const IpcMessage& message)
 {
-    LOG(CLOG_DEBUG4 "ipc write: %d", message.type());
+    LOG_DEBUG4("ipc write: %d", message.type());
 
     switch (message.type()) {
     case kIpcHello: {
@@ -90,7 +90,7 @@ IpcServerProxy::send(const IpcMessage& message)
     }
 
     default:
-        LOG(CLOG_ERR "ipc message not supported: %d", message.type());
+        LOG_ERR("ipc message not supported: %d", message.type());
         break;
     }
 }
@@ -107,7 +107,7 @@ IpcLogLineMessage IpcServerProxy::parseLogLine()
 void
 IpcServerProxy::disconnect()
 {
-    LOG(CLOG_DEBUG "ipc disconnect, closing stream");
+    LOG_DEBUG("ipc disconnect, closing stream");
     m_stream.close();
 }
 

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -134,24 +134,24 @@ void Thread::threadFunc(const std::function<void()>& func)
 
     try {
         // go
-        LOG((CLOG_DEBUG1 "thread 0x%08x entry", id));
+        LOG(CLOG_DEBUG1 "thread 0x%08x entry", id);
         func();
-        LOG((CLOG_DEBUG1 "thread 0x%08x exit", id));
+        LOG(CLOG_DEBUG1 "thread 0x%08x exit", id);
     }
     catch (XThreadCancel&) {
         // client called cancel()
-        LOG((CLOG_DEBUG1 "caught cancel on thread 0x%08x", id));
+        LOG(CLOG_DEBUG1 "caught cancel on thread 0x%08x", id);
         throw;
     }
     catch (XThreadExit&) {
-        LOG((CLOG_DEBUG1 "caught exit on thread 0x%08x", id));
+        LOG(CLOG_DEBUG1 "caught exit on thread 0x%08x", id);
     }
     catch (XBase& e) {
-        LOG((CLOG_ERR "exception on thread 0x%08x: %s", id, e.what()));
+        LOG(CLOG_ERR "exception on thread 0x%08x: %s", id, e.what());
         throw;
     }
     catch (...) {
-        LOG((CLOG_ERR "exception on thread 0x%08x: <unknown>", id));
+        LOG(CLOG_ERR "exception on thread 0x%08x: <unknown>", id);
         throw;
     }
 }

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -134,24 +134,24 @@ void Thread::threadFunc(const std::function<void()>& func)
 
     try {
         // go
-        LOG(CLOG_DEBUG1 "thread 0x%08x entry", id);
+        LOG_DEBUG1("thread 0x%08x entry", id);
         func();
-        LOG(CLOG_DEBUG1 "thread 0x%08x exit", id);
+        LOG_DEBUG1("thread 0x%08x exit", id);
     }
     catch (XThreadCancel&) {
         // client called cancel()
-        LOG(CLOG_DEBUG1 "caught cancel on thread 0x%08x", id);
+        LOG_DEBUG1("caught cancel on thread 0x%08x", id);
         throw;
     }
     catch (XThreadExit&) {
-        LOG(CLOG_DEBUG1 "caught exit on thread 0x%08x", id);
+        LOG_DEBUG1("caught exit on thread 0x%08x", id);
     }
     catch (XBase& e) {
-        LOG(CLOG_ERR "exception on thread 0x%08x: %s", id, e.what());
+        LOG_ERR("exception on thread 0x%08x: %s", id, e.what());
         throw;
     }
     catch (...) {
-        LOG(CLOG_ERR "exception on thread 0x%08x: <unknown>", id);
+        LOG_ERR("exception on thread 0x%08x: <unknown>", id);
         throw;
     }
 }

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -254,7 +254,7 @@ SecureSocket::secureRead(void* buffer, int size, int& read)
     std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
 
     if (m_ssl->m_ssl != nullptr) {
-        LOG((CLOG_DEBUG2 "reading secure socket"));
+        LOG(CLOG_DEBUG2 "reading secure socket");
         read = SSL_read(m_ssl->m_ssl, buffer, size);
 
         // Check result will cleanup the connection in the case of a fatal
@@ -280,7 +280,7 @@ SecureSocket::secureWrite(const void* buffer, int size, int& wrote)
     std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
 
     if (m_ssl->m_ssl != nullptr) {
-        LOG((CLOG_DEBUG2 "writing secure socket:%p", this));
+        LOG(CLOG_DEBUG2 "writing secure socket:%p", this);
 
         wrote = SSL_write(m_ssl->m_ssl, buffer, size);
 
@@ -428,15 +428,15 @@ SecureSocket::secureAccept(int socket)
     // set connection socket to SSL state
     SSL_set_fd(m_ssl->m_ssl, socket);
 
-    LOG((CLOG_DEBUG2 "accepting secure socket"));
+    LOG(CLOG_DEBUG2 "accepting secure socket");
     int r = SSL_accept(m_ssl->m_ssl);
 
     checkResult(r, secure_accept_retry_);
 
     if (isFatal()) {
         // tell user and sleep so the socket isn't hammered.
-        LOG((CLOG_ERR "failed to accept secure socket"));
-        LOG((CLOG_INFO "client connection may not be secure"));
+        LOG(CLOG_ERR "failed to accept secure socket");
+        LOG(CLOG_INFO "client connection may not be secure");
         m_secureReady = false;
         inputleap::this_thread_sleep(1);
         secure_accept_retry_ = 0;
@@ -448,10 +448,10 @@ SecureSocket::secureAccept(int socket)
         if (security_level_ == ConnectionSecurityLevel::ENCRYPTED_AUTHENTICATED) {
             if (verify_peer_certificate(
                         inputleap::DataDirectories::trusted_clients_ssl_fingerprints_path())) {
-                LOG((CLOG_INFO "accepted secure socket"));
+                LOG(CLOG_INFO "accepted secure socket");
             }
             else {
-                LOG((CLOG_ERR "failed to verify client certificate fingerprint"));
+                LOG(CLOG_ERR "failed to verify client certificate fingerprint");
                 secure_accept_retry_ = 0;
                 disconnect();
                 return -1; // Fingerprint failed, error
@@ -459,7 +459,7 @@ SecureSocket::secureAccept(int socket)
         }
 
         m_secureReady = true;
-        LOG((CLOG_INFO "accepted secure socket"));
+        LOG(CLOG_INFO "accepted secure socket");
         if (CLOG->getFilter() >= kDEBUG1) {
             showSecureCipherInfo();
         }
@@ -469,14 +469,14 @@ SecureSocket::secureAccept(int socket)
 
     // If not fatal and retry is set, not ready, and return retry
     if (secure_accept_retry_ > 0) {
-        LOG((CLOG_DEBUG2 "retry accepting secure socket"));
+        LOG(CLOG_DEBUG2 "retry accepting secure socket");
         m_secureReady = false;
         inputleap::this_thread_sleep(s_retryDelay);
         return 0;
     }
 
     // no good state exists here
-    LOG((CLOG_ERR "unexpected state attempting to accept connection"));
+    LOG(CLOG_ERR "unexpected state attempting to accept connection");
     return -1;
 }
 
@@ -485,7 +485,7 @@ SecureSocket::secureConnect(int socket)
 {
     // note that load_certificates acquires ssl_mutex_
     if (!load_certificates(inputleap::DataDirectories::ssl_certificate_path())) {
-        LOG((CLOG_ERR "could not load client certificates"));
+        LOG(CLOG_ERR "could not load client certificates");
         // FIXME: this is fatal error, but we current don't disconnect because whole logic in this
         // function needs to be cleaned up
     }
@@ -497,20 +497,20 @@ SecureSocket::secureConnect(int socket)
     // attach the socket descriptor
     SSL_set_fd(m_ssl->m_ssl, socket);
 
-    LOG((CLOG_DEBUG2 "connecting secure socket"));
+    LOG(CLOG_DEBUG2 "connecting secure socket");
     int r = SSL_connect(m_ssl->m_ssl);
 
     checkResult(r, secure_connect_retry_);
 
     if (isFatal()) {
-        LOG((CLOG_ERR "failed to connect secure socket"));
+        LOG(CLOG_ERR "failed to connect secure socket");
         secure_connect_retry_ = 0;
         return -1;
     }
 
     // If we should retry, not ready and return 0
     if (secure_connect_retry_ > 0) {
-        LOG((CLOG_DEBUG2 "retry connect secure socket"));
+        LOG(CLOG_DEBUG2 "retry connect secure socket");
         m_secureReady = false;
         inputleap::this_thread_sleep(s_retryDelay);
         return 0;
@@ -520,14 +520,14 @@ SecureSocket::secureConnect(int socket)
     // No error, set ready, process and return ok
     m_secureReady = true;
     if (verify_peer_certificate(inputleap::DataDirectories::trusted_servers_ssl_fingerprints_path())) {
-        LOG((CLOG_INFO "connected to secure socket"));
+        LOG(CLOG_INFO "connected to secure socket");
     }
     else {
-        LOG((CLOG_ERR "failed to verify server certificate fingerprint"));
+        LOG(CLOG_ERR "failed to verify server certificate fingerprint");
         disconnect();
         return -1; // Fingerprint failed, error
     }
-    LOG((CLOG_DEBUG2 "connected secure socket"));
+    LOG(CLOG_DEBUG2 "connected secure socket");
     if (CLOG->getFilter() >= kDEBUG1) {
         showSecureCipherInfo();
     }
@@ -554,12 +554,12 @@ SecureSocket::checkResult(int status, int& retry)
     case SSL_ERROR_ZERO_RETURN:
         // connection closed
         isFatal(true);
-        LOG((CLOG_DEBUG "ssl connection closed"));
+        LOG(CLOG_DEBUG "ssl connection closed");
         break;
 
     case SSL_ERROR_WANT_READ:
         retry++;
-        LOG((CLOG_DEBUG2 "want to read, error=%d, attempt=%d", errorCode, retry));
+        LOG(CLOG_DEBUG2 "want to read, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_WANT_WRITE:
@@ -568,24 +568,24 @@ SecureSocket::checkResult(int status, int& retry)
         // m_readable because the socket logic is always readable
         m_writable = true;
         retry++;
-        LOG((CLOG_DEBUG2 "want to write, error=%d, attempt=%d", errorCode, retry));
+        LOG(CLOG_DEBUG2 "want to write, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_WANT_CONNECT:
         retry++;
-        LOG((CLOG_DEBUG2 "want to connect, error=%d, attempt=%d", errorCode, retry));
+        LOG(CLOG_DEBUG2 "want to connect, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_WANT_ACCEPT:
         retry++;
-        LOG((CLOG_DEBUG2 "want to accept, error=%d, attempt=%d", errorCode, retry));
+        LOG(CLOG_DEBUG2 "want to accept, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_SYSCALL:
-        LOG((CLOG_ERR "ssl error occurred (system call failure)"));
+        LOG(CLOG_ERR "ssl error occurred (system call failure)");
         if (ERR_peek_error() == 0) {
             if (status == 0) {
-                LOG((CLOG_ERR "eof violates ssl protocol"));
+                LOG(CLOG_ERR "eof violates ssl protocol");
             }
             else if (status == -1) {
                 // underlying socket I/O reproted an error
@@ -593,7 +593,7 @@ SecureSocket::checkResult(int status, int& retry)
                     ARCH->throwErrorOnSocket(getSocket());
                 }
                 catch (XArchNetwork& e) {
-                    LOG((CLOG_ERR "%s", e.what()));
+                    LOG(CLOG_ERR "%s", e.what());
                 }
             }
         }
@@ -602,12 +602,12 @@ SecureSocket::checkResult(int status, int& retry)
         break;
 
     case SSL_ERROR_SSL:
-        LOG((CLOG_ERR "ssl error occurred (generic failure)"));
+        LOG(CLOG_ERR "ssl error occurred (generic failure)");
         isFatal(true);
         break;
 
     default:
-        LOG((CLOG_ERR "ssl error occurred (unknown failure)"));
+        LOG(CLOG_ERR "ssl error occurred (unknown failure)");
         isFatal(true);
         break;
     }
@@ -622,12 +622,12 @@ SecureSocket::checkResult(int status, int& retry)
 void SecureSocket::showError(const std::string& reason)
 {
     if (!reason.empty()) {
-        LOG((CLOG_ERR "%s", reason.c_str()));
+        LOG(CLOG_ERR "%s", reason.c_str());
     }
 
     std::string error = getError();
     if (!error.empty()) {
-        LOG((CLOG_ERR "%s", error.c_str()));
+        LOG(CLOG_ERR "%s", error.c_str());
     }
 }
 
@@ -665,7 +665,7 @@ bool SecureSocket::verify_peer_certificate(const inputleap::fs::path& fingerprin
     }
     auto cert_free = inputleap::finally([cert]() { X509_free(cert); });
     char* line = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
-    LOG((CLOG_INFO "peer ssl certificate info: %s", line));
+    LOG(CLOG_INFO "peer ssl certificate info: %s", line);
     OPENSSL_free(line);
 
     // calculate received certificate fingerprint
@@ -676,34 +676,34 @@ bool SecureSocket::verify_peer_certificate(const inputleap::fs::path& fingerprin
         fingerprint_sha256 = inputleap::get_ssl_cert_fingerprint(cert,
                                                                inputleap::FingerprintType::SHA256);
     } catch (const std::exception& e) {
-        LOG((CLOG_ERR "%s", e.what()));
+        LOG(CLOG_ERR "%s", e.what());
         return false;
     }
 
     // note: the GUI parses the following two lines of logs, don't change unnecessarily
-    LOG((CLOG_NOTE "peer fingerprint (SHA1): %s (SHA256): %s",
+    LOG(CLOG_NOTE "peer fingerprint (SHA1): %s (SHA256): %s",
          inputleap::format_ssl_fingerprint(fingerprint_sha1.data).c_str(),
-         inputleap::format_ssl_fingerprint(fingerprint_sha256.data).c_str()));
+         inputleap::format_ssl_fingerprint(fingerprint_sha256.data).c_str());
 
     // Provide debug hint as to what file is being used to verify fingerprint trust
-    LOG((CLOG_NOTE "fingerprint_db_path: %s", fingerprint_db_path.u8string().c_str()));
+    LOG(CLOG_NOTE "fingerprint_db_path: %s", fingerprint_db_path.u8string().c_str());
 
     inputleap::FingerprintDatabase db;
     db.read(fingerprint_db_path);
 
     if (!db.fingerprints().empty()) {
-        LOG((CLOG_NOTE "Read %zd fingerprints from: %s", db.fingerprints().size(),
-             fingerprint_db_path.u8string().c_str()));
+        LOG(CLOG_NOTE "Read %zd fingerprints from: %s", db.fingerprints().size(),
+             fingerprint_db_path.u8string().c_str());
     } else {
-        LOG((CLOG_NOTE "Could not read fingerprints from: %s",
-             fingerprint_db_path.u8string().c_str()));
+        LOG(CLOG_NOTE "Could not read fingerprints from: %s",
+             fingerprint_db_path.u8string().c_str());
     }
 
     if (db.is_trusted(fingerprint_sha256)) {
-        LOG((CLOG_NOTE "Fingerprint matches trusted fingerprint"));
+        LOG(CLOG_NOTE "Fingerprint matches trusted fingerprint");
         return true;
     } else {
-        LOG((CLOG_NOTE "Fingerprint does not match trusted fingerprint"));
+        LOG(CLOG_NOTE "Fingerprint does not match trusted fingerprint");
         return false;
     }
 }
@@ -796,7 +796,7 @@ showCipherStackDesc(STACK_OF(SSL_CIPHER) * stack) {
             msg[pos] = '\0';
         }
 
-        LOG((CLOG_DEBUG1 "%s",msg));
+        LOG(CLOG_DEBUG1 "%s",msg);
     }
 }
 
@@ -808,10 +808,10 @@ SecureSocket::showSecureCipherInfo()
     STACK_OF(SSL_CIPHER) * sStack = SSL_get_ciphers(m_ssl->m_ssl);
 
     if (sStack == nullptr) {
-        LOG((CLOG_DEBUG1 "local cipher list not available"));
+        LOG(CLOG_DEBUG1 "local cipher list not available");
     }
     else {
-        LOG((CLOG_DEBUG1 "available local ciphers:"));
+        LOG(CLOG_DEBUG1 "available local ciphers:");
         showCipherStackDesc(sStack);
     }
 
@@ -824,10 +824,10 @@ SecureSocket::showSecureCipherInfo()
 	STACK_OF(SSL_CIPHER) * cStack = SSL_get_client_ciphers(m_ssl->m_ssl);
 #endif
 	if (cStack == nullptr) {
-        LOG((CLOG_DEBUG1 "remote cipher list not available"));
+        LOG(CLOG_DEBUG1 "remote cipher list not available");
     }
     else {
-        LOG((CLOG_DEBUG1 "available remote ciphers:"));
+        LOG(CLOG_DEBUG1 "available remote ciphers:");
         showCipherStackDesc(cStack);
     }
     return;
@@ -836,11 +836,11 @@ SecureSocket::showSecureCipherInfo()
 void
 SecureSocket::showSecureLibInfo()
 {
-    LOG((CLOG_INFO "%s",SSLeay_version(SSLEAY_VERSION)));
-    LOG((CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_CFLAGS)));
-    LOG((CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_BUILT_ON)));
-    LOG((CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_PLATFORM)));
-    LOG((CLOG_DEBUG1 "%s",SSLeay_version(SSLEAY_DIR)));
+    LOG(CLOG_INFO "%s",SSLeay_version(SSLEAY_VERSION));
+    LOG(CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_CFLAGS));
+    LOG(CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_BUILT_ON));
+    LOG(CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_PLATFORM));
+    LOG(CLOG_DEBUG1 "%s",SSLeay_version(SSLEAY_DIR));
     return;
 }
 
@@ -854,7 +854,7 @@ SecureSocket::showSecureConnectInfo()
     if (cipher != nullptr) {
         char msg[kMsgSize];
         SSL_CIPHER_description(cipher, msg, kMsgSize);
-        LOG((CLOG_INFO "%s", msg));
+        LOG(CLOG_INFO "%s", msg);
         }
     return;
 }
@@ -864,7 +864,7 @@ void SecureSocket::handle_tcp_connected(const Event& event)
     (void) event;
 
     if (getSocket() == nullptr) {
-        LOG((CLOG_DEBUG "disregarding stale connect event"));
+        LOG(CLOG_DEBUG "disregarding stale connect event");
         return;
     }
     secureConnect();

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -254,7 +254,7 @@ SecureSocket::secureRead(void* buffer, int size, int& read)
     std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
 
     if (m_ssl->m_ssl != nullptr) {
-        LOG(CLOG_DEBUG2 "reading secure socket");
+        LOG_DEBUG2("reading secure socket");
         read = SSL_read(m_ssl->m_ssl, buffer, size);
 
         // Check result will cleanup the connection in the case of a fatal
@@ -280,7 +280,7 @@ SecureSocket::secureWrite(const void* buffer, int size, int& wrote)
     std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
 
     if (m_ssl->m_ssl != nullptr) {
-        LOG(CLOG_DEBUG2 "writing secure socket:%p", this);
+        LOG_DEBUG2("writing secure socket:%p", this);
 
         wrote = SSL_write(m_ssl->m_ssl, buffer, size);
 
@@ -428,15 +428,15 @@ SecureSocket::secureAccept(int socket)
     // set connection socket to SSL state
     SSL_set_fd(m_ssl->m_ssl, socket);
 
-    LOG(CLOG_DEBUG2 "accepting secure socket");
+    LOG_DEBUG2("accepting secure socket");
     int r = SSL_accept(m_ssl->m_ssl);
 
     checkResult(r, secure_accept_retry_);
 
     if (isFatal()) {
         // tell user and sleep so the socket isn't hammered.
-        LOG(CLOG_ERR "failed to accept secure socket");
-        LOG(CLOG_INFO "client connection may not be secure");
+        LOG_ERR("failed to accept secure socket");
+        LOG_INFO("client connection may not be secure");
         m_secureReady = false;
         inputleap::this_thread_sleep(1);
         secure_accept_retry_ = 0;
@@ -448,10 +448,10 @@ SecureSocket::secureAccept(int socket)
         if (security_level_ == ConnectionSecurityLevel::ENCRYPTED_AUTHENTICATED) {
             if (verify_peer_certificate(
                         inputleap::DataDirectories::trusted_clients_ssl_fingerprints_path())) {
-                LOG(CLOG_INFO "accepted secure socket");
+                LOG_INFO("accepted secure socket");
             }
             else {
-                LOG(CLOG_ERR "failed to verify client certificate fingerprint");
+                LOG_ERR("failed to verify client certificate fingerprint");
                 secure_accept_retry_ = 0;
                 disconnect();
                 return -1; // Fingerprint failed, error
@@ -459,7 +459,7 @@ SecureSocket::secureAccept(int socket)
         }
 
         m_secureReady = true;
-        LOG(CLOG_INFO "accepted secure socket");
+        LOG_INFO("accepted secure socket");
         if (CLOG->getFilter() >= kDEBUG1) {
             showSecureCipherInfo();
         }
@@ -469,14 +469,14 @@ SecureSocket::secureAccept(int socket)
 
     // If not fatal and retry is set, not ready, and return retry
     if (secure_accept_retry_ > 0) {
-        LOG(CLOG_DEBUG2 "retry accepting secure socket");
+        LOG_DEBUG2("retry accepting secure socket");
         m_secureReady = false;
         inputleap::this_thread_sleep(s_retryDelay);
         return 0;
     }
 
     // no good state exists here
-    LOG(CLOG_ERR "unexpected state attempting to accept connection");
+    LOG_ERR("unexpected state attempting to accept connection");
     return -1;
 }
 
@@ -485,7 +485,7 @@ SecureSocket::secureConnect(int socket)
 {
     // note that load_certificates acquires ssl_mutex_
     if (!load_certificates(inputleap::DataDirectories::ssl_certificate_path())) {
-        LOG(CLOG_ERR "could not load client certificates");
+        LOG_ERR("could not load client certificates");
         // FIXME: this is fatal error, but we current don't disconnect because whole logic in this
         // function needs to be cleaned up
     }
@@ -497,20 +497,20 @@ SecureSocket::secureConnect(int socket)
     // attach the socket descriptor
     SSL_set_fd(m_ssl->m_ssl, socket);
 
-    LOG(CLOG_DEBUG2 "connecting secure socket");
+    LOG_DEBUG2("connecting secure socket");
     int r = SSL_connect(m_ssl->m_ssl);
 
     checkResult(r, secure_connect_retry_);
 
     if (isFatal()) {
-        LOG(CLOG_ERR "failed to connect secure socket");
+        LOG_ERR("failed to connect secure socket");
         secure_connect_retry_ = 0;
         return -1;
     }
 
     // If we should retry, not ready and return 0
     if (secure_connect_retry_ > 0) {
-        LOG(CLOG_DEBUG2 "retry connect secure socket");
+        LOG_DEBUG2("retry connect secure socket");
         m_secureReady = false;
         inputleap::this_thread_sleep(s_retryDelay);
         return 0;
@@ -520,14 +520,14 @@ SecureSocket::secureConnect(int socket)
     // No error, set ready, process and return ok
     m_secureReady = true;
     if (verify_peer_certificate(inputleap::DataDirectories::trusted_servers_ssl_fingerprints_path())) {
-        LOG(CLOG_INFO "connected to secure socket");
+        LOG_INFO("connected to secure socket");
     }
     else {
-        LOG(CLOG_ERR "failed to verify server certificate fingerprint");
+        LOG_ERR("failed to verify server certificate fingerprint");
         disconnect();
         return -1; // Fingerprint failed, error
     }
-    LOG(CLOG_DEBUG2 "connected secure socket");
+    LOG_DEBUG2("connected secure socket");
     if (CLOG->getFilter() >= kDEBUG1) {
         showSecureCipherInfo();
     }
@@ -554,12 +554,12 @@ SecureSocket::checkResult(int status, int& retry)
     case SSL_ERROR_ZERO_RETURN:
         // connection closed
         isFatal(true);
-        LOG(CLOG_DEBUG "ssl connection closed");
+        LOG_DEBUG("ssl connection closed");
         break;
 
     case SSL_ERROR_WANT_READ:
         retry++;
-        LOG(CLOG_DEBUG2 "want to read, error=%d, attempt=%d", errorCode, retry);
+        LOG_DEBUG2("want to read, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_WANT_WRITE:
@@ -568,24 +568,24 @@ SecureSocket::checkResult(int status, int& retry)
         // m_readable because the socket logic is always readable
         m_writable = true;
         retry++;
-        LOG(CLOG_DEBUG2 "want to write, error=%d, attempt=%d", errorCode, retry);
+        LOG_DEBUG2("want to write, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_WANT_CONNECT:
         retry++;
-        LOG(CLOG_DEBUG2 "want to connect, error=%d, attempt=%d", errorCode, retry);
+        LOG_DEBUG2("want to connect, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_WANT_ACCEPT:
         retry++;
-        LOG(CLOG_DEBUG2 "want to accept, error=%d, attempt=%d", errorCode, retry);
+        LOG_DEBUG2("want to accept, error=%d, attempt=%d", errorCode, retry);
         break;
 
     case SSL_ERROR_SYSCALL:
-        LOG(CLOG_ERR "ssl error occurred (system call failure)");
+        LOG_ERR("ssl error occurred (system call failure)");
         if (ERR_peek_error() == 0) {
             if (status == 0) {
-                LOG(CLOG_ERR "eof violates ssl protocol");
+                LOG_ERR("eof violates ssl protocol");
             }
             else if (status == -1) {
                 // underlying socket I/O reproted an error
@@ -593,7 +593,7 @@ SecureSocket::checkResult(int status, int& retry)
                     ARCH->throwErrorOnSocket(getSocket());
                 }
                 catch (XArchNetwork& e) {
-                    LOG(CLOG_ERR "%s", e.what());
+                    LOG_ERR("%s", e.what());
                 }
             }
         }
@@ -602,12 +602,12 @@ SecureSocket::checkResult(int status, int& retry)
         break;
 
     case SSL_ERROR_SSL:
-        LOG(CLOG_ERR "ssl error occurred (generic failure)");
+        LOG_ERR("ssl error occurred (generic failure)");
         isFatal(true);
         break;
 
     default:
-        LOG(CLOG_ERR "ssl error occurred (unknown failure)");
+        LOG_ERR("ssl error occurred (unknown failure)");
         isFatal(true);
         break;
     }
@@ -622,12 +622,12 @@ SecureSocket::checkResult(int status, int& retry)
 void SecureSocket::showError(const std::string& reason)
 {
     if (!reason.empty()) {
-        LOG(CLOG_ERR "%s", reason.c_str());
+        LOG_ERR("%s", reason.c_str());
     }
 
     std::string error = getError();
     if (!error.empty()) {
-        LOG(CLOG_ERR "%s", error.c_str());
+        LOG_ERR("%s", error.c_str());
     }
 }
 
@@ -665,7 +665,7 @@ bool SecureSocket::verify_peer_certificate(const inputleap::fs::path& fingerprin
     }
     auto cert_free = inputleap::finally([cert]() { X509_free(cert); });
     char* line = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
-    LOG(CLOG_INFO "peer ssl certificate info: %s", line);
+    LOG_INFO("peer ssl certificate info: %s", line);
     OPENSSL_free(line);
 
     // calculate received certificate fingerprint
@@ -676,34 +676,34 @@ bool SecureSocket::verify_peer_certificate(const inputleap::fs::path& fingerprin
         fingerprint_sha256 = inputleap::get_ssl_cert_fingerprint(cert,
                                                                inputleap::FingerprintType::SHA256);
     } catch (const std::exception& e) {
-        LOG(CLOG_ERR "%s", e.what());
+        LOG_ERR("%s", e.what());
         return false;
     }
 
     // note: the GUI parses the following two lines of logs, don't change unnecessarily
-    LOG(CLOG_NOTE "peer fingerprint (SHA1): %s (SHA256): %s",
+    LOG_NOTE("peer fingerprint (SHA1): %s (SHA256): %s",
          inputleap::format_ssl_fingerprint(fingerprint_sha1.data).c_str(),
          inputleap::format_ssl_fingerprint(fingerprint_sha256.data).c_str());
 
     // Provide debug hint as to what file is being used to verify fingerprint trust
-    LOG(CLOG_NOTE "fingerprint_db_path: %s", fingerprint_db_path.u8string().c_str());
+    LOG_NOTE("fingerprint_db_path: %s", fingerprint_db_path.u8string().c_str());
 
     inputleap::FingerprintDatabase db;
     db.read(fingerprint_db_path);
 
     if (!db.fingerprints().empty()) {
-        LOG(CLOG_NOTE "Read %zd fingerprints from: %s", db.fingerprints().size(),
+        LOG_NOTE("Read %zd fingerprints from: %s", db.fingerprints().size(),
              fingerprint_db_path.u8string().c_str());
     } else {
-        LOG(CLOG_NOTE "Could not read fingerprints from: %s",
+        LOG_NOTE("Could not read fingerprints from: %s",
              fingerprint_db_path.u8string().c_str());
     }
 
     if (db.is_trusted(fingerprint_sha256)) {
-        LOG(CLOG_NOTE "Fingerprint matches trusted fingerprint");
+        LOG_NOTE("Fingerprint matches trusted fingerprint");
         return true;
     } else {
-        LOG(CLOG_NOTE "Fingerprint does not match trusted fingerprint");
+        LOG_NOTE("Fingerprint does not match trusted fingerprint");
         return false;
     }
 }
@@ -796,7 +796,7 @@ showCipherStackDesc(STACK_OF(SSL_CIPHER) * stack) {
             msg[pos] = '\0';
         }
 
-        LOG(CLOG_DEBUG1 "%s",msg);
+        LOG_DEBUG1("%s",msg);
     }
 }
 
@@ -808,10 +808,10 @@ SecureSocket::showSecureCipherInfo()
     STACK_OF(SSL_CIPHER) * sStack = SSL_get_ciphers(m_ssl->m_ssl);
 
     if (sStack == nullptr) {
-        LOG(CLOG_DEBUG1 "local cipher list not available");
+        LOG_DEBUG1("local cipher list not available");
     }
     else {
-        LOG(CLOG_DEBUG1 "available local ciphers:");
+        LOG_DEBUG1("available local ciphers:");
         showCipherStackDesc(sStack);
     }
 
@@ -824,10 +824,10 @@ SecureSocket::showSecureCipherInfo()
 	STACK_OF(SSL_CIPHER) * cStack = SSL_get_client_ciphers(m_ssl->m_ssl);
 #endif
 	if (cStack == nullptr) {
-        LOG(CLOG_DEBUG1 "remote cipher list not available");
+        LOG_DEBUG1("remote cipher list not available");
     }
     else {
-        LOG(CLOG_DEBUG1 "available remote ciphers:");
+        LOG_DEBUG1("available remote ciphers:");
         showCipherStackDesc(cStack);
     }
     return;
@@ -836,11 +836,11 @@ SecureSocket::showSecureCipherInfo()
 void
 SecureSocket::showSecureLibInfo()
 {
-    LOG(CLOG_INFO "%s",SSLeay_version(SSLEAY_VERSION));
-    LOG(CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_CFLAGS));
-    LOG(CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_BUILT_ON));
-    LOG(CLOG_DEBUG1 "openSSL : %s",SSLeay_version(SSLEAY_PLATFORM));
-    LOG(CLOG_DEBUG1 "%s",SSLeay_version(SSLEAY_DIR));
+    LOG_INFO("%s",SSLeay_version(SSLEAY_VERSION));
+    LOG_DEBUG1("openSSL : %s",SSLeay_version(SSLEAY_CFLAGS));
+    LOG_DEBUG1("openSSL : %s",SSLeay_version(SSLEAY_BUILT_ON));
+    LOG_DEBUG1("openSSL : %s",SSLeay_version(SSLEAY_PLATFORM));
+    LOG_DEBUG1("%s",SSLeay_version(SSLEAY_DIR));
     return;
 }
 
@@ -854,7 +854,7 @@ SecureSocket::showSecureConnectInfo()
     if (cipher != nullptr) {
         char msg[kMsgSize];
         SSL_CIPHER_description(cipher, msg, kMsgSize);
-        LOG(CLOG_INFO "%s", msg);
+        LOG_INFO("%s", msg);
         }
     return;
 }
@@ -864,7 +864,7 @@ void SecureSocket::handle_tcp_connected(const Event& event)
     (void) event;
 
     if (getSocket() == nullptr) {
-        LOG(CLOG_DEBUG "disregarding stale connect event");
+        LOG_DEBUG("disregarding stale connect event");
         return;
     }
     secureConnect();

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -187,7 +187,7 @@ void SocketMultiplexer::service_thread()
             }
         }
         catch (XArchNetwork& e) {
-            LOG(CLOG_WARN "error in socket multiplexer: %s", e.what());
+            LOG_WARN("error in socket multiplexer: %s", e.what());
             poll_status = 0;
         }
 

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -187,7 +187,7 @@ void SocketMultiplexer::service_thread()
             }
         }
         catch (XArchNetwork& e) {
-            LOG((CLOG_WARN "error in socket multiplexer: %s", e.what()));
+            LOG(CLOG_WARN "error in socket multiplexer: %s", e.what());
             poll_status = 0;
         }
 

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -47,7 +47,7 @@ TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
         throw XSocketCreate(e.what());
     }
 
-    LOG((CLOG_DEBUG "Opening new socket: %p", m_socket));
+    LOG(CLOG_DEBUG "Opening new socket: %p", m_socket);
 
     init();
 }
@@ -60,7 +60,7 @@ TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
 {
     assert(m_socket != nullptr);
 
-    LOG((CLOG_DEBUG "Opening new socket: %p", m_socket));
+    LOG(CLOG_DEBUG "Opening new socket: %p", m_socket);
 
     // socket starts in connected state
     init();
@@ -95,7 +95,7 @@ TCPSocket::bind(const NetworkAddress& addr)
 void
 TCPSocket::close()
 {
-    LOG((CLOG_DEBUG "Closing socket: %p", m_socket));
+    LOG(CLOG_DEBUG "Closing socket: %p", m_socket);
 
     // remove ourself from the multiplexer
     setJob(nullptr);
@@ -117,7 +117,7 @@ TCPSocket::close()
         }
         catch (XArchNetwork& e) {
             // ignore, there's not much we can do
-            LOG((CLOG_WARN "error closing socket: %s", e.what()));
+            LOG(CLOG_WARN "error closing socket: %s", e.what());
         }
     }
 }
@@ -252,7 +252,7 @@ bool
 TCPSocket::isFatal() const
 {
     // TCP sockets aren't ever left in a fatal state.
-    LOG((CLOG_ERR "isFatal() not valid for non-secure connections"));
+    LOG(CLOG_ERR "isFatal() not valid for non-secure connections");
     return false;
 }
 
@@ -574,7 +574,7 @@ MultiplexerJobStatus TCPSocket::serviceConnected(ISocketMultiplexerJob* job,
         }
         catch (XArchNetwork& e) {
             // other write error
-            LOG((CLOG_WARN "error writing socket: %s", e.what()));
+            LOG(CLOG_WARN "error writing socket: %s", e.what());
             onDisconnected();
             sendEvent(EventType::STREAM_OUTPUT_ERROR);
             sendEvent(EventType::SOCKET_DISCONNECTED);
@@ -594,7 +594,7 @@ MultiplexerJobStatus TCPSocket::serviceConnected(ISocketMultiplexerJob* job,
         }
         catch (XArchNetwork& e) {
             // ignore other read error
-            LOG((CLOG_WARN "error reading socket: %s", e.what()));
+            LOG(CLOG_WARN "error reading socket: %s", e.what());
         }
     }
 

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -47,7 +47,7 @@ TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
         throw XSocketCreate(e.what());
     }
 
-    LOG(CLOG_DEBUG "Opening new socket: %p", m_socket);
+    LOG_DEBUG("Opening new socket: %p", m_socket);
 
     init();
 }
@@ -60,7 +60,7 @@ TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
 {
     assert(m_socket != nullptr);
 
-    LOG(CLOG_DEBUG "Opening new socket: %p", m_socket);
+    LOG_DEBUG("Opening new socket: %p", m_socket);
 
     // socket starts in connected state
     init();
@@ -95,7 +95,7 @@ TCPSocket::bind(const NetworkAddress& addr)
 void
 TCPSocket::close()
 {
-    LOG(CLOG_DEBUG "Closing socket: %p", m_socket);
+    LOG_DEBUG("Closing socket: %p", m_socket);
 
     // remove ourself from the multiplexer
     setJob(nullptr);
@@ -117,7 +117,7 @@ TCPSocket::close()
         }
         catch (XArchNetwork& e) {
             // ignore, there's not much we can do
-            LOG(CLOG_WARN "error closing socket: %s", e.what());
+            LOG_WARN("error closing socket: %s", e.what());
         }
     }
 }
@@ -252,7 +252,7 @@ bool
 TCPSocket::isFatal() const
 {
     // TCP sockets aren't ever left in a fatal state.
-    LOG(CLOG_ERR "isFatal() not valid for non-secure connections");
+    LOG_ERR("isFatal() not valid for non-secure connections");
     return false;
 }
 
@@ -574,7 +574,7 @@ MultiplexerJobStatus TCPSocket::serviceConnected(ISocketMultiplexerJob* job,
         }
         catch (XArchNetwork& e) {
             // other write error
-            LOG(CLOG_WARN "error writing socket: %s", e.what());
+            LOG_WARN("error writing socket: %s", e.what());
             onDisconnected();
             sendEvent(EventType::STREAM_OUTPUT_ERROR);
             sendEvent(EventType::SOCKET_DISCONNECTED);
@@ -594,7 +594,7 @@ MultiplexerJobStatus TCPSocket::serviceConnected(ISocketMultiplexerJob* job,
         }
         catch (XArchNetwork& e) {
             // ignore other read error
-            LOG(CLOG_WARN "error reading socket: %s", e.what());
+            LOG_WARN("error reading socket: %s", e.what());
         }
     }
 

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -63,7 +63,7 @@ void EiKeyState::init(int fd, size_t len)
     auto sz = read(fd, buffer.get(), len);
 
     if ((size_t)sz < len) {
-        LOG((CLOG_NOTE "Failed to create XKB context: %s", strerror(errno)));
+        LOG(CLOG_NOTE "Failed to create XKB context: %s", strerror(errno));
         return;
     }
 
@@ -76,7 +76,7 @@ void EiKeyState::init(int fd, size_t len)
                                              XKB_KEYMAP_FORMAT_TEXT_V1,
                                              XKB_KEYMAP_COMPILE_NO_FLAGS);
     if (!keymap) {
-        LOG((CLOG_NOTE "Failed to compile keymap, falling back to defaults"));
+        LOG(CLOG_NOTE "Failed to compile keymap, falling back to defaults");
         // Falling back to layout "us" is a lot more useful than segfaulting
         init_default_keymap();
         return;
@@ -207,7 +207,7 @@ void EiKeyState::getKeyMap(inputleap::KeyMap& keyMap)
                     continue;
 
                 if (nsyms > 1)
-                    LOG((CLOG_WARN " Multiple keysyms per keycode are not supported, keycode %d", keycode));
+                    LOG(CLOG_WARN " Multiple keysyms per keycode are not supported, keycode %d", keycode);
 
                 xkb_keysym_t keysym = syms[0];
                 KeySym sym = static_cast<KeyID>(keysym);
@@ -257,9 +257,9 @@ void EiKeyState::fakeKey(const Keystroke& keystroke)
 {
     switch (keystroke.m_type) {
     case Keystroke::kButton:
-        LOG((CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button,
+        LOG(CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button,
              keystroke.m_data.m_button.m_client,
-             keystroke.m_data.m_button.m_press ? "down" : "up"));
+             keystroke.m_data.m_button.m_press ? "down" : "up");
         screen_->fakeKey(keystroke.m_data.m_button.m_button,
                          keystroke.m_data.m_button.m_press);
         break;
@@ -270,22 +270,22 @@ void EiKeyState::fakeKey(const Keystroke& keystroke)
 
 KeyID EiKeyState::map_key_from_keyval(uint32_t keyval) const
 {
-    LOG((CLOG_DEBUG1 "map_key_from_keyval keyval=%d", keyval));
+    LOG(CLOG_DEBUG1 "map_key_from_keyval keyval=%d", keyval);
 
     // FIXME: That might be a bit crude...?
     xkb_keysym_t xkb_keysym = xkb_state_key_get_one_sym(xkb_state_, keyval);
     KeySym keysym = static_cast<KeySym>(xkb_keysym);
-    LOG((CLOG_DEBUG1 "mapped code=%d to keysym=0x%04lx", keyval, keysym));
+    LOG(CLOG_DEBUG1 "mapped code=%d to keysym=0x%04lx", keyval, keysym);
 
     KeyID keyid = XWindowsUtil::mapKeySymToKeyID(keysym);
-    LOG((CLOG_DEBUG1 "mapped keysym=0x%04lx to keyID=%d", keysym, keyid));
+    LOG(CLOG_DEBUG1 "mapped keysym=0x%04lx to keyID=%d", keysym, keyid);
 
     return keyid;
 }
 
 void EiKeyState::update_xkb_state(uint32_t keyval, bool is_pressed)
 {
-    LOG((CLOG_DEBUG1 "update_xkb_state keyval=%d pressed=%i", keyval, is_pressed));
+    LOG(CLOG_DEBUG1 "update_xkb_state keyval=%d pressed=%i", keyval, is_pressed);
     xkb_state_update_key(xkb_state_, keyval, is_pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
 }
 

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -63,7 +63,7 @@ void EiKeyState::init(int fd, size_t len)
     auto sz = read(fd, buffer.get(), len);
 
     if ((size_t)sz < len) {
-        LOG(CLOG_NOTE "Failed to create XKB context: %s", strerror(errno));
+        LOG_NOTE("Failed to create XKB context: %s", strerror(errno));
         return;
     }
 
@@ -76,7 +76,7 @@ void EiKeyState::init(int fd, size_t len)
                                              XKB_KEYMAP_FORMAT_TEXT_V1,
                                              XKB_KEYMAP_COMPILE_NO_FLAGS);
     if (!keymap) {
-        LOG(CLOG_NOTE "Failed to compile keymap, falling back to defaults");
+        LOG_NOTE("Failed to compile keymap, falling back to defaults");
         // Falling back to layout "us" is a lot more useful than segfaulting
         init_default_keymap();
         return;
@@ -207,7 +207,7 @@ void EiKeyState::getKeyMap(inputleap::KeyMap& keyMap)
                     continue;
 
                 if (nsyms > 1)
-                    LOG(CLOG_WARN " Multiple keysyms per keycode are not supported, keycode %d", keycode);
+                    LOG_WARN(" Multiple keysyms per keycode are not supported, keycode %d", keycode);
 
                 xkb_keysym_t keysym = syms[0];
                 KeySym sym = static_cast<KeyID>(keysym);
@@ -257,7 +257,7 @@ void EiKeyState::fakeKey(const Keystroke& keystroke)
 {
     switch (keystroke.m_type) {
     case Keystroke::kButton:
-        LOG(CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button,
+        LOG_DEBUG1("  %03x (%08x) %s", keystroke.m_data.m_button.m_button,
              keystroke.m_data.m_button.m_client,
              keystroke.m_data.m_button.m_press ? "down" : "up");
         screen_->fakeKey(keystroke.m_data.m_button.m_button,
@@ -270,22 +270,22 @@ void EiKeyState::fakeKey(const Keystroke& keystroke)
 
 KeyID EiKeyState::map_key_from_keyval(uint32_t keyval) const
 {
-    LOG(CLOG_DEBUG1 "map_key_from_keyval keyval=%d", keyval);
+    LOG_DEBUG1("map_key_from_keyval keyval=%d", keyval);
 
     // FIXME: That might be a bit crude...?
     xkb_keysym_t xkb_keysym = xkb_state_key_get_one_sym(xkb_state_, keyval);
     KeySym keysym = static_cast<KeySym>(xkb_keysym);
-    LOG(CLOG_DEBUG1 "mapped code=%d to keysym=0x%04lx", keyval, keysym);
+    LOG_DEBUG1("mapped code=%d to keysym=0x%04lx", keyval, keysym);
 
     KeyID keyid = XWindowsUtil::mapKeySymToKeyID(keysym);
-    LOG(CLOG_DEBUG1 "mapped keysym=0x%04lx to keyID=%d", keysym, keyid);
+    LOG_DEBUG1("mapped keysym=0x%04lx to keyID=%d", keysym, keyid);
 
     return keyid;
 }
 
 void EiKeyState::update_xkb_state(uint32_t keyval, bool is_pressed)
 {
-    LOG(CLOG_DEBUG1 "update_xkb_state keyval=%d pressed=%i", keyval, is_pressed);
+    LOG_DEBUG1("update_xkb_state keyval=%d pressed=%i", keyval, is_pressed);
     xkb_state_update_key(xkb_state_, keyval, is_pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
 }
 

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -76,7 +76,7 @@ EiScreen::EiScreen(bool is_primary, IEventQueue* events, bool use_portal) :
     } else {
         auto rc = ei_setup_backend_socket(ei_, nullptr);
         if (rc != 0) {
-            LOG(CLOG_DEBUG "ei init error: %s", strerror(-rc));
+            LOG_DEBUG("ei init error: %s", strerror(-rc));
             throw std::runtime_error("Failed to init ei context");
         }
     }
@@ -278,7 +278,7 @@ void EiScreen::enter()
     }
 #if HAVE_LIBPORTAL_INPUTCAPTURE
     else {
-        LOG(CLOG_DEBUG "Releasing input capture at (cursor_x_,cursor_y_) = (%i,%i)",
+        LOG_DEBUG("Releasing input capture at (cursor_x_,cursor_y_) = (%i,%i)",
              cursor_x_, cursor_y_);
         portal_input_capture_->release(cursor_x_, cursor_y_);
     }
@@ -364,14 +364,14 @@ void EiScreen::update_shape()
         }
     }
 
-    LOG(CLOG_NOTE "Logical output size: %dx%d@%d.%d", w_, h_, x_, y_);
+    LOG_NOTE("Logical output size: %dx%d@%d.%d", w_, h_, x_, y_);
     cursor_x_ = x_ + w_ / 2;
     cursor_y_ = y_ + h_ / 2;
 }
 
 void EiScreen::add_device(struct ei_device *device)
 {
-    LOG(CLOG_DEBUG "adding device %s", ei_device_get_name(device));
+    LOG_DEBUG("adding device %s", ei_device_get_name(device));
 
     // Noteworthy: EI in principle supports multiple devices with multiple
     // capabilities, so there may be more than one logical pointer (or even
@@ -400,7 +400,7 @@ void EiScreen::add_device(struct ei_device *device)
             // Where the EIS implementation does not tell us, we just default to
             // whatever libxkbcommon thinks is default. At least this way we can
             // influence with env vars what we get
-            LOG(CLOG_WARN "keyboard device %s does not have a keymap, we are guessing", ei_device_get_name(device));
+            LOG_WARN("keyboard device %s does not have a keymap, we are guessing", ei_device_get_name(device));
             key_state_->init_default_keymap();
         }
         key_state_->updateKeyMap();
@@ -420,7 +420,7 @@ void EiScreen::add_device(struct ei_device *device)
 
 void EiScreen::remove_device(struct ei_device *device)
 {
-    LOG(CLOG_DEBUG "removing device %s", ei_device_get_name(device));
+    LOG_DEBUG("removing device %s", ei_device_get_name(device));
 
     if (device == ei_pointer_)
         ei_pointer_ = ei_device_unref(ei_pointer_);
@@ -479,7 +479,7 @@ void EiScreen::on_key_event(ei_event* event)
     key_state_->update_xkb_state(keyval, pressed);
     KeyModifierMask mask = key_state_->pollActiveModifiers();
 
-    LOG(CLOG_DEBUG1 "event: Key %s keycode=%d keyid=%d mask=0x%x", pressed ? "press" : "release", keycode, keyid, mask);
+    LOG_DEBUG1("event: Key %s keycode=%d keyid=%d mask=0x%x", pressed ? "press" : "release", keycode, keyid, mask);
 
     if (keyid != kKeyNone) {
         key_state_->sendKeyEvent(get_event_target(), pressed, false, keyid,
@@ -489,17 +489,17 @@ void EiScreen::on_key_event(ei_event* event)
 
 void EiScreen::on_button_event(ei_event* event)
 {
-    LOG(CLOG_DEBUG "on_button_event");
+    LOG_DEBUG("on_button_event");
     assert(is_primary_);
 
     ButtonID button = map_button_from_evdev(event);
     bool pressed = ei_event_button_get_is_press(event);
     KeyModifierMask mask = key_state_->pollActiveModifiers();
 
-    LOG(CLOG_DEBUG1 "event: Button %s button=%d mask=0x%x", pressed ? "press" : "release", button, mask);
+    LOG_DEBUG1("event: Button %s button=%d mask=0x%x", pressed ? "press" : "release", button, mask);
 
     if (button == kButtonNone) {
-        LOG(CLOG_DEBUG "onButtonEvent: button not recognized");
+        LOG_DEBUG("onButtonEvent: button not recognized");
         return;
     }
 
@@ -525,7 +525,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     double dy = ei_event_scroll_get_dy(event);
     struct ei_device *device = ei_event_get_device(event);
 
-    LOG(CLOG_DEBUG1 "event: Scroll (%.2f, %.2f)", dx, dy);
+    LOG_DEBUG1("event: Scroll (%.2f, %.2f)", dx, dy);
 
     struct ScrollRemainder *remainder = static_cast<struct ScrollRemainder*>(ei_device_get_user_data(device));
     if (!remainder) {
@@ -536,7 +536,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     dx += remainder->x;
     dy += remainder->y;
 
-    LOG(CLOG_DEBUG1 "event: after remainder (%.2f, %.2f)", dx, dy);
+    LOG_DEBUG1("event: after remainder (%.2f, %.2f)", dx, dy);
 
     double x, y;
     double rx = modf(dx, &x);
@@ -545,7 +545,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     assert(!std::isnan(x) && !std::isinf(x));
     assert(!std::isnan(y) && !std::isinf(y));
 
-    LOG(CLOG_DEBUG1 "event: xy is (%.2f, %.2f)", x, y);
+    LOG_DEBUG1("event: xy is (%.2f, %.2f)", x, y);
 
     // libEI and InputLeap seem to use opposite directions, so we have
     // to send the opposite of the value reported by EI if we want to
@@ -557,7 +557,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
 
     remainder->x = rx;
     remainder->y = ry;
-    LOG(CLOG_DEBUG1 "event: remainder is (%.2f, %.2f)", x, y);
+    LOG_DEBUG1("event: remainder is (%.2f, %.2f)", x, y);
 }
 
 void EiScreen::on_pointer_scroll_discrete_event(ei_event* event)
@@ -571,7 +571,7 @@ void EiScreen::on_pointer_scroll_discrete_event(ei_event* event)
     std::int32_t dx = ei_event_scroll_get_discrete_dx(event);
     std::int32_t dy = ei_event_scroll_get_discrete_dy(event);
 
-    LOG(CLOG_DEBUG1 "event: Scroll discrete (%d, %d)", dx, dy);
+    LOG_DEBUG1("event: Scroll discrete (%d, %d)", dx, dy);
 
     // libEI and InputLeap seem to use opposite directions, so we have
     // to send the opposite of the value reported by EI if we want to
@@ -582,14 +582,14 @@ void EiScreen::on_pointer_scroll_discrete_event(ei_event* event)
 
 void EiScreen::on_motion_event(ei_event* event)
 {
-    LOG(CLOG_DEBUG "on_motion_event");
+    LOG_DEBUG("on_motion_event");
     assert(is_primary_);
 
     double dx = ei_event_pointer_get_dx(event);
     double dy = ei_event_pointer_get_dy(event);
 
     if (is_on_screen_) {
-        LOG(CLOG_DEBUG "on_motion_event on primary at (cursor_x_,cursor_y_)=(%i,%i)",
+        LOG_DEBUG("on_motion_event on primary at (cursor_x_,cursor_y_)=(%i,%i)",
              cursor_x_, cursor_y_);
         send_event(EventType::PRIMARY_SCREEN_MOTION_ON_PRIMARY,
                    create_event_data<MotionInfo>(MotionInfo{cursor_x_, cursor_y_}));
@@ -600,7 +600,7 @@ void EiScreen::on_motion_event(ei_event* event)
          }
 #endif
     } else {
-        LOG(CLOG_DEBUG "on_motion_event on secondary at (dx,dy)=(%.2f,%.2f)", dx, dy);
+        LOG_DEBUG("on_motion_event on secondary at (dx,dy)=(%.2f,%.2f)", dx, dy);
         send_event(EventType::PRIMARY_SCREEN_MOTION_ON_SECONDARY,
                    create_event_data<MotionInfo>(MotionInfo{static_cast<std::int32_t>(dx),
                                                             static_cast<std::int32_t>(dy)}));
@@ -615,11 +615,11 @@ void EiScreen::on_abs_motion_event(ei_event* event)
 void EiScreen::handle_connected_to_eis_event(const Event& event)
 {
     int fd = event.get_data_as<int>();
-    LOG(CLOG_DEBUG "We have an EIS connection! fd is %d", fd);
+    LOG_DEBUG("We have an EIS connection! fd is %d", fd);
 
     auto rc = ei_setup_backend_fd(ei_, fd);
     if (rc != 0) {
-        LOG(CLOG_NOTE "Failed to set up ei: %s", strerror(-rc));
+        LOG_NOTE("Failed to set up ei: %s", strerror(-rc));
     }
 }
 
@@ -639,7 +639,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
 
         switch (type) {
             case EI_EVENT_CONNECT:
-                LOG(CLOG_DEBUG "connected to EIS");
+                LOG_DEBUG("connected to EIS");
                 break;
             case EI_EVENT_SEAT_ADDED:
                 if (!ei_seat_) {
@@ -650,7 +650,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
                                               EI_DEVICE_CAP_BUTTON,
                                               EI_DEVICE_CAP_SCROLL,
                                               nullptr);
-                    LOG(CLOG_DEBUG "using seat %s", ei_seat_get_name(ei_seat_));
+                    LOG_DEBUG("using seat %s", ei_seat_get_name(ei_seat_));
                     // we don't care about touch
                 }
                 break;
@@ -658,7 +658,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
                 if (seat == ei_seat_) {
                     add_device(device);
                 } else {
-                    LOG(CLOG_INFO "seat %s is ignored", ei_seat_get_name(ei_seat_));
+                    LOG_INFO("seat %s is ignored", ei_seat_get_name(ei_seat_));
                 }
                 break;
             case EI_EVENT_DEVICE_REMOVED:
@@ -672,10 +672,10 @@ void EiScreen::handle_system_event(const Event& sysevent)
             case EI_EVENT_DISCONNECT:
                 throw std::runtime_error("Oops, EIS didn't like us");
             case EI_EVENT_DEVICE_PAUSED:
-                LOG(CLOG_DEBUG "device %s is paused", ei_device_get_name(device));
+                LOG_DEBUG("device %s is paused", ei_device_get_name(device));
                 break;
             case EI_EVENT_DEVICE_RESUMED:
-                LOG(CLOG_DEBUG "device %s is resumed", ei_device_get_name(device));
+                LOG_DEBUG("device %s is resumed", ei_device_get_name(device));
                 break;
             case EI_EVENT_KEYBOARD_MODIFIERS:
                 // FIXME
@@ -685,10 +685,10 @@ void EiScreen::handle_system_event(const Event& sysevent)
             case EI_EVENT_FRAME:
                 break;
             case EI_EVENT_DEVICE_START_EMULATING:
-                LOG(CLOG_DEBUG "device %s starts emulating", ei_device_get_name(device));
+                LOG_DEBUG("device %s starts emulating", ei_device_get_name(device));
                 break;
             case EI_EVENT_DEVICE_STOP_EMULATING:
-                LOG(CLOG_DEBUG "device %s stops emulating", ei_device_get_name(device));
+                LOG_DEBUG("device %s stops emulating", ei_device_get_name(device));
                 break;
             case EI_EVENT_KEYBOARD_KEY:
                 on_key_event(event);

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -76,7 +76,7 @@ EiScreen::EiScreen(bool is_primary, IEventQueue* events, bool use_portal) :
     } else {
         auto rc = ei_setup_backend_socket(ei_, nullptr);
         if (rc != 0) {
-            LOG((CLOG_DEBUG "ei init error: %s", strerror(-rc)));
+            LOG(CLOG_DEBUG "ei init error: %s", strerror(-rc));
             throw std::runtime_error("Failed to init ei context");
         }
     }
@@ -278,8 +278,8 @@ void EiScreen::enter()
     }
 #if HAVE_LIBPORTAL_INPUTCAPTURE
     else {
-        LOG((CLOG_DEBUG "Releasing input capture at (cursor_x_,cursor_y_) = (%i,%i)",
-             cursor_x_, cursor_y_));
+        LOG(CLOG_DEBUG "Releasing input capture at (cursor_x_,cursor_y_) = (%i,%i)",
+             cursor_x_, cursor_y_);
         portal_input_capture_->release(cursor_x_, cursor_y_);
     }
 #endif
@@ -364,14 +364,14 @@ void EiScreen::update_shape()
         }
     }
 
-    LOG((CLOG_NOTE "Logical output size: %dx%d@%d.%d", w_, h_, x_, y_));
+    LOG(CLOG_NOTE "Logical output size: %dx%d@%d.%d", w_, h_, x_, y_);
     cursor_x_ = x_ + w_ / 2;
     cursor_y_ = y_ + h_ / 2;
 }
 
 void EiScreen::add_device(struct ei_device *device)
 {
-    LOG((CLOG_DEBUG "adding device %s", ei_device_get_name(device)));
+    LOG(CLOG_DEBUG "adding device %s", ei_device_get_name(device));
 
     // Noteworthy: EI in principle supports multiple devices with multiple
     // capabilities, so there may be more than one logical pointer (or even
@@ -400,7 +400,7 @@ void EiScreen::add_device(struct ei_device *device)
             // Where the EIS implementation does not tell us, we just default to
             // whatever libxkbcommon thinks is default. At least this way we can
             // influence with env vars what we get
-            LOG((CLOG_WARN "keyboard device %s does not have a keymap, we are guessing", ei_device_get_name(device)));
+            LOG(CLOG_WARN "keyboard device %s does not have a keymap, we are guessing", ei_device_get_name(device));
             key_state_->init_default_keymap();
         }
         key_state_->updateKeyMap();
@@ -420,7 +420,7 @@ void EiScreen::add_device(struct ei_device *device)
 
 void EiScreen::remove_device(struct ei_device *device)
 {
-    LOG((CLOG_DEBUG "removing device %s", ei_device_get_name(device)));
+    LOG(CLOG_DEBUG "removing device %s", ei_device_get_name(device));
 
     if (device == ei_pointer_)
         ei_pointer_ = ei_device_unref(ei_pointer_);
@@ -479,7 +479,7 @@ void EiScreen::on_key_event(ei_event* event)
     key_state_->update_xkb_state(keyval, pressed);
     KeyModifierMask mask = key_state_->pollActiveModifiers();
 
-    LOG((CLOG_DEBUG1 "event: Key %s keycode=%d keyid=%d mask=0x%x", pressed ? "press" : "release", keycode, keyid, mask));
+    LOG(CLOG_DEBUG1 "event: Key %s keycode=%d keyid=%d mask=0x%x", pressed ? "press" : "release", keycode, keyid, mask);
 
     if (keyid != kKeyNone) {
         key_state_->sendKeyEvent(get_event_target(), pressed, false, keyid,
@@ -489,17 +489,17 @@ void EiScreen::on_key_event(ei_event* event)
 
 void EiScreen::on_button_event(ei_event* event)
 {
-    LOG((CLOG_DEBUG "on_button_event"));
+    LOG(CLOG_DEBUG "on_button_event");
     assert(is_primary_);
 
     ButtonID button = map_button_from_evdev(event);
     bool pressed = ei_event_button_get_is_press(event);
     KeyModifierMask mask = key_state_->pollActiveModifiers();
 
-    LOG((CLOG_DEBUG1 "event: Button %s button=%d mask=0x%x", pressed ? "press" : "release", button, mask));
+    LOG(CLOG_DEBUG1 "event: Button %s button=%d mask=0x%x", pressed ? "press" : "release", button, mask);
 
     if (button == kButtonNone) {
-        LOG((CLOG_DEBUG "onButtonEvent: button not recognized"));
+        LOG(CLOG_DEBUG "onButtonEvent: button not recognized");
         return;
     }
 
@@ -525,7 +525,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     double dy = ei_event_scroll_get_dy(event);
     struct ei_device *device = ei_event_get_device(event);
 
-    LOG((CLOG_DEBUG1 "event: Scroll (%.2f, %.2f)", dx, dy));
+    LOG(CLOG_DEBUG1 "event: Scroll (%.2f, %.2f)", dx, dy);
 
     struct ScrollRemainder *remainder = static_cast<struct ScrollRemainder*>(ei_device_get_user_data(device));
     if (!remainder) {
@@ -536,7 +536,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     dx += remainder->x;
     dy += remainder->y;
 
-    LOG((CLOG_DEBUG1 "event: after remainder (%.2f, %.2f)", dx, dy));
+    LOG(CLOG_DEBUG1 "event: after remainder (%.2f, %.2f)", dx, dy);
 
     double x, y;
     double rx = modf(dx, &x);
@@ -545,7 +545,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
     assert(!std::isnan(x) && !std::isinf(x));
     assert(!std::isnan(y) && !std::isinf(y));
 
-    LOG((CLOG_DEBUG1 "event: xy is (%.2f, %.2f)", x, y));
+    LOG(CLOG_DEBUG1 "event: xy is (%.2f, %.2f)", x, y);
 
     // libEI and InputLeap seem to use opposite directions, so we have
     // to send the opposite of the value reported by EI if we want to
@@ -557,7 +557,7 @@ void EiScreen::on_pointer_scroll_event(ei_event* event)
 
     remainder->x = rx;
     remainder->y = ry;
-    LOG((CLOG_DEBUG1 "event: remainder is (%.2f, %.2f)", x, y));
+    LOG(CLOG_DEBUG1 "event: remainder is (%.2f, %.2f)", x, y);
 }
 
 void EiScreen::on_pointer_scroll_discrete_event(ei_event* event)
@@ -571,7 +571,7 @@ void EiScreen::on_pointer_scroll_discrete_event(ei_event* event)
     std::int32_t dx = ei_event_scroll_get_discrete_dx(event);
     std::int32_t dy = ei_event_scroll_get_discrete_dy(event);
 
-    LOG((CLOG_DEBUG1 "event: Scroll discrete (%d, %d)", dx, dy));
+    LOG(CLOG_DEBUG1 "event: Scroll discrete (%d, %d)", dx, dy);
 
     // libEI and InputLeap seem to use opposite directions, so we have
     // to send the opposite of the value reported by EI if we want to
@@ -582,15 +582,15 @@ void EiScreen::on_pointer_scroll_discrete_event(ei_event* event)
 
 void EiScreen::on_motion_event(ei_event* event)
 {
-    LOG((CLOG_DEBUG "on_motion_event"));
+    LOG(CLOG_DEBUG "on_motion_event");
     assert(is_primary_);
 
     double dx = ei_event_pointer_get_dx(event);
     double dy = ei_event_pointer_get_dy(event);
 
     if (is_on_screen_) {
-        LOG((CLOG_DEBUG "on_motion_event on primary at (cursor_x_,cursor_y_)=(%i,%i)",
-             cursor_x_, cursor_y_));
+        LOG(CLOG_DEBUG "on_motion_event on primary at (cursor_x_,cursor_y_)=(%i,%i)",
+             cursor_x_, cursor_y_);
         send_event(EventType::PRIMARY_SCREEN_MOTION_ON_PRIMARY,
                    create_event_data<MotionInfo>(MotionInfo{cursor_x_, cursor_y_}));
 
@@ -600,7 +600,7 @@ void EiScreen::on_motion_event(ei_event* event)
          }
 #endif
     } else {
-        LOG((CLOG_DEBUG "on_motion_event on secondary at (dx,dy)=(%.2f,%.2f)", dx, dy));
+        LOG(CLOG_DEBUG "on_motion_event on secondary at (dx,dy)=(%.2f,%.2f)", dx, dy);
         send_event(EventType::PRIMARY_SCREEN_MOTION_ON_SECONDARY,
                    create_event_data<MotionInfo>(MotionInfo{static_cast<std::int32_t>(dx),
                                                             static_cast<std::int32_t>(dy)}));
@@ -615,11 +615,11 @@ void EiScreen::on_abs_motion_event(ei_event* event)
 void EiScreen::handle_connected_to_eis_event(const Event& event)
 {
     int fd = event.get_data_as<int>();
-    LOG((CLOG_DEBUG "We have an EIS connection! fd is %d", fd));
+    LOG(CLOG_DEBUG "We have an EIS connection! fd is %d", fd);
 
     auto rc = ei_setup_backend_fd(ei_, fd);
     if (rc != 0) {
-        LOG((CLOG_NOTE "Failed to set up ei: %s", strerror(-rc)));
+        LOG(CLOG_NOTE "Failed to set up ei: %s", strerror(-rc));
     }
 }
 
@@ -639,7 +639,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
 
         switch (type) {
             case EI_EVENT_CONNECT:
-                LOG((CLOG_DEBUG "connected to EIS"));
+                LOG(CLOG_DEBUG "connected to EIS");
                 break;
             case EI_EVENT_SEAT_ADDED:
                 if (!ei_seat_) {
@@ -650,7 +650,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
                                               EI_DEVICE_CAP_BUTTON,
                                               EI_DEVICE_CAP_SCROLL,
                                               nullptr);
-                    LOG((CLOG_DEBUG "using seat %s", ei_seat_get_name(ei_seat_)));
+                    LOG(CLOG_DEBUG "using seat %s", ei_seat_get_name(ei_seat_));
                     // we don't care about touch
                 }
                 break;
@@ -658,7 +658,7 @@ void EiScreen::handle_system_event(const Event& sysevent)
                 if (seat == ei_seat_) {
                     add_device(device);
                 } else {
-                    LOG((CLOG_INFO "seat %s is ignored", ei_seat_get_name(ei_seat_)));
+                    LOG(CLOG_INFO "seat %s is ignored", ei_seat_get_name(ei_seat_));
                 }
                 break;
             case EI_EVENT_DEVICE_REMOVED:
@@ -672,10 +672,10 @@ void EiScreen::handle_system_event(const Event& sysevent)
             case EI_EVENT_DISCONNECT:
                 throw std::runtime_error("Oops, EIS didn't like us");
             case EI_EVENT_DEVICE_PAUSED:
-                LOG((CLOG_DEBUG "device %s is paused", ei_device_get_name(device)));
+                LOG(CLOG_DEBUG "device %s is paused", ei_device_get_name(device));
                 break;
             case EI_EVENT_DEVICE_RESUMED:
-                LOG((CLOG_DEBUG "device %s is resumed", ei_device_get_name(device)));
+                LOG(CLOG_DEBUG "device %s is resumed", ei_device_get_name(device));
                 break;
             case EI_EVENT_KEYBOARD_MODIFIERS:
                 // FIXME
@@ -685,10 +685,10 @@ void EiScreen::handle_system_event(const Event& sysevent)
             case EI_EVENT_FRAME:
                 break;
             case EI_EVENT_DEVICE_START_EMULATING:
-                LOG((CLOG_DEBUG "device %s starts emulating", ei_device_get_name(device)));
+                LOG(CLOG_DEBUG "device %s starts emulating", ei_device_get_name(device));
                 break;
             case EI_EVENT_DEVICE_STOP_EMULATING:
-                LOG((CLOG_DEBUG "device %s stops emulating", ei_device_get_name(device)));
+                LOG(CLOG_DEBUG "device %s stops emulating", ei_device_get_name(device));
                 break;
             case EI_EVENT_KEYBOARD_KEY:
                 on_key_event(event);

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -64,13 +64,13 @@ MSWindowsClipboard::setFacade(IMSWindowsClipboardFacade& facade)
 bool
 MSWindowsClipboard::emptyUnowned()
 {
-    LOG(CLOG_DEBUG "empty clipboard");
+    LOG_DEBUG("empty clipboard");
 
     // empty the clipboard (and take ownership)
     if (!EmptyClipboard()) {
         // unable to cause this in integ tests, but this error has never
         // actually been reported by users.
-        LOG(CLOG_DEBUG "failed to grab clipboard");
+        LOG_DEBUG("failed to grab clipboard");
         return false;
     }
 
@@ -87,7 +87,7 @@ MSWindowsClipboard::empty()
     // mark clipboard as being owned by InputLeap
     HGLOBAL data = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, 1);
     if (nullptr == SetClipboardData(getOwnershipFormat(), data)) {
-        LOG(CLOG_DEBUG "failed to set clipboard data");
+        LOG_DEBUG("failed to set clipboard data");
         GlobalFree(data);
         return false;
     }
@@ -98,7 +98,7 @@ MSWindowsClipboard::empty()
 void
 MSWindowsClipboard::add(EFormat format, const std::string& data)
 {
-    LOG(CLOG_DEBUG "add %d bytes to clipboard format: %d", data.size(), format);
+    LOG_DEBUG("add %d bytes to clipboard format: %d", data.size(), format);
 
     // convert data to win32 form
     for (ConverterList::const_iterator index = m_converters.begin();
@@ -119,14 +119,14 @@ MSWindowsClipboard::add(EFormat format, const std::string& data)
 bool
 MSWindowsClipboard::open(Time time) const
 {
-    LOG(CLOG_DEBUG "open clipboard");
+    LOG_DEBUG("open clipboard");
 
     if (!OpenClipboard(m_window)) {
         // unable to cause this in integ tests; but this can happen!
         // * http://symless.com/pm/issues/86
         // * http://symless.com/pm/issues/1256
         // logging improved to see if we can catch more info next time.
-        LOG(CLOG_WARN "failed to open clipboard: %d", GetLastError());
+        LOG_WARN("failed to open clipboard: %d", GetLastError());
         return false;
     }
 
@@ -138,7 +138,7 @@ MSWindowsClipboard::open(Time time) const
 void
 MSWindowsClipboard::close() const
 {
-    LOG(CLOG_DEBUG "close clipboard");
+    LOG_DEBUG("close clipboard");
     CloseClipboard();
 }
 
@@ -179,7 +179,7 @@ std::string MSWindowsClipboard::get(EFormat format) const
 
     // if no converter then we don't recognize any formats
     if (converter == nullptr) {
-        LOG(CLOG_WARN "no converter for format %d", format);
+        LOG_WARN("no converter for format %d", format);
         return {};
     }
 

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -64,13 +64,13 @@ MSWindowsClipboard::setFacade(IMSWindowsClipboardFacade& facade)
 bool
 MSWindowsClipboard::emptyUnowned()
 {
-    LOG((CLOG_DEBUG "empty clipboard"));
+    LOG(CLOG_DEBUG "empty clipboard");
 
     // empty the clipboard (and take ownership)
     if (!EmptyClipboard()) {
         // unable to cause this in integ tests, but this error has never
         // actually been reported by users.
-        LOG((CLOG_DEBUG "failed to grab clipboard"));
+        LOG(CLOG_DEBUG "failed to grab clipboard");
         return false;
     }
 
@@ -87,7 +87,7 @@ MSWindowsClipboard::empty()
     // mark clipboard as being owned by InputLeap
     HGLOBAL data = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, 1);
     if (nullptr == SetClipboardData(getOwnershipFormat(), data)) {
-        LOG((CLOG_DEBUG "failed to set clipboard data"));
+        LOG(CLOG_DEBUG "failed to set clipboard data");
         GlobalFree(data);
         return false;
     }
@@ -98,7 +98,7 @@ MSWindowsClipboard::empty()
 void
 MSWindowsClipboard::add(EFormat format, const std::string& data)
 {
-    LOG((CLOG_DEBUG "add %d bytes to clipboard format: %d", data.size(), format));
+    LOG(CLOG_DEBUG "add %d bytes to clipboard format: %d", data.size(), format);
 
     // convert data to win32 form
     for (ConverterList::const_iterator index = m_converters.begin();
@@ -119,14 +119,14 @@ MSWindowsClipboard::add(EFormat format, const std::string& data)
 bool
 MSWindowsClipboard::open(Time time) const
 {
-    LOG((CLOG_DEBUG "open clipboard"));
+    LOG(CLOG_DEBUG "open clipboard");
 
     if (!OpenClipboard(m_window)) {
         // unable to cause this in integ tests; but this can happen!
         // * http://symless.com/pm/issues/86
         // * http://symless.com/pm/issues/1256
         // logging improved to see if we can catch more info next time.
-        LOG((CLOG_WARN "failed to open clipboard: %d", GetLastError()));
+        LOG(CLOG_WARN "failed to open clipboard: %d", GetLastError());
         return false;
     }
 
@@ -138,7 +138,7 @@ MSWindowsClipboard::open(Time time) const
 void
 MSWindowsClipboard::close() const
 {
-    LOG((CLOG_DEBUG "close clipboard"));
+    LOG(CLOG_DEBUG "close clipboard");
     CloseClipboard();
 }
 
@@ -179,7 +179,7 @@ std::string MSWindowsClipboard::get(EFormat format) const
 
     // if no converter then we don't recognize any formats
     if (converter == nullptr) {
-        LOG((CLOG_WARN "no converter for format %d", format));
+        LOG(CLOG_WARN "no converter for format %d", format);
         return {};
     }
 

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -75,7 +75,7 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
 
     // check image type
     const BITMAPINFO* bitmap = static_cast<const BITMAPINFO*>(src);
-    LOG(CLOG_INFO "bitmap: %dx%d %d", bitmap->bmiHeader.biWidth, bitmap->bmiHeader.biHeight, (int)bitmap->bmiHeader.biBitCount);
+    LOG_INFO("bitmap: %dx%d %d", bitmap->bmiHeader.biWidth, bitmap->bmiHeader.biHeight, (int)bitmap->bmiHeader.biBitCount);
     if (bitmap->bmiHeader.biPlanes == 1 &&
         (bitmap->bmiHeader.biBitCount == 24 ||
         bitmap->bmiHeader.biBitCount == 32) &&
@@ -87,7 +87,7 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
     }
 
     // create a destination DIB section
-    LOG(CLOG_INFO "convert image from: depth=%d comp=%d", bitmap->bmiHeader.biBitCount, bitmap->bmiHeader.biCompression);
+    LOG_INFO("convert image from: depth=%d comp=%d", bitmap->bmiHeader.biBitCount, bitmap->bmiHeader.biCompression);
     void* raw;
     BITMAPINFOHEADER info;
     LONG w               = bitmap->bmiHeader.biWidth;

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -75,7 +75,7 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
 
     // check image type
     const BITMAPINFO* bitmap = static_cast<const BITMAPINFO*>(src);
-    LOG((CLOG_INFO "bitmap: %dx%d %d", bitmap->bmiHeader.biWidth, bitmap->bmiHeader.biHeight, (int)bitmap->bmiHeader.biBitCount));
+    LOG(CLOG_INFO "bitmap: %dx%d %d", bitmap->bmiHeader.biWidth, bitmap->bmiHeader.biHeight, (int)bitmap->bmiHeader.biBitCount);
     if (bitmap->bmiHeader.biPlanes == 1 &&
         (bitmap->bmiHeader.biBitCount == 24 ||
         bitmap->bmiHeader.biBitCount == 32) &&
@@ -87,7 +87,7 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
     }
 
     // create a destination DIB section
-    LOG((CLOG_INFO "convert image from: depth=%d comp=%d", bitmap->bmiHeader.biBitCount, bitmap->bmiHeader.biCompression));
+    LOG(CLOG_INFO "convert image from: depth=%d comp=%d", bitmap->bmiHeader.biBitCount, bitmap->bmiHeader.biCompression);
     void* raw;
     BITMAPINFOHEADER info;
     LONG w               = bitmap->bmiHeader.biWidth;

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -186,7 +186,7 @@ MSWindowsDesks::setOptions(const OptionsList& options)
     for (std::uint32_t i = 0, n = (std::uint32_t)options.size(); i < n; i += 2) {
         if (options[i] == kOptionWin32KeepForeground) {
             m_leaveForegroundOption = (options[i + 1] != 0);
-            LOG((CLOG_DEBUG1 "%s the foreground window", m_leaveForegroundOption ? "don\'t grab" : "grab"));
+            LOG(CLOG_DEBUG1 "%s the foreground window", m_leaveForegroundOption ? "don\'t grab" : "grab");
         }
     }
 }
@@ -406,7 +406,7 @@ MSWindowsDesks::createWindow(ATOM windowClass, const char* name) const
                                 MSWindowsScreen::getWindowInstance(),
                                 nullptr);
     if (window == nullptr) {
-        LOG((CLOG_ERR "failed to create window: %d", GetLastError()));
+        LOG(CLOG_ERR "failed to create window: %d", GetLastError());
         throw XScreenOpenFailure();
     }
     return window;
@@ -583,7 +583,7 @@ MSWindowsDesks::deskLeave(Desk* desk, HKL keyLayout)
         SetCapture(desk->m_window);
 
         // warp the mouse to the cursor center
-        LOG((CLOG_DEBUG2 "warping cursor to center: %+d,%+d", m_xCenter, m_yCenter));
+        LOG(CLOG_DEBUG2 "warping cursor to center: %+d,%+d", m_xCenter, m_yCenter);
         deskMouseMove(m_xCenter, m_yCenter);
     }
 }
@@ -603,11 +603,11 @@ void MSWindowsDesks::desk_thread(Desk* desk)
         // create a window.  we use this window to hide the cursor.
         try {
             desk->m_window = createWindow(m_deskClass, "InputLeapDesk");
-            LOG((CLOG_DEBUG "desk %s window is 0x%08x", desk->m_name.c_str(), desk->m_window));
+            LOG(CLOG_DEBUG "desk %s window is 0x%08x", desk->m_name.c_str(), desk->m_window);
         }
         catch (...) {
             // ignore
-            LOG((CLOG_DEBUG "can't create desk window for %s", desk->m_name.c_str()));
+            LOG(CLOG_DEBUG "can't create desk window for %s", desk->m_name.c_str());
         }
     }
 
@@ -634,7 +634,7 @@ void MSWindowsDesks::desk_thread(Desk* desk)
                 }
                 if (!MSWindowsHook::install()) {
                     // we won't work on this desk
-                    LOG((CLOG_DEBUG "Cannot hook on this desk"));
+                    LOG(CLOG_DEBUG "Cannot hook on this desk");
                 }
                 // a window on the primary screen with low-level hooks
                 // should never activate.
@@ -779,7 +779,7 @@ MSWindowsDesks::checkDesk()
     // if we are told to shut down on desk switch, and this is not the
     // first switch, then shut down.
     if (m_stopOnDeskSwitch && m_activeDesk != nullptr && name != m_activeDeskName) {
-        LOG((CLOG_DEBUG "shutting down because of desk switch to \"%s\"", name.c_str()));
+        LOG(CLOG_DEBUG "shutting down because of desk switch to \"%s\"", name.c_str());
         m_events->add_event(EventType::QUIT);
         return;
     }
@@ -800,16 +800,16 @@ MSWindowsDesks::checkDesk()
         // from an inaccessible desktop so when we switch from an
         // inaccessible desktop to an accessible one we have to
         // update the keyboard state.
-        LOG((CLOG_DEBUG "switched to desk \"%s\"", name.c_str()));
+        LOG(CLOG_DEBUG "switched to desk \"%s\"", name.c_str());
         bool syncKeys = false;
         bool isAccessible = isDeskAccessible(desk);
         if (isDeskAccessible(m_activeDesk) != isAccessible) {
             if (isAccessible) {
-                LOG((CLOG_DEBUG "desktop is now accessible"));
+                LOG(CLOG_DEBUG "desktop is now accessible");
                 syncKeys = true;
             }
             else {
-                LOG((CLOG_DEBUG "desktop is now inaccessible"));
+                LOG(CLOG_DEBUG "desktop is now inaccessible");
             }
         }
 

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -186,7 +186,7 @@ MSWindowsDesks::setOptions(const OptionsList& options)
     for (std::uint32_t i = 0, n = (std::uint32_t)options.size(); i < n; i += 2) {
         if (options[i] == kOptionWin32KeepForeground) {
             m_leaveForegroundOption = (options[i + 1] != 0);
-            LOG(CLOG_DEBUG1 "%s the foreground window", m_leaveForegroundOption ? "don\'t grab" : "grab");
+            LOG_DEBUG1("%s the foreground window", m_leaveForegroundOption ? "don\'t grab" : "grab");
         }
     }
 }
@@ -406,7 +406,7 @@ MSWindowsDesks::createWindow(ATOM windowClass, const char* name) const
                                 MSWindowsScreen::getWindowInstance(),
                                 nullptr);
     if (window == nullptr) {
-        LOG(CLOG_ERR "failed to create window: %d", GetLastError());
+        LOG_ERR("failed to create window: %d", GetLastError());
         throw XScreenOpenFailure();
     }
     return window;
@@ -583,7 +583,7 @@ MSWindowsDesks::deskLeave(Desk* desk, HKL keyLayout)
         SetCapture(desk->m_window);
 
         // warp the mouse to the cursor center
-        LOG(CLOG_DEBUG2 "warping cursor to center: %+d,%+d", m_xCenter, m_yCenter);
+        LOG_DEBUG2("warping cursor to center: %+d,%+d", m_xCenter, m_yCenter);
         deskMouseMove(m_xCenter, m_yCenter);
     }
 }
@@ -603,11 +603,11 @@ void MSWindowsDesks::desk_thread(Desk* desk)
         // create a window.  we use this window to hide the cursor.
         try {
             desk->m_window = createWindow(m_deskClass, "InputLeapDesk");
-            LOG(CLOG_DEBUG "desk %s window is 0x%08x", desk->m_name.c_str(), desk->m_window);
+            LOG_DEBUG("desk %s window is 0x%08x", desk->m_name.c_str(), desk->m_window);
         }
         catch (...) {
             // ignore
-            LOG(CLOG_DEBUG "can't create desk window for %s", desk->m_name.c_str());
+            LOG_DEBUG("can't create desk window for %s", desk->m_name.c_str());
         }
     }
 
@@ -634,7 +634,7 @@ void MSWindowsDesks::desk_thread(Desk* desk)
                 }
                 if (!MSWindowsHook::install()) {
                     // we won't work on this desk
-                    LOG(CLOG_DEBUG "Cannot hook on this desk");
+                    LOG_DEBUG("Cannot hook on this desk");
                 }
                 // a window on the primary screen with low-level hooks
                 // should never activate.
@@ -779,7 +779,7 @@ MSWindowsDesks::checkDesk()
     // if we are told to shut down on desk switch, and this is not the
     // first switch, then shut down.
     if (m_stopOnDeskSwitch && m_activeDesk != nullptr && name != m_activeDeskName) {
-        LOG(CLOG_DEBUG "shutting down because of desk switch to \"%s\"", name.c_str());
+        LOG_DEBUG("shutting down because of desk switch to \"%s\"", name.c_str());
         m_events->add_event(EventType::QUIT);
         return;
     }
@@ -800,16 +800,16 @@ MSWindowsDesks::checkDesk()
         // from an inaccessible desktop so when we switch from an
         // inaccessible desktop to an accessible one we have to
         // update the keyboard state.
-        LOG(CLOG_DEBUG "switched to desk \"%s\"", name.c_str());
+        LOG_DEBUG("switched to desk \"%s\"", name.c_str());
         bool syncKeys = false;
         bool isAccessible = isDeskAccessible(desk);
         if (isDeskAccessible(m_activeDesk) != isAccessible) {
             if (isAccessible) {
-                LOG(CLOG_DEBUG "desktop is now accessible");
+                LOG_DEBUG("desktop is now accessible");
                 syncKeys = true;
             }
             else {
-                LOG(CLOG_DEBUG "desktop is now inaccessible");
+                LOG_DEBUG("desktop is now inaccessible");
             }
         }
 

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -65,7 +65,7 @@ static std::vector<DWORD> immune_keys_list()
     std::vector<DWORD> keys;
     std::string badLine;
     if (!ImmuneKeysReader::get_list(g_immuneKeysPath.c_str(), keys, badLine))
-        LOG(CLOG_ERR "Reading immune keys stopped at: %s", badLine.c_str());
+        LOG_ERR("Reading immune keys stopped at: %s", badLine.c_str());
     return keys;
 }
 
@@ -575,7 +575,7 @@ MSWindowsHook::install()
     // setup immune keys
     g_immuneKeysPath = (inputleap::DataDirectories::profile() / "ImmuneKeys.txt").u8string();
     g_immuneKeys = immune_keys_list();
-    LOG(CLOG_DEBUG "Found %u immune keys in %s", g_immuneKeys.size(), g_immuneKeysPath.c_str());
+    LOG_DEBUG("Found %u immune keys in %s", g_immuneKeys.size(), g_immuneKeysPath.c_str());
 
 #if NO_GRAB_KEYBOARD
     // we only need the mouse hook

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -65,7 +65,7 @@ static std::vector<DWORD> immune_keys_list()
     std::vector<DWORD> keys;
     std::string badLine;
     if (!ImmuneKeysReader::get_list(g_immuneKeysPath.c_str(), keys, badLine))
-        LOG((CLOG_ERR "Reading immune keys stopped at: %s", badLine.c_str()));
+        LOG(CLOG_ERR "Reading immune keys stopped at: %s", badLine.c_str());
     return keys;
 }
 
@@ -575,7 +575,7 @@ MSWindowsHook::install()
     // setup immune keys
     g_immuneKeysPath = (inputleap::DataDirectories::profile() / "ImmuneKeys.txt").u8string();
     g_immuneKeys = immune_keys_list();
-    LOG((CLOG_DEBUG "Found %u immune keys in %s", g_immuneKeys.size(), g_immuneKeysPath.c_str()));
+    LOG(CLOG_DEBUG "Found %u immune keys in %s", g_immuneKeys.size(), g_immuneKeysPath.c_str());
 
 #if NO_GRAB_KEYBOARD
     // we only need the mouse hook

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -792,7 +792,7 @@ MSWindowsKeyState::fakeCtrlAltDel()
 	// or hooks.  so start a new thread to do the real work.
 	HANDLE hEvtSendSas = OpenEvent(EVENT_MODIFY_STATE, FALSE, "Global\\SendSAS");
 	if (hEvtSendSas) {
-		LOG((CLOG_DEBUG "found the SendSAS event - signaling my launcher to simulate ctrl+alt+del"));
+		LOG(CLOG_DEBUG "found the SendSAS event - signaling my launcher to simulate ctrl+alt+del");
 		SetEvent(hEvtSendSas);
 		CloseHandle(hEvtSendSas);
 	}
@@ -814,12 +814,12 @@ void MSWindowsKeyState::ctrl_alt_del_thread()
 						MAKELPARAM(MOD_CONTROL | MOD_ALT, VK_DELETE));
 		}
 		else {
-			LOG((CLOG_DEBUG "can't switch to Winlogon desk: %d", GetLastError()));
+			LOG(CLOG_DEBUG "can't switch to Winlogon desk: %d", GetLastError());
 		}
 		CloseDesktop(desk);
 	}
 	else {
-		LOG((CLOG_DEBUG "can't open Winlogon desk: %d", GetLastError()));
+		LOG(CLOG_DEBUG "can't open Winlogon desk: %d", GetLastError());
 	}
 }
 
@@ -870,7 +870,7 @@ std::int32_t MSWindowsKeyState::pollActiveGroup() const
 	// get group
 	GroupMap::const_iterator i = m_groupMap.find(hkl);
 	if (i == m_groupMap.end()) {
-		LOG((CLOG_DEBUG1 "can't find keyboard layout %08x", hkl));
+		LOG(CLOG_DEBUG1 "can't find keyboard layout %08x", hkl);
 		return 0;
 	}
 
@@ -882,7 +882,7 @@ MSWindowsKeyState::pollPressedKeys(KeyButtonSet& pressedKeys) const
 {
 	BYTE keyState[256];
 	if (!GetKeyboardState(keyState)) {
-		LOG((CLOG_ERR "GetKeyboardState returned false on pollPressedKeys"));
+		LOG(CLOG_ERR "GetKeyboardState returned false on pollPressedKeys");
 		return;
 	}
 	for (KeyButton i = 1; i < 256; ++i) {
@@ -1207,13 +1207,13 @@ MSWindowsKeyState::fakeKey(const Keystroke& keystroke)
 {
 	switch (keystroke.m_type) {
 	case Keystroke::kButton: {
-		LOG((CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up"));
+		LOG(CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up");
 		KeyButton button = keystroke.m_data.m_button.m_button;
 
 		// windows doesn't send key ups for key repeats
 		if (keystroke.m_data.m_button.m_repeat &&
 			!keystroke.m_data.m_button.m_press) {
-			LOG((CLOG_DEBUG1 "  discard key repeat release"));
+			LOG(CLOG_DEBUG1 "  discard key repeat release");
 			break;
 		}
 
@@ -1245,11 +1245,11 @@ MSWindowsKeyState::fakeKey(const Keystroke& keystroke)
 		// key events.
 		if (!keystroke.m_data.m_group.m_restore) {
 			if (keystroke.m_data.m_group.m_absolute) {
-				LOG((CLOG_DEBUG1 "  group %d", keystroke.m_data.m_group.m_group));
+				LOG(CLOG_DEBUG1 "  group %d", keystroke.m_data.m_group.m_group);
 				setWindowGroup(keystroke.m_data.m_group.m_group);
 			}
 			else {
-				LOG((CLOG_DEBUG1 "  group %+d", keystroke.m_data.m_group.m_group));
+				LOG(CLOG_DEBUG1 "  group %+d", keystroke.m_data.m_group.m_group);
 				setWindowGroup(getEffectiveGroup(pollActiveGroup(),
 									keystroke.m_data.m_group.m_group));
 			}
@@ -1275,13 +1275,13 @@ MSWindowsKeyState::getGroups(GroupList& groups) const
 	// get keyboard layouts
 	std::uint32_t newNumLayouts = GetKeyboardLayoutList(0, nullptr);
 	if (newNumLayouts == 0) {
-		LOG((CLOG_DEBUG1 "can't get keyboard layouts"));
+		LOG(CLOG_DEBUG1 "can't get keyboard layouts");
 		return false;
 	}
 	HKL* newLayouts = new HKL[newNumLayouts];
 	newNumLayouts = GetKeyboardLayoutList(newNumLayouts, newLayouts);
 	if (newNumLayouts == 0) {
-		LOG((CLOG_DEBUG1 "can't get keyboard layouts"));
+		LOG(CLOG_DEBUG1 "can't get keyboard layouts");
 		delete[] newLayouts;
 		return false;
 	}

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -792,7 +792,7 @@ MSWindowsKeyState::fakeCtrlAltDel()
 	// or hooks.  so start a new thread to do the real work.
 	HANDLE hEvtSendSas = OpenEvent(EVENT_MODIFY_STATE, FALSE, "Global\\SendSAS");
 	if (hEvtSendSas) {
-		LOG(CLOG_DEBUG "found the SendSAS event - signaling my launcher to simulate ctrl+alt+del");
+		LOG_DEBUG("found the SendSAS event - signaling my launcher to simulate ctrl+alt+del");
 		SetEvent(hEvtSendSas);
 		CloseHandle(hEvtSendSas);
 	}
@@ -814,12 +814,12 @@ void MSWindowsKeyState::ctrl_alt_del_thread()
 						MAKELPARAM(MOD_CONTROL | MOD_ALT, VK_DELETE));
 		}
 		else {
-			LOG(CLOG_DEBUG "can't switch to Winlogon desk: %d", GetLastError());
+			LOG_DEBUG("can't switch to Winlogon desk: %d", GetLastError());
 		}
 		CloseDesktop(desk);
 	}
 	else {
-		LOG(CLOG_DEBUG "can't open Winlogon desk: %d", GetLastError());
+		LOG_DEBUG("can't open Winlogon desk: %d", GetLastError());
 	}
 }
 
@@ -870,7 +870,7 @@ std::int32_t MSWindowsKeyState::pollActiveGroup() const
 	// get group
 	GroupMap::const_iterator i = m_groupMap.find(hkl);
 	if (i == m_groupMap.end()) {
-		LOG(CLOG_DEBUG1 "can't find keyboard layout %08x", hkl);
+		LOG_DEBUG1("can't find keyboard layout %08x", hkl);
 		return 0;
 	}
 
@@ -882,7 +882,7 @@ MSWindowsKeyState::pollPressedKeys(KeyButtonSet& pressedKeys) const
 {
 	BYTE keyState[256];
 	if (!GetKeyboardState(keyState)) {
-		LOG(CLOG_ERR "GetKeyboardState returned false on pollPressedKeys");
+		LOG_ERR("GetKeyboardState returned false on pollPressedKeys");
 		return;
 	}
 	for (KeyButton i = 1; i < 256; ++i) {
@@ -1207,13 +1207,13 @@ MSWindowsKeyState::fakeKey(const Keystroke& keystroke)
 {
 	switch (keystroke.m_type) {
 	case Keystroke::kButton: {
-		LOG(CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up");
+		LOG_DEBUG1("  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up");
 		KeyButton button = keystroke.m_data.m_button.m_button;
 
 		// windows doesn't send key ups for key repeats
 		if (keystroke.m_data.m_button.m_repeat &&
 			!keystroke.m_data.m_button.m_press) {
-			LOG(CLOG_DEBUG1 "  discard key repeat release");
+			LOG_DEBUG1("  discard key repeat release");
 			break;
 		}
 
@@ -1245,11 +1245,11 @@ MSWindowsKeyState::fakeKey(const Keystroke& keystroke)
 		// key events.
 		if (!keystroke.m_data.m_group.m_restore) {
 			if (keystroke.m_data.m_group.m_absolute) {
-				LOG(CLOG_DEBUG1 "  group %d", keystroke.m_data.m_group.m_group);
+				LOG_DEBUG1("  group %d", keystroke.m_data.m_group.m_group);
 				setWindowGroup(keystroke.m_data.m_group.m_group);
 			}
 			else {
-				LOG(CLOG_DEBUG1 "  group %+d", keystroke.m_data.m_group.m_group);
+				LOG_DEBUG1("  group %+d", keystroke.m_data.m_group.m_group);
 				setWindowGroup(getEffectiveGroup(pollActiveGroup(),
 									keystroke.m_data.m_group.m_group));
 			}
@@ -1275,13 +1275,13 @@ MSWindowsKeyState::getGroups(GroupList& groups) const
 	// get keyboard layouts
 	std::uint32_t newNumLayouts = GetKeyboardLayoutList(0, nullptr);
 	if (newNumLayouts == 0) {
-		LOG(CLOG_DEBUG1 "can't get keyboard layouts");
+		LOG_DEBUG1("can't get keyboard layouts");
 		return false;
 	}
 	HKL* newLayouts = new HKL[newNumLayouts];
 	newNumLayouts = GetKeyboardLayoutList(newNumLayouts, newLayouts);
 	if (newNumLayouts == 0) {
-		LOG(CLOG_DEBUG1 "can't get keyboard layouts");
+		LOG_DEBUG1("can't get keyboard layouts");
 		delete[] newLayouts;
 		return false;
 	}

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -138,8 +138,8 @@ MSWindowsScreen::MSWindowsScreen(
         m_class       = createWindowClass();
         m_window      = createWindow(m_class, "InputLeap");
         forceShowCursor();
-        LOG(CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : "");
-        LOG(CLOG_DEBUG "window is 0x%08x", m_window);
+        LOG_DEBUG("screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : "");
+        LOG_DEBUG("window is 0x%08x", m_window);
 
         OleInitialize(0);
         m_dropWindow = createDropWindow(m_class, "DropWindow");
@@ -319,7 +319,7 @@ MSWindowsScreen::leave()
     if (m_isPrimary) {
 
         // warp to center
-        LOG(CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter);
+        LOG_DEBUG1("warping cursor to center: %+d, %+d", m_xCenter, m_yCenter);
         warpCursor(m_xCenter, m_yCenter);
 
         // disable special key sequences on win95 family
@@ -338,7 +338,7 @@ MSWindowsScreen::leave()
         for (KeyButton i = 0; i < IKeyState::kNumButtons; ++i) {
             if (m_keyState->isKeyDown(i)) {
                 m_primaryKeyDownList.push_back(i);
-                LOG(CLOG_DEBUG1 "key button %d is down before leaving to another screen", i);
+                LOG_DEBUG1("key button %d is down before leaving to another screen", i);
             }
         }
     }
@@ -363,9 +363,9 @@ void MSWindowsScreen::send_drag_thread()
         ClientApp& app = ClientApp::instance();
         Client* client = app.getClientPtr();
         std::uint32_t fileCount = 1;
-        LOG(CLOG_DEBUG "send dragging info to server: %s", draggingFilename.c_str());
+        LOG_DEBUG("send dragging info to server: %s", draggingFilename.c_str());
         client->sendDragInfo(fileCount, draggingFilename, size);
-        LOG(CLOG_DEBUG "send dragging file to server");
+        LOG_DEBUG("send dragging file to server");
         client->sendFileToServer(draggingFilename.c_str());
     }
 
@@ -406,7 +406,7 @@ MSWindowsScreen::checkClipboards()
     // won't be reflected on other screens until we leave but at
     // least the clipboard itself will work.
     if (m_ownClipboard && !MSWindowsClipboard::is_owned_by_us()) {
-        LOG(CLOG_DEBUG "clipboard changed: lost ownership and no notification received");
+        LOG_DEBUG("clipboard changed: lost ownership and no notification received");
         m_ownClipboard = false;
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardClipboard);
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardSelection);
@@ -511,7 +511,7 @@ void MSWindowsScreen::reconfigure(std::uint32_t activeSides)
 {
     assert(m_isPrimary);
 
-    LOG(CLOG_DEBUG "active sides: %x", activeSides);
+    LOG_DEBUG("active sides: %x", activeSides);
     m_hook.setSides(activeSides);
 }
 
@@ -535,7 +535,7 @@ void MSWindowsScreen::saveMousePosition(std::int32_t x, std::int32_t y) {
     m_xCursor = x;
     m_yCursor = y;
 
-    LOG(CLOG_DEBUG5 "saved mouse position for next delta: %+d,%+d", x,y);
+    LOG_DEBUG5("saved mouse position for next delta: %+d,%+d", x,y);
 }
 
 std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
@@ -545,7 +545,7 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
                   KeyModifierAlt   | KeyModifierSuper)) != 0) {
         // this should be a warning, but this can confuse users,
         // as this warning happens almost always.
-        LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
+        LOG_DEBUG("could not map hotkey id=%04x mask=%04x", key, mask);
         return 0;
     }
 
@@ -573,7 +573,7 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
         // can't map key
         // this should be a warning, but this can confuse users,
         // as this warning happens almost always.
-        LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
+        LOG_DEBUG("could not map hotkey id=%04x mask=%04x", key, mask);
         return 0;
     }
 
@@ -606,11 +606,11 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
     else {
         m_oldHotKeyIDs.push_back(id);
         m_hotKeys.erase(id);
-        LOG(CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
+        LOG_WARN("failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
         return 0;
     }
 
-    LOG(CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
+    LOG_DEBUG("registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
     return id;
 }
 
@@ -631,10 +631,10 @@ void MSWindowsScreen::unregisterHotKey(std::uint32_t id)
         err = false;
     }
     if (err) {
-        LOG(CLOG_WARN "failed to unregister hotkey id=%d", id);
+        LOG_WARN("failed to unregister hotkey id=%d", id);
     }
     else {
-        LOG(CLOG_DEBUG "unregistered hotkey id=%d", id);
+        LOG_DEBUG("unregistered hotkey id=%d", id);
     }
 
     // discard hot key from map and record old id for reuse
@@ -684,7 +684,7 @@ bool MSWindowsScreen::isAnyMouseButtonDown(std::uint32_t& buttonID) const
     for (std::uint32_t i = 1; i < sizeof(m_buttons) / sizeof(m_buttons[0]); ++i) {
         if (m_buttons[i]) {
             buttonID = i;
-            LOG(CLOG_DEBUG "locked by \"%s\"", buttonToName[i]);
+            LOG_DEBUG("locked by \"%s\"", buttonToName[i]);
             return true;
         }
     }
@@ -836,7 +836,7 @@ MSWindowsScreen::createWindow(ATOM windowClass, const char* name) const
                                 s_windowInstance,
                                 nullptr);
     if (window == nullptr) {
-        LOG(CLOG_ERR "failed to create window: %d", GetLastError());
+        LOG_ERR("failed to create window: %d", GetLastError());
         throw XScreenOpenFailure();
     }
     return window;
@@ -855,7 +855,7 @@ MSWindowsScreen::createDropWindow(ATOM windowClass, const char* name) const
                                  nullptr);
 
     if (window == nullptr) {
-        LOG(CLOG_ERR "failed to create drop window: %d", GetLastError());
+        LOG_ERR("failed to create drop window: %d", GetLastError());
         throw XScreenOpenFailure();
     }
 
@@ -928,7 +928,7 @@ MSWindowsScreen::onPreDispatch(HWND hwnd,
         return onScreensaver(wParam != 0);
 
     case INPUTLEAP_MSG_DEBUG:
-        LOG(CLOG_DEBUG1 "hook: 0x%08x 0x%08x", wParam, lParam);
+        LOG_DEBUG1("hook: 0x%08x 0x%08x", wParam, lParam);
         return true;
     }
 
@@ -943,7 +943,7 @@ bool
 MSWindowsScreen::onPreDispatchPrimary(HWND,
                 UINT message, WPARAM wParam, LPARAM lParam)
 {
-    LOG(CLOG_DEBUG5 "handling pre-dispatch primary");
+    LOG_DEBUG5("handling pre-dispatch primary");
 
     // handle event
     switch (message) {
@@ -981,7 +981,7 @@ MSWindowsScreen::onPreDispatchPrimary(HWND,
         return true;
 
     case INPUTLEAP_MSG_POST_WARP:
-        LOG(CLOG_WARN "unmatched post warp");
+        LOG_WARN("unmatched post warp");
         return true;
 
     case WM_HOTKEY:
@@ -1012,7 +1012,7 @@ MSWindowsScreen::onEvent(HWND, UINT msg,
     case WM_CHANGECBCHAIN:
         if (m_nextClipboardWindow == (HWND)wParam) {
             m_nextClipboardWindow = (HWND)lParam;
-            LOG(CLOG_DEBUG "clipboard chain: new next: 0x%08x", m_nextClipboardWindow);
+            LOG_DEBUG("clipboard chain: new next: 0x%08x", m_nextClipboardWindow);
         }
         else if (m_nextClipboardWindow != nullptr) {
             SendMessage(m_nextClipboardWindow, msg, wParam, lParam);
@@ -1065,7 +1065,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
     static const KeyModifierMask s_ctrlAlt =
         KeyModifierControl | KeyModifierAlt;
 
-    LOG(CLOG_DEBUG1 "event: Key char=%d, vk=0x%02x, nagr=%d, lParam=0x%08x", wParam & 0xffffu, (wParam >> 16) & 0xffu, (wParam & 0x1000000u) ? 1 : 0, lParam);
+    LOG_DEBUG1("event: Key char=%d, vk=0x%02x, nagr=%d, lParam=0x%08x", wParam & 0xffffu, (wParam >> 16) & 0xffu, (wParam & 0x1000000u) ? 1 : 0, lParam);
 
     // get event info
     KeyButton button         = (KeyButton)((lParam & 0x01ff0000) >> 16);
@@ -1096,7 +1096,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
     if (!down && m_isPrimary && !m_isOnScreen) {
         PrimaryKeyDownList::iterator find = std::find(m_primaryKeyDownList.begin(), m_primaryKeyDownList.end(), button);
         if (find != m_primaryKeyDownList.end()) {
-            LOG(CLOG_DEBUG1 "release key button %d on primary", *find);
+            LOG_DEBUG1("release key button %d on primary", *find);
             m_hook.setMode(kHOOK_WATCH_JUMP_ZONE);
             fakeLocalKey(*find, false);
             m_primaryKeyDownList.erase(find);
@@ -1151,14 +1151,14 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
         // client.  the user can use ctrl+alt+pause to emulate it.
         UINT virtKey = (wParam >> 16) & 0xffu;
         if (virtKey == VK_DELETE && (state & s_ctrlAlt) == s_ctrlAlt) {
-            LOG(CLOG_DEBUG "discard ctrl+alt+del");
+            LOG_DEBUG("discard ctrl+alt+del");
             return true;
         }
 
         // check for ctrl+alt+del emulation
         if ((virtKey == VK_PAUSE || virtKey == VK_CANCEL) &&
             (state & s_ctrlAlt) == s_ctrlAlt) {
-            LOG(CLOG_DEBUG "emulate ctrl+alt+del");
+            LOG_DEBUG("emulate ctrl+alt+del");
             // switch wParam and lParam to be as if VK_DELETE was
             // pressed or released.  when mapping the key we require that
             // we not use AltGr (the 0x10000 flag in wParam) and we not
@@ -1181,7 +1181,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
                             key, mask, (std::int32_t)(lParam & 0xffff), button);
         }
         else {
-            LOG(CLOG_DEBUG1 "cannot map key");
+            LOG_DEBUG1("cannot map key");
         }
     }
 
@@ -1248,7 +1248,7 @@ MSWindowsScreen::onMouseButton(WPARAM wParam, LPARAM lParam)
             m_buttons[button] = true;
             if (button == kButtonLeft) {
                 m_draggingFilename.clear();
-                LOG(CLOG_DEBUG2 "dragging filename is cleared");
+                LOG_DEBUG2("dragging filename is cleared");
             }
         }
         else {
@@ -1263,14 +1263,14 @@ MSWindowsScreen::onMouseButton(WPARAM wParam, LPARAM lParam)
     if (!ignore()) {
         KeyModifierMask mask = m_keyState->getActiveModifiers();
         if (pressed) {
-            LOG(CLOG_DEBUG1 "event: button press button=%d", button);
+            LOG_DEBUG1("event: button press button=%d", button);
             if (button != kButtonNone) {
                 sendEvent(EventType::PRIMARY_SCREEN_BUTTON_DOWN,
                           create_event_data<ButtonInfo>(ButtonInfo{button, mask}));
             }
         }
         else {
-            LOG(CLOG_DEBUG1 "event: button release button=%d", button);
+            LOG_DEBUG1("event: button release button=%d", button);
             if (button != kButtonNone) {
                 sendEvent(EventType::PRIMARY_SCREEN_BUTTON_UP,
                           create_event_data<ButtonInfo>(ButtonInfo{button, mask}));
@@ -1296,7 +1296,7 @@ bool MSWindowsScreen::onMouseMove(std::int32_t mx, std::int32_t my)
     std::int32_t x = mx - m_xCursor;
     std::int32_t y = my - m_yCursor;
 
-    LOG(CLOG_DEBUG3
+    LOG_DEBUG3(
         "mouse move - motion delta: %+d=(%+d - %+d),%+d=(%+d - %+d)",
         x, mx, m_xCursor, y, my, m_yCursor);
 
@@ -1325,7 +1325,7 @@ bool MSWindowsScreen::onMouseMove(std::int32_t mx, std::int32_t my)
         // center on the server screen. if we don't do this, then the mouse
         // will always try to return to the original entry point on the
         // secondary screen.
-        LOG(CLOG_DEBUG5 "warping server cursor to center: %+d,%+d", m_xCenter, m_yCenter);
+        LOG_DEBUG5("warping server cursor to center: %+d,%+d", m_xCenter, m_yCenter);
         warpCursorNoFlush(m_xCenter, m_yCenter);
 
         // examine the motion.  if it's about the distance
@@ -1339,7 +1339,7 @@ bool MSWindowsScreen::onMouseMove(std::int32_t mx, std::int32_t my)
             -y + bogusZoneSize > m_yCenter - m_y ||
              y + bogusZoneSize > m_y + m_h - m_yCenter) {
 
-            LOG(CLOG_DEBUG "dropped bogus delta motion: %+d,%+d", x, y);
+            LOG_DEBUG("dropped bogus delta motion: %+d,%+d", x, y);
         }
         else {
             // send motion
@@ -1355,7 +1355,7 @@ bool MSWindowsScreen::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 {
     // ignore message if posted prior to last mark change
     if (!ignore()) {
-        LOG(CLOG_DEBUG1 "event: button wheel delta=%+d,%+d", xDelta, yDelta);
+        LOG_DEBUG1("event: button wheel delta=%+d,%+d", xDelta, yDelta);
         sendEvent(EventType::PRIMARY_SCREEN_WHEEL,
                   create_event_data<WheelInfo>(WheelInfo{xDelta, yDelta}));
     }
@@ -1417,7 +1417,7 @@ MSWindowsScreen::onDisplayChange()
             // warp mouse to center if off screen
             if (!m_isOnScreen) {
 
-                LOG(CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter);
+                LOG_DEBUG1("warping cursor to center: %+d, %+d", m_xCenter, m_yCenter);
                 warpCursor(m_xCenter, m_yCenter);
             }
 
@@ -1430,7 +1430,7 @@ MSWindowsScreen::onDisplayChange()
         // send new screen info
         sendEvent(EventType::SCREEN_SHAPE_CHANGED);
 
-        LOG(CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : "");
+        LOG_DEBUG("screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : "");
     }
 
     return true;
@@ -1443,14 +1443,14 @@ MSWindowsScreen::onClipboardChange()
     // we're the owner).
     if (!MSWindowsClipboard::is_owned_by_us()) {
         if (m_ownClipboard) {
-            LOG(CLOG_DEBUG "clipboard changed: lost ownership");
+            LOG_DEBUG("clipboard changed: lost ownership");
             m_ownClipboard = false;
             sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardClipboard);
             sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardSelection);
         }
     }
     else if (!m_ownClipboard) {
-        LOG(CLOG_DEBUG "clipboard changed: got ownership");
+        LOG_DEBUG("clipboard changed: got ownership");
         m_ownClipboard = true;
     }
 
@@ -1475,8 +1475,8 @@ void MSWindowsScreen::warpCursorNoFlush(std::int32_t x, std::int32_t y)
     // since this feature is mainly for client, so only check on client.
     if (!isPrimary()) {
         if ((cursorPos.x != x) && (cursorPos.y != y)) {
-            LOG(CLOG_DEBUG "SetCursorPos did not work; using fakeMouseMove instead");
-            LOG(CLOG_DEBUG "cursor pos %d, %d expected pos %d, %d", cursorPos.x, cursorPos.y, x, y);
+            LOG_DEBUG("SetCursorPos did not work; using fakeMouseMove instead");
+            LOG_DEBUG("cursor pos %d, %d expected pos %d, %d", cursorPos.x, cursorPos.y, x, y);
             // when at Vista/7 login screen, SetCursorPos does not work (which could be
             // an MS security feature). instead we can use fakeMouseMove, which calls
             // mouse_event.
@@ -1858,12 +1858,12 @@ std::string& MSWindowsScreen::getDraggingFilename()
                 m_draggingFilename = filename;
             }
             else {
-                LOG(CLOG_ERR "drag file name is invalid: %s", filename.c_str());
+                LOG_ERR("drag file name is invalid: %s", filename.c_str());
             }
         }
 
         if (m_draggingFilename.empty()) {
-            LOG(CLOG_ERR "failed to get drag file name from OLE");
+            LOG_ERR("failed to get drag file name from OLE");
         }
     }
 
@@ -1878,10 +1878,10 @@ MSWindowsScreen::getDropTarget() const
         char desktopPath[MAX_PATH];
         if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_DESKTOP, nullptr, 0, desktopPath))) {
             m_dropTargetPath = std::string(desktopPath);
-            LOG(CLOG_INFO "using desktop for drop target: %s", m_dropTargetPath.c_str());
+            LOG_INFO("using desktop for drop target: %s", m_dropTargetPath.c_str());
         }
         else {
-            LOG(CLOG_ERR "failed to get desktop path, no drop target available, error=%d", GetLastError());
+            LOG_ERR("failed to get desktop path, no drop target available, error=%d", GetLastError());
         }
     }
     return m_dropTargetPath;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -138,8 +138,8 @@ MSWindowsScreen::MSWindowsScreen(
         m_class       = createWindowClass();
         m_window      = createWindow(m_class, "InputLeap");
         forceShowCursor();
-        LOG((CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : ""));
-        LOG((CLOG_DEBUG "window is 0x%08x", m_window));
+        LOG(CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : "");
+        LOG(CLOG_DEBUG "window is 0x%08x", m_window);
 
         OleInitialize(0);
         m_dropWindow = createDropWindow(m_class, "DropWindow");
@@ -319,7 +319,7 @@ MSWindowsScreen::leave()
     if (m_isPrimary) {
 
         // warp to center
-        LOG((CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter));
+        LOG(CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter);
         warpCursor(m_xCenter, m_yCenter);
 
         // disable special key sequences on win95 family
@@ -338,7 +338,7 @@ MSWindowsScreen::leave()
         for (KeyButton i = 0; i < IKeyState::kNumButtons; ++i) {
             if (m_keyState->isKeyDown(i)) {
                 m_primaryKeyDownList.push_back(i);
-                LOG((CLOG_DEBUG1 "key button %d is down before leaving to another screen", i));
+                LOG(CLOG_DEBUG1 "key button %d is down before leaving to another screen", i);
             }
         }
     }
@@ -363,9 +363,9 @@ void MSWindowsScreen::send_drag_thread()
         ClientApp& app = ClientApp::instance();
         Client* client = app.getClientPtr();
         std::uint32_t fileCount = 1;
-        LOG((CLOG_DEBUG "send dragging info to server: %s", draggingFilename.c_str()));
+        LOG(CLOG_DEBUG "send dragging info to server: %s", draggingFilename.c_str());
         client->sendDragInfo(fileCount, draggingFilename, size);
-        LOG((CLOG_DEBUG "send dragging file to server"));
+        LOG(CLOG_DEBUG "send dragging file to server");
         client->sendFileToServer(draggingFilename.c_str());
     }
 
@@ -406,7 +406,7 @@ MSWindowsScreen::checkClipboards()
     // won't be reflected on other screens until we leave but at
     // least the clipboard itself will work.
     if (m_ownClipboard && !MSWindowsClipboard::is_owned_by_us()) {
-        LOG((CLOG_DEBUG "clipboard changed: lost ownership and no notification received"));
+        LOG(CLOG_DEBUG "clipboard changed: lost ownership and no notification received");
         m_ownClipboard = false;
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardClipboard);
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardSelection);
@@ -511,7 +511,7 @@ void MSWindowsScreen::reconfigure(std::uint32_t activeSides)
 {
     assert(m_isPrimary);
 
-    LOG((CLOG_DEBUG "active sides: %x", activeSides));
+    LOG(CLOG_DEBUG "active sides: %x", activeSides);
     m_hook.setSides(activeSides);
 }
 
@@ -535,7 +535,7 @@ void MSWindowsScreen::saveMousePosition(std::int32_t x, std::int32_t y) {
     m_xCursor = x;
     m_yCursor = y;
 
-    LOG((CLOG_DEBUG5 "saved mouse position for next delta: %+d,%+d", x,y));
+    LOG(CLOG_DEBUG5 "saved mouse position for next delta: %+d,%+d", x,y);
 }
 
 std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
@@ -545,7 +545,7 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
                   KeyModifierAlt   | KeyModifierSuper)) != 0) {
         // this should be a warning, but this can confuse users,
         // as this warning happens almost always.
-        LOG((CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask));
+        LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
         return 0;
     }
 
@@ -573,7 +573,7 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
         // can't map key
         // this should be a warning, but this can confuse users,
         // as this warning happens almost always.
-        LOG((CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask));
+        LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
         return 0;
     }
 
@@ -606,11 +606,11 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
     else {
         m_oldHotKeyIDs.push_back(id);
         m_hotKeys.erase(id);
-        LOG((CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask));
+        LOG(CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
         return 0;
     }
 
-    LOG((CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id));
+    LOG(CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
     return id;
 }
 
@@ -631,10 +631,10 @@ void MSWindowsScreen::unregisterHotKey(std::uint32_t id)
         err = false;
     }
     if (err) {
-        LOG((CLOG_WARN "failed to unregister hotkey id=%d", id));
+        LOG(CLOG_WARN "failed to unregister hotkey id=%d", id);
     }
     else {
-        LOG((CLOG_DEBUG "unregistered hotkey id=%d", id));
+        LOG(CLOG_DEBUG "unregistered hotkey id=%d", id);
     }
 
     // discard hot key from map and record old id for reuse
@@ -684,7 +684,7 @@ bool MSWindowsScreen::isAnyMouseButtonDown(std::uint32_t& buttonID) const
     for (std::uint32_t i = 1; i < sizeof(m_buttons) / sizeof(m_buttons[0]); ++i) {
         if (m_buttons[i]) {
             buttonID = i;
-            LOG((CLOG_DEBUG "locked by \"%s\"", buttonToName[i]));
+            LOG(CLOG_DEBUG "locked by \"%s\"", buttonToName[i]);
             return true;
         }
     }
@@ -836,7 +836,7 @@ MSWindowsScreen::createWindow(ATOM windowClass, const char* name) const
                                 s_windowInstance,
                                 nullptr);
     if (window == nullptr) {
-        LOG((CLOG_ERR "failed to create window: %d", GetLastError()));
+        LOG(CLOG_ERR "failed to create window: %d", GetLastError());
         throw XScreenOpenFailure();
     }
     return window;
@@ -855,7 +855,7 @@ MSWindowsScreen::createDropWindow(ATOM windowClass, const char* name) const
                                  nullptr);
 
     if (window == nullptr) {
-        LOG((CLOG_ERR "failed to create drop window: %d", GetLastError()));
+        LOG(CLOG_ERR "failed to create drop window: %d", GetLastError());
         throw XScreenOpenFailure();
     }
 
@@ -928,7 +928,7 @@ MSWindowsScreen::onPreDispatch(HWND hwnd,
         return onScreensaver(wParam != 0);
 
     case INPUTLEAP_MSG_DEBUG:
-        LOG((CLOG_DEBUG1 "hook: 0x%08x 0x%08x", wParam, lParam));
+        LOG(CLOG_DEBUG1 "hook: 0x%08x 0x%08x", wParam, lParam);
         return true;
     }
 
@@ -943,7 +943,7 @@ bool
 MSWindowsScreen::onPreDispatchPrimary(HWND,
                 UINT message, WPARAM wParam, LPARAM lParam)
 {
-    LOG((CLOG_DEBUG5 "handling pre-dispatch primary"));
+    LOG(CLOG_DEBUG5 "handling pre-dispatch primary");
 
     // handle event
     switch (message) {
@@ -981,7 +981,7 @@ MSWindowsScreen::onPreDispatchPrimary(HWND,
         return true;
 
     case INPUTLEAP_MSG_POST_WARP:
-        LOG((CLOG_WARN "unmatched post warp"));
+        LOG(CLOG_WARN "unmatched post warp");
         return true;
 
     case WM_HOTKEY:
@@ -1012,7 +1012,7 @@ MSWindowsScreen::onEvent(HWND, UINT msg,
     case WM_CHANGECBCHAIN:
         if (m_nextClipboardWindow == (HWND)wParam) {
             m_nextClipboardWindow = (HWND)lParam;
-            LOG((CLOG_DEBUG "clipboard chain: new next: 0x%08x", m_nextClipboardWindow));
+            LOG(CLOG_DEBUG "clipboard chain: new next: 0x%08x", m_nextClipboardWindow);
         }
         else if (m_nextClipboardWindow != nullptr) {
             SendMessage(m_nextClipboardWindow, msg, wParam, lParam);
@@ -1065,7 +1065,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
     static const KeyModifierMask s_ctrlAlt =
         KeyModifierControl | KeyModifierAlt;
 
-    LOG((CLOG_DEBUG1 "event: Key char=%d, vk=0x%02x, nagr=%d, lParam=0x%08x", wParam & 0xffffu, (wParam >> 16) & 0xffu, (wParam & 0x1000000u) ? 1 : 0, lParam));
+    LOG(CLOG_DEBUG1 "event: Key char=%d, vk=0x%02x, nagr=%d, lParam=0x%08x", wParam & 0xffffu, (wParam >> 16) & 0xffu, (wParam & 0x1000000u) ? 1 : 0, lParam);
 
     // get event info
     KeyButton button         = (KeyButton)((lParam & 0x01ff0000) >> 16);
@@ -1096,7 +1096,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
     if (!down && m_isPrimary && !m_isOnScreen) {
         PrimaryKeyDownList::iterator find = std::find(m_primaryKeyDownList.begin(), m_primaryKeyDownList.end(), button);
         if (find != m_primaryKeyDownList.end()) {
-            LOG((CLOG_DEBUG1 "release key button %d on primary", *find));
+            LOG(CLOG_DEBUG1 "release key button %d on primary", *find);
             m_hook.setMode(kHOOK_WATCH_JUMP_ZONE);
             fakeLocalKey(*find, false);
             m_primaryKeyDownList.erase(find);
@@ -1151,14 +1151,14 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
         // client.  the user can use ctrl+alt+pause to emulate it.
         UINT virtKey = (wParam >> 16) & 0xffu;
         if (virtKey == VK_DELETE && (state & s_ctrlAlt) == s_ctrlAlt) {
-            LOG((CLOG_DEBUG "discard ctrl+alt+del"));
+            LOG(CLOG_DEBUG "discard ctrl+alt+del");
             return true;
         }
 
         // check for ctrl+alt+del emulation
         if ((virtKey == VK_PAUSE || virtKey == VK_CANCEL) &&
             (state & s_ctrlAlt) == s_ctrlAlt) {
-            LOG((CLOG_DEBUG "emulate ctrl+alt+del"));
+            LOG(CLOG_DEBUG "emulate ctrl+alt+del");
             // switch wParam and lParam to be as if VK_DELETE was
             // pressed or released.  when mapping the key we require that
             // we not use AltGr (the 0x10000 flag in wParam) and we not
@@ -1181,7 +1181,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
                             key, mask, (std::int32_t)(lParam & 0xffff), button);
         }
         else {
-            LOG((CLOG_DEBUG1 "cannot map key"));
+            LOG(CLOG_DEBUG1 "cannot map key");
         }
     }
 
@@ -1248,7 +1248,7 @@ MSWindowsScreen::onMouseButton(WPARAM wParam, LPARAM lParam)
             m_buttons[button] = true;
             if (button == kButtonLeft) {
                 m_draggingFilename.clear();
-                LOG((CLOG_DEBUG2 "dragging filename is cleared"));
+                LOG(CLOG_DEBUG2 "dragging filename is cleared");
             }
         }
         else {
@@ -1263,14 +1263,14 @@ MSWindowsScreen::onMouseButton(WPARAM wParam, LPARAM lParam)
     if (!ignore()) {
         KeyModifierMask mask = m_keyState->getActiveModifiers();
         if (pressed) {
-            LOG((CLOG_DEBUG1 "event: button press button=%d", button));
+            LOG(CLOG_DEBUG1 "event: button press button=%d", button);
             if (button != kButtonNone) {
                 sendEvent(EventType::PRIMARY_SCREEN_BUTTON_DOWN,
                           create_event_data<ButtonInfo>(ButtonInfo{button, mask}));
             }
         }
         else {
-            LOG((CLOG_DEBUG1 "event: button release button=%d", button));
+            LOG(CLOG_DEBUG1 "event: button release button=%d", button);
             if (button != kButtonNone) {
                 sendEvent(EventType::PRIMARY_SCREEN_BUTTON_UP,
                           create_event_data<ButtonInfo>(ButtonInfo{button, mask}));
@@ -1296,9 +1296,9 @@ bool MSWindowsScreen::onMouseMove(std::int32_t mx, std::int32_t my)
     std::int32_t x = mx - m_xCursor;
     std::int32_t y = my - m_yCursor;
 
-    LOG((CLOG_DEBUG3
+    LOG(CLOG_DEBUG3
         "mouse move - motion delta: %+d=(%+d - %+d),%+d=(%+d - %+d)",
-        x, mx, m_xCursor, y, my, m_yCursor));
+        x, mx, m_xCursor, y, my, m_yCursor);
 
     // ignore if the mouse didn't move or if message posted prior
     // to last mark change.
@@ -1325,7 +1325,7 @@ bool MSWindowsScreen::onMouseMove(std::int32_t mx, std::int32_t my)
         // center on the server screen. if we don't do this, then the mouse
         // will always try to return to the original entry point on the
         // secondary screen.
-        LOG((CLOG_DEBUG5 "warping server cursor to center: %+d,%+d", m_xCenter, m_yCenter));
+        LOG(CLOG_DEBUG5 "warping server cursor to center: %+d,%+d", m_xCenter, m_yCenter);
         warpCursorNoFlush(m_xCenter, m_yCenter);
 
         // examine the motion.  if it's about the distance
@@ -1339,7 +1339,7 @@ bool MSWindowsScreen::onMouseMove(std::int32_t mx, std::int32_t my)
             -y + bogusZoneSize > m_yCenter - m_y ||
              y + bogusZoneSize > m_y + m_h - m_yCenter) {
 
-            LOG((CLOG_DEBUG "dropped bogus delta motion: %+d,%+d", x, y));
+            LOG(CLOG_DEBUG "dropped bogus delta motion: %+d,%+d", x, y);
         }
         else {
             // send motion
@@ -1355,7 +1355,7 @@ bool MSWindowsScreen::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 {
     // ignore message if posted prior to last mark change
     if (!ignore()) {
-        LOG((CLOG_DEBUG1 "event: button wheel delta=%+d,%+d", xDelta, yDelta));
+        LOG(CLOG_DEBUG1 "event: button wheel delta=%+d,%+d", xDelta, yDelta);
         sendEvent(EventType::PRIMARY_SCREEN_WHEEL,
                   create_event_data<WheelInfo>(WheelInfo{xDelta, yDelta}));
     }
@@ -1417,7 +1417,7 @@ MSWindowsScreen::onDisplayChange()
             // warp mouse to center if off screen
             if (!m_isOnScreen) {
 
-                LOG((CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter));
+                LOG(CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter);
                 warpCursor(m_xCenter, m_yCenter);
             }
 
@@ -1430,7 +1430,7 @@ MSWindowsScreen::onDisplayChange()
         // send new screen info
         sendEvent(EventType::SCREEN_SHAPE_CHANGED);
 
-        LOG((CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : ""));
+        LOG(CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : "");
     }
 
     return true;
@@ -1443,14 +1443,14 @@ MSWindowsScreen::onClipboardChange()
     // we're the owner).
     if (!MSWindowsClipboard::is_owned_by_us()) {
         if (m_ownClipboard) {
-            LOG((CLOG_DEBUG "clipboard changed: lost ownership"));
+            LOG(CLOG_DEBUG "clipboard changed: lost ownership");
             m_ownClipboard = false;
             sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardClipboard);
             sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardSelection);
         }
     }
     else if (!m_ownClipboard) {
-        LOG((CLOG_DEBUG "clipboard changed: got ownership"));
+        LOG(CLOG_DEBUG "clipboard changed: got ownership");
         m_ownClipboard = true;
     }
 
@@ -1475,8 +1475,8 @@ void MSWindowsScreen::warpCursorNoFlush(std::int32_t x, std::int32_t y)
     // since this feature is mainly for client, so only check on client.
     if (!isPrimary()) {
         if ((cursorPos.x != x) && (cursorPos.y != y)) {
-            LOG((CLOG_DEBUG "SetCursorPos did not work; using fakeMouseMove instead"));
-            LOG((CLOG_DEBUG "cursor pos %d, %d expected pos %d, %d", cursorPos.x, cursorPos.y, x, y));
+            LOG(CLOG_DEBUG "SetCursorPos did not work; using fakeMouseMove instead");
+            LOG(CLOG_DEBUG "cursor pos %d, %d expected pos %d, %d", cursorPos.x, cursorPos.y, x, y);
             // when at Vista/7 login screen, SetCursorPos does not work (which could be
             // an MS security feature). instead we can use fakeMouseMove, which calls
             // mouse_event.
@@ -1858,12 +1858,12 @@ std::string& MSWindowsScreen::getDraggingFilename()
                 m_draggingFilename = filename;
             }
             else {
-                LOG((CLOG_ERR "drag file name is invalid: %s", filename.c_str()));
+                LOG(CLOG_ERR "drag file name is invalid: %s", filename.c_str());
             }
         }
 
         if (m_draggingFilename.empty()) {
-            LOG((CLOG_ERR "failed to get drag file name from OLE"));
+            LOG(CLOG_ERR "failed to get drag file name from OLE");
         }
     }
 
@@ -1878,10 +1878,10 @@ MSWindowsScreen::getDropTarget() const
         char desktopPath[MAX_PATH];
         if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_DESKTOP, nullptr, 0, desktopPath))) {
             m_dropTargetPath = std::string(desktopPath);
-            LOG((CLOG_INFO "using desktop for drop target: %s", m_dropTargetPath.c_str()));
+            LOG(CLOG_INFO "using desktop for drop target: %s", m_dropTargetPath.c_str());
         }
         else {
-            LOG((CLOG_ERR "failed to get desktop path, no drop target available, error=%d", GetLastError()));
+            LOG(CLOG_ERR "failed to get desktop path, no drop target available, error=%d", GetLastError());
         }
     }
     return m_dropTargetPath;

--- a/src/lib/platform/MSWindowsScreenSaver.cpp
+++ b/src/lib/platform/MSWindowsScreenSaver.cpp
@@ -98,7 +98,7 @@ MSWindowsScreenSaver::checkStarted(UINT msg, WPARAM wParam, LPARAM lParam)
     // we first check that the screen saver is indeed active
     // before watching for it to stop.
     if (!isActive()) {
-        LOG(CLOG_DEBUG2 "can't open screen saver desktop");
+        LOG_DEBUG2("can't open screen saver desktop");
         return false;
     }
 
@@ -223,7 +223,7 @@ MSWindowsScreenSaver::watchDesktop()
     unwatchProcess();
 
     // watch desktop in another thread
-    LOG(CLOG_DEBUG "watching screen saver desktop");
+    LOG_DEBUG("watching screen saver desktop");
     m_active = true;
     m_watch  = new Thread([this](){ watch_desktop_thread(); });
 }
@@ -236,7 +236,7 @@ MSWindowsScreenSaver::watchProcess(HANDLE process)
 
     // watch new process in another thread
     if (process != nullptr) {
-        LOG(CLOG_DEBUG "watching screen saver process");
+        LOG_DEBUG("watching screen saver process");
         m_process = process;
         m_active  = true;
         m_watch   = new Thread([this](){ watch_process_thread(); });
@@ -247,7 +247,7 @@ void
 MSWindowsScreenSaver::unwatchProcess()
 {
     if (m_watch != nullptr) {
-        LOG(CLOG_DEBUG "stopped watching screen saver process/desktop");
+        LOG_DEBUG("stopped watching screen saver process/desktop");
         m_watch->cancel();
         m_watch->wait();
         delete m_watch;
@@ -288,7 +288,7 @@ void MSWindowsScreenSaver::watch_process_thread()
         Thread::testCancel();
         if (WaitForSingleObject(m_process, 50) == WAIT_OBJECT_0) {
             // process terminated
-            LOG(CLOG_DEBUG "screen saver died");
+            LOG_DEBUG("screen saver died");
 
             // send screen saver deactivation message
             m_active = false;

--- a/src/lib/platform/MSWindowsScreenSaver.cpp
+++ b/src/lib/platform/MSWindowsScreenSaver.cpp
@@ -98,7 +98,7 @@ MSWindowsScreenSaver::checkStarted(UINT msg, WPARAM wParam, LPARAM lParam)
     // we first check that the screen saver is indeed active
     // before watching for it to stop.
     if (!isActive()) {
-        LOG((CLOG_DEBUG2 "can't open screen saver desktop"));
+        LOG(CLOG_DEBUG2 "can't open screen saver desktop");
         return false;
     }
 
@@ -223,7 +223,7 @@ MSWindowsScreenSaver::watchDesktop()
     unwatchProcess();
 
     // watch desktop in another thread
-    LOG((CLOG_DEBUG "watching screen saver desktop"));
+    LOG(CLOG_DEBUG "watching screen saver desktop");
     m_active = true;
     m_watch  = new Thread([this](){ watch_desktop_thread(); });
 }
@@ -236,7 +236,7 @@ MSWindowsScreenSaver::watchProcess(HANDLE process)
 
     // watch new process in another thread
     if (process != nullptr) {
-        LOG((CLOG_DEBUG "watching screen saver process"));
+        LOG(CLOG_DEBUG "watching screen saver process");
         m_process = process;
         m_active  = true;
         m_watch   = new Thread([this](){ watch_process_thread(); });
@@ -247,7 +247,7 @@ void
 MSWindowsScreenSaver::unwatchProcess()
 {
     if (m_watch != nullptr) {
-        LOG((CLOG_DEBUG "stopped watching screen saver process/desktop"));
+        LOG(CLOG_DEBUG "stopped watching screen saver process/desktop");
         m_watch->cancel();
         m_watch->wait();
         delete m_watch;
@@ -288,7 +288,7 @@ void MSWindowsScreenSaver::watch_process_thread()
         Thread::testCancel();
         if (WaitForSingleObject(m_process, 50) == WAIT_OBJECT_0) {
             // process terminated
-            LOG((CLOG_DEBUG "screen saver died"));
+            LOG(CLOG_DEBUG "screen saver died");
 
             // send screen saver deactivation message
             m_active = false;

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -40,7 +40,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG((CLOG_ERR "could not get process snapshot"));
+        LOG(CLOG_ERR "could not get process snapshot");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -51,7 +51,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG((CLOG_ERR "could not get first process entry"));
+        LOG(CLOG_ERR "could not get first process entry");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -72,7 +72,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
             if (!pidToSidRet) {
                 // if we can not acquire session associated with a specified process,
                 // simply ignore it
-                LOG((CLOG_ERR "could not get session id for process id %i", entry.th32ProcessID));
+                LOG(CLOG_ERR "could not get session id for process id %i", entry.th32ProcessID);
                 gotEntry = nextProcessEntry(snapshot, &entry);
                 continue;
             }
@@ -102,21 +102,21 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
             nameListJoin.append(", ");
     }
 
-    LOG((CLOG_DEBUG "processes in session %d: %s",
-        m_activeSessionId, nameListJoin.c_str()));
+    LOG(CLOG_DEBUG "processes in session %d: %s",
+        m_activeSessionId, nameListJoin.c_str());
 
     CloseHandle(snapshot);
 
     if (pid) {
         if (process != nullptr) {
             // now get the process, which we'll use to get the process token.
-            LOG((CLOG_DEBUG "found %s in session %i", name, m_activeSessionId));
+            LOG(CLOG_DEBUG "found %s in session %i", name, m_activeSessionId);
             *process = OpenProcess(MAXIMUM_ALLOWED, FALSE, pid);
         }
         return true;
     }
     else {
-        LOG((CLOG_DEBUG "did not find %s in session %i", name, m_activeSessionId));
+        LOG(CLOG_DEBUG "did not find %s in session %i", name, m_activeSessionId);
         return false;
     }
 }
@@ -126,7 +126,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
 {
     HANDLE sourceToken;
     if (!WTSQueryUserToken(m_activeSessionId, &sourceToken)) {
-        LOG((CLOG_ERR "could not get token from session %d", m_activeSessionId));
+        LOG(CLOG_ERR "could not get token from session %d", m_activeSessionId);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -135,11 +135,11 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
         sourceToken, TOKEN_ASSIGN_PRIMARY | TOKEN_ALL_ACCESS, security,
         SecurityImpersonation, TokenPrimary, &newToken)) {
 
-        LOG((CLOG_ERR "could not duplicate token"));
+        LOG(CLOG_ERR "could not duplicate token");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
-    LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
+    LOG(CLOG_DEBUG "duplicated, new token: %i", newToken);
     return newToken;
 }
 
@@ -166,7 +166,7 @@ MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
         if (err != ERROR_NO_MORE_FILES) {
 
             // only worry about error if it's not the end of the snapshot
-            LOG((CLOG_ERR "could not get next process entry"));
+            LOG(CLOG_ERR "could not get next process entry");
             throw std::runtime_error(error_code_to_string_windows(GetLastError()));
         }
     }
@@ -189,7 +189,7 @@ std::string MSWindowsSession::getActiveDesktopName()
         }
     }
     catch (std::exception& error) {
-        LOG((CLOG_ERR "failed to get active desktop name: %s", error.what()));
+        LOG(CLOG_ERR "failed to get active desktop name: %s", error.what());
     }
 
     return result;

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -40,7 +40,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG(CLOG_ERR "could not get process snapshot");
+        LOG_ERR("could not get process snapshot");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -51,7 +51,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG(CLOG_ERR "could not get first process entry");
+        LOG_ERR("could not get first process entry");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -72,7 +72,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
             if (!pidToSidRet) {
                 // if we can not acquire session associated with a specified process,
                 // simply ignore it
-                LOG(CLOG_ERR "could not get session id for process id %i", entry.th32ProcessID);
+                LOG_ERR("could not get session id for process id %i", entry.th32ProcessID);
                 gotEntry = nextProcessEntry(snapshot, &entry);
                 continue;
             }
@@ -102,7 +102,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
             nameListJoin.append(", ");
     }
 
-    LOG(CLOG_DEBUG "processes in session %d: %s",
+    LOG_DEBUG("processes in session %d: %s",
         m_activeSessionId, nameListJoin.c_str());
 
     CloseHandle(snapshot);
@@ -110,13 +110,13 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     if (pid) {
         if (process != nullptr) {
             // now get the process, which we'll use to get the process token.
-            LOG(CLOG_DEBUG "found %s in session %i", name, m_activeSessionId);
+            LOG_DEBUG("found %s in session %i", name, m_activeSessionId);
             *process = OpenProcess(MAXIMUM_ALLOWED, FALSE, pid);
         }
         return true;
     }
     else {
-        LOG(CLOG_DEBUG "did not find %s in session %i", name, m_activeSessionId);
+        LOG_DEBUG("did not find %s in session %i", name, m_activeSessionId);
         return false;
     }
 }
@@ -126,7 +126,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
 {
     HANDLE sourceToken;
     if (!WTSQueryUserToken(m_activeSessionId, &sourceToken)) {
-        LOG(CLOG_ERR "could not get token from session %d", m_activeSessionId);
+        LOG_ERR("could not get token from session %d", m_activeSessionId);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -135,11 +135,11 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
         sourceToken, TOKEN_ASSIGN_PRIMARY | TOKEN_ALL_ACCESS, security,
         SecurityImpersonation, TokenPrimary, &newToken)) {
 
-        LOG(CLOG_ERR "could not duplicate token");
+        LOG_ERR("could not duplicate token");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
-    LOG(CLOG_DEBUG "duplicated, new token: %i", newToken);
+    LOG_DEBUG("duplicated, new token: %i", newToken);
     return newToken;
 }
 
@@ -166,7 +166,7 @@ MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
         if (err != ERROR_NO_MORE_FILES) {
 
             // only worry about error if it's not the end of the snapshot
-            LOG(CLOG_ERR "could not get next process entry");
+            LOG_ERR("could not get next process entry");
             throw std::runtime_error(error_code_to_string_windows(GetLastError()));
         }
     }
@@ -189,7 +189,7 @@ std::string MSWindowsSession::getActiveDesktopName()
         }
     }
     catch (std::exception& error) {
-        LOG(CLOG_ERR "failed to get active desktop name: %s", error.what());
+        LOG_ERR("failed to get active desktop name: %s", error.what());
     }
 
     return result;

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -57,7 +57,7 @@ std::string activeDesktopName()
             name = buffer;
         CloseDesktop(desk);
     }
-    LOG((CLOG_DEBUG "found desktop name: %.64s", name.c_str()));
+    LOG(CLOG_DEBUG "found desktop name: %.64s", name.c_str());
     return name;
 }
 
@@ -113,11 +113,11 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
         &sourceToken);
 
     if (!tokenRet) {
-        LOG((CLOG_ERR "could not open token, process handle: %d", process));
+        LOG(CLOG_ERR "could not open token, process handle: %d", process);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
-    LOG((CLOG_DEBUG "got token %i, duplicating", sourceToken));
+    LOG(CLOG_DEBUG "got token %i, duplicating", sourceToken);
 
     HANDLE newToken;
     BOOL duplicateRet = DuplicateTokenEx(
@@ -125,11 +125,11 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
         SecurityImpersonation, TokenPrimary, &newToken);
 
     if (!duplicateRet) {
-        LOG((CLOG_ERR "could not duplicate token %i", sourceToken));
+        LOG(CLOG_ERR "could not duplicate token %i", sourceToken);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
-    LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
+    LOG(CLOG_DEBUG "duplicated, new token: %i", newToken);
     return newToken;
 }
 
@@ -141,8 +141,8 @@ MSWindowsWatchdog::getUserToken(LPSECURITY_ATTRIBUTES security)
     // since InputLeap would re-launch as non-elevated after the desk switch,
     // and so would be unusable with the new elevated process taking focus.
     if (m_elevateProcess || m_autoElevated) {
-        LOG((CLOG_DEBUG "getting elevated token, %s",
-            (m_elevateProcess ? "elevation required" : "at login screen")));
+        LOG(CLOG_DEBUG "getting elevated token, %s",
+            (m_elevateProcess ? "elevation required" : "at login screen"));
 
         HANDLE process;
         if (!m_session.isProcessInSession("winlogon.exe", &process)) {
@@ -151,7 +151,7 @@ MSWindowsWatchdog::getUserToken(LPSECURITY_ATTRIBUTES security)
 
         return duplicateProcessToken(process, security);
     } else {
-        LOG((CLOG_DEBUG "getting non-elevated token"));
+        LOG(CLOG_DEBUG "getting non-elevated token");
         return m_session.getUserToken(security);
     }
 }
@@ -163,7 +163,7 @@ void MSWindowsWatchdog::main_loop()
     SendSas sendSasFunc = nullptr;
     HINSTANCE sasLib = LoadLibrary("sas.dll");
     if (sasLib) {
-        LOG((CLOG_DEBUG "found sas.dll"));
+        LOG(CLOG_DEBUG "found sas.dll");
         sendSasFunc = (SendSas)GetProcAddress(sasLib, "SendSAS");
     }
 
@@ -182,7 +182,7 @@ void MSWindowsWatchdog::main_loop()
         try {
 
             if (m_processRunning && getCommand().empty()) {
-                LOG((CLOG_INFO "process started but command is empty, shutting down"));
+                LOG(CLOG_INFO "process started but command is empty, shutting down");
                 shutdownExistingProcesses();
                 m_processRunning = false;
                 continue;
@@ -191,7 +191,7 @@ void MSWindowsWatchdog::main_loop()
             if (m_processFailures != 0) {
                 // increasing backoff period, maximum of 10 seconds.
                 int timeout = (m_processFailures * 2) < 10 ? (m_processFailures * 2) : 10;
-                LOG((CLOG_INFO "backing off, wait=%ds, failures=%d", timeout, m_processFailures));
+                LOG(CLOG_INFO "backing off, wait=%ds, failures=%d", timeout, m_processFailures);
                 inputleap::this_thread_sleep(timeout);
             }
 
@@ -204,8 +204,8 @@ void MSWindowsWatchdog::main_loop()
                 m_processFailures++;
                 m_processRunning = false;
 
-                LOG((CLOG_WARN "detected application not running, pid=%d",
-                    m_processInfo.dwProcessId));
+                LOG(CLOG_WARN "detected application not running, pid=%d",
+                    m_processInfo.dwProcessId);
             }
 
             if (sendSasFunc != nullptr) {
@@ -215,7 +215,7 @@ void MSWindowsWatchdog::main_loop()
 
                     // use SendSAS event to wait for next session (timeout 1 second).
                     if (WaitForSingleObject(sendSasEvent, 1000) == WAIT_OBJECT_0) {
-                        LOG((CLOG_DEBUG "calling SendSAS"));
+                        LOG(CLOG_DEBUG "calling SendSAS");
                         sendSasFunc(FALSE);
                     }
 
@@ -229,13 +229,13 @@ void MSWindowsWatchdog::main_loop()
 
         }
         catch (std::exception& e) {
-            LOG((CLOG_ERR "failed to launch, error: %s", e.what()));
+            LOG(CLOG_ERR "failed to launch, error: %s", e.what());
             m_processFailures++;
             m_processRunning = false;
             continue;
         }
         catch (...) {
-            LOG((CLOG_ERR "failed to launch, unknown error."));
+            LOG(CLOG_ERR "failed to launch, unknown error.");
             m_processFailures++;
             m_processRunning = false;
             continue;
@@ -243,11 +243,11 @@ void MSWindowsWatchdog::main_loop()
     }
 
     if (m_processRunning) {
-        LOG((CLOG_DEBUG "terminated running process on exit"));
+        LOG(CLOG_DEBUG "terminated running process on exit");
         shutdownProcess(m_processInfo.hProcess, m_processInfo.dwProcessId, 20);
     }
 
-    LOG((CLOG_DEBUG "watchdog main thread finished"));
+    LOG(CLOG_DEBUG "watchdog main thread finished");
 }
 
 bool
@@ -274,7 +274,7 @@ MSWindowsWatchdog::startProcess()
     m_commandChanged = false;
 
     if (m_processRunning) {
-        LOG((CLOG_DEBUG "closing existing process to make way for new one"));
+        LOG(CLOG_DEBUG "closing existing process to make way for new one");
         shutdownProcess(m_processInfo.hProcess, m_processInfo.dwProcessId, 20);
         m_processRunning = false;
     }
@@ -302,10 +302,10 @@ MSWindowsWatchdog::startProcess()
     }
 
     if (!createRet) {
-        LOG((CLOG_ERR "could not launch"));
+        LOG(CLOG_ERR "could not launch");
         DWORD exitCode = 0;
         GetExitCodeProcess(m_processInfo.hProcess, &exitCode);
-        LOG((CLOG_ERR "exit code: %d", exitCode));
+        LOG(CLOG_ERR "exit code: %d", exitCode);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
     else {
@@ -318,10 +318,10 @@ MSWindowsWatchdog::startProcess()
         m_processRunning = true;
         m_processFailures = 0;
 
-        LOG((CLOG_DEBUG "started process, session=%i, elevated: %s, command=%s",
+        LOG(CLOG_DEBUG "started process, session=%i, elevated: %s, command=%s",
             m_session.getActiveSessionId(),
             m_elevateProcess ? "yes" : "no",
-            m_command.c_str()));
+            m_command.c_str());
     }
 }
 
@@ -340,7 +340,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsSelf(std::string& command)
     si.hStdOutput = m_stdOutWrite;
     si.dwFlags |= STARTF_USESTDHANDLES;
 
-    LOG((CLOG_INFO "starting new process as self"));
+    LOG(CLOG_INFO "starting new process as self");
     return CreateProcess(nullptr, LPSTR(command.c_str()), nullptr, nullptr, FALSE, creationFlags, nullptr, nullptr, &si, &m_processInfo);
 }
 
@@ -361,7 +361,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
     LPVOID environment;
     BOOL blockRet = CreateEnvironmentBlock(&environment, userToken, FALSE);
     if (!blockRet) {
-        LOG((CLOG_ERR "could not create environment block"));
+        LOG(CLOG_ERR "could not create environment block");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -371,7 +371,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
         CREATE_UNICODE_ENVIRONMENT;
 
     // re-launch in current active user session
-    LOG((CLOG_INFO "starting new process as privileged user"));
+    LOG(CLOG_INFO "starting new process as privileged user");
     BOOL createRet = CreateProcessAsUser(userToken, nullptr, LPSTR(command.c_str()),
                                          sa, nullptr, TRUE, creationFlags,
                                          environment, nullptr, &si, &m_processInfo);
@@ -385,7 +385,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
 void
 MSWindowsWatchdog::setCommand(const std::string& command, bool elevate)
 {
-    LOG((CLOG_INFO "service command updated"));
+    LOG(CLOG_INFO "service command updated");
     m_command = command;
     m_elevateProcess = elevate;
     m_commandChanged = true;
@@ -462,7 +462,7 @@ MSWindowsWatchdog::shutdownProcess(HANDLE handle, DWORD pid, int timeout)
         GetExitCodeProcess(handle, &exitCode);
         if (exitCode != STILL_ACTIVE) {
             // yay, we got a graceful shutdown. there should be no hook in use errors!
-            LOG((CLOG_INFO "process %d was shutdown gracefully", pid));
+            LOG(CLOG_INFO "process %d was shutdown gracefully", pid);
             break;
         }
         else {
@@ -473,7 +473,7 @@ MSWindowsWatchdog::shutdownProcess(HANDLE handle, DWORD pid, int timeout)
                 // calling TerminateProcess on InputLeap is very bad!
                 // it causes the hook DLL to stay loaded in some apps,
                 // making it impossible to start InputLeap again.
-                LOG((CLOG_WARN "shutdown timed out after %d secs, forcefully terminating", (int)elapsed));
+                LOG(CLOG_WARN "shutdown timed out after %d secs, forcefully terminating", (int)elapsed);
                 TerminateProcess(handle, kExitSuccess);
                 break;
             }
@@ -489,7 +489,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG((CLOG_ERR "could not get process snapshot"));
+        LOG(CLOG_ERR "could not get process snapshot");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -500,7 +500,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG((CLOG_ERR "could not get first process entry"));
+        LOG(CLOG_ERR "could not get first process entry");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -527,7 +527,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
             if (err != ERROR_NO_MORE_FILES) {
 
                 // only worry about error if it's not the end of the snapshot
-                LOG((CLOG_ERR "could not get subsiquent process entry"));
+                LOG(CLOG_ERR "could not get subsiquent process entry");
                 throw std::runtime_error(error_code_to_string_windows(GetLastError()));
             }
         }

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -57,7 +57,7 @@ std::string activeDesktopName()
             name = buffer;
         CloseDesktop(desk);
     }
-    LOG(CLOG_DEBUG "found desktop name: %.64s", name.c_str());
+    LOG_DEBUG("found desktop name: %.64s", name.c_str());
     return name;
 }
 
@@ -113,11 +113,11 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
         &sourceToken);
 
     if (!tokenRet) {
-        LOG(CLOG_ERR "could not open token, process handle: %d", process);
+        LOG_ERR("could not open token, process handle: %d", process);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
-    LOG(CLOG_DEBUG "got token %i, duplicating", sourceToken);
+    LOG_DEBUG("got token %i, duplicating", sourceToken);
 
     HANDLE newToken;
     BOOL duplicateRet = DuplicateTokenEx(
@@ -125,11 +125,11 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
         SecurityImpersonation, TokenPrimary, &newToken);
 
     if (!duplicateRet) {
-        LOG(CLOG_ERR "could not duplicate token %i", sourceToken);
+        LOG_ERR("could not duplicate token %i", sourceToken);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
-    LOG(CLOG_DEBUG "duplicated, new token: %i", newToken);
+    LOG_DEBUG("duplicated, new token: %i", newToken);
     return newToken;
 }
 
@@ -141,7 +141,7 @@ MSWindowsWatchdog::getUserToken(LPSECURITY_ATTRIBUTES security)
     // since InputLeap would re-launch as non-elevated after the desk switch,
     // and so would be unusable with the new elevated process taking focus.
     if (m_elevateProcess || m_autoElevated) {
-        LOG(CLOG_DEBUG "getting elevated token, %s",
+        LOG_DEBUG("getting elevated token, %s",
             (m_elevateProcess ? "elevation required" : "at login screen"));
 
         HANDLE process;
@@ -151,7 +151,7 @@ MSWindowsWatchdog::getUserToken(LPSECURITY_ATTRIBUTES security)
 
         return duplicateProcessToken(process, security);
     } else {
-        LOG(CLOG_DEBUG "getting non-elevated token");
+        LOG_DEBUG("getting non-elevated token");
         return m_session.getUserToken(security);
     }
 }
@@ -163,7 +163,7 @@ void MSWindowsWatchdog::main_loop()
     SendSas sendSasFunc = nullptr;
     HINSTANCE sasLib = LoadLibrary("sas.dll");
     if (sasLib) {
-        LOG(CLOG_DEBUG "found sas.dll");
+        LOG_DEBUG("found sas.dll");
         sendSasFunc = (SendSas)GetProcAddress(sasLib, "SendSAS");
     }
 
@@ -182,7 +182,7 @@ void MSWindowsWatchdog::main_loop()
         try {
 
             if (m_processRunning && getCommand().empty()) {
-                LOG(CLOG_INFO "process started but command is empty, shutting down");
+                LOG_INFO("process started but command is empty, shutting down");
                 shutdownExistingProcesses();
                 m_processRunning = false;
                 continue;
@@ -191,7 +191,7 @@ void MSWindowsWatchdog::main_loop()
             if (m_processFailures != 0) {
                 // increasing backoff period, maximum of 10 seconds.
                 int timeout = (m_processFailures * 2) < 10 ? (m_processFailures * 2) : 10;
-                LOG(CLOG_INFO "backing off, wait=%ds, failures=%d", timeout, m_processFailures);
+                LOG_INFO("backing off, wait=%ds, failures=%d", timeout, m_processFailures);
                 inputleap::this_thread_sleep(timeout);
             }
 
@@ -204,7 +204,7 @@ void MSWindowsWatchdog::main_loop()
                 m_processFailures++;
                 m_processRunning = false;
 
-                LOG(CLOG_WARN "detected application not running, pid=%d",
+                LOG_WARN("detected application not running, pid=%d",
                     m_processInfo.dwProcessId);
             }
 
@@ -215,7 +215,7 @@ void MSWindowsWatchdog::main_loop()
 
                     // use SendSAS event to wait for next session (timeout 1 second).
                     if (WaitForSingleObject(sendSasEvent, 1000) == WAIT_OBJECT_0) {
-                        LOG(CLOG_DEBUG "calling SendSAS");
+                        LOG_DEBUG("calling SendSAS");
                         sendSasFunc(FALSE);
                     }
 
@@ -229,13 +229,13 @@ void MSWindowsWatchdog::main_loop()
 
         }
         catch (std::exception& e) {
-            LOG(CLOG_ERR "failed to launch, error: %s", e.what());
+            LOG_ERR("failed to launch, error: %s", e.what());
             m_processFailures++;
             m_processRunning = false;
             continue;
         }
         catch (...) {
-            LOG(CLOG_ERR "failed to launch, unknown error.");
+            LOG_ERR("failed to launch, unknown error.");
             m_processFailures++;
             m_processRunning = false;
             continue;
@@ -243,11 +243,11 @@ void MSWindowsWatchdog::main_loop()
     }
 
     if (m_processRunning) {
-        LOG(CLOG_DEBUG "terminated running process on exit");
+        LOG_DEBUG("terminated running process on exit");
         shutdownProcess(m_processInfo.hProcess, m_processInfo.dwProcessId, 20);
     }
 
-    LOG(CLOG_DEBUG "watchdog main thread finished");
+    LOG_DEBUG("watchdog main thread finished");
 }
 
 bool
@@ -274,7 +274,7 @@ MSWindowsWatchdog::startProcess()
     m_commandChanged = false;
 
     if (m_processRunning) {
-        LOG(CLOG_DEBUG "closing existing process to make way for new one");
+        LOG_DEBUG("closing existing process to make way for new one");
         shutdownProcess(m_processInfo.hProcess, m_processInfo.dwProcessId, 20);
         m_processRunning = false;
     }
@@ -302,10 +302,10 @@ MSWindowsWatchdog::startProcess()
     }
 
     if (!createRet) {
-        LOG(CLOG_ERR "could not launch");
+        LOG_ERR("could not launch");
         DWORD exitCode = 0;
         GetExitCodeProcess(m_processInfo.hProcess, &exitCode);
-        LOG(CLOG_ERR "exit code: %d", exitCode);
+        LOG_ERR("exit code: %d", exitCode);
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
     else {
@@ -318,7 +318,7 @@ MSWindowsWatchdog::startProcess()
         m_processRunning = true;
         m_processFailures = 0;
 
-        LOG(CLOG_DEBUG "started process, session=%i, elevated: %s, command=%s",
+        LOG_DEBUG("started process, session=%i, elevated: %s, command=%s",
             m_session.getActiveSessionId(),
             m_elevateProcess ? "yes" : "no",
             m_command.c_str());
@@ -340,7 +340,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsSelf(std::string& command)
     si.hStdOutput = m_stdOutWrite;
     si.dwFlags |= STARTF_USESTDHANDLES;
 
-    LOG(CLOG_INFO "starting new process as self");
+    LOG_INFO("starting new process as self");
     return CreateProcess(nullptr, LPSTR(command.c_str()), nullptr, nullptr, FALSE, creationFlags, nullptr, nullptr, &si, &m_processInfo);
 }
 
@@ -361,7 +361,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
     LPVOID environment;
     BOOL blockRet = CreateEnvironmentBlock(&environment, userToken, FALSE);
     if (!blockRet) {
-        LOG(CLOG_ERR "could not create environment block");
+        LOG_ERR("could not create environment block");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -371,7 +371,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
         CREATE_UNICODE_ENVIRONMENT;
 
     // re-launch in current active user session
-    LOG(CLOG_INFO "starting new process as privileged user");
+    LOG_INFO("starting new process as privileged user");
     BOOL createRet = CreateProcessAsUser(userToken, nullptr, LPSTR(command.c_str()),
                                          sa, nullptr, TRUE, creationFlags,
                                          environment, nullptr, &si, &m_processInfo);
@@ -385,7 +385,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
 void
 MSWindowsWatchdog::setCommand(const std::string& command, bool elevate)
 {
-    LOG(CLOG_INFO "service command updated");
+    LOG_INFO("service command updated");
     m_command = command;
     m_elevateProcess = elevate;
     m_commandChanged = true;
@@ -462,7 +462,7 @@ MSWindowsWatchdog::shutdownProcess(HANDLE handle, DWORD pid, int timeout)
         GetExitCodeProcess(handle, &exitCode);
         if (exitCode != STILL_ACTIVE) {
             // yay, we got a graceful shutdown. there should be no hook in use errors!
-            LOG(CLOG_INFO "process %d was shutdown gracefully", pid);
+            LOG_INFO("process %d was shutdown gracefully", pid);
             break;
         }
         else {
@@ -473,7 +473,7 @@ MSWindowsWatchdog::shutdownProcess(HANDLE handle, DWORD pid, int timeout)
                 // calling TerminateProcess on InputLeap is very bad!
                 // it causes the hook DLL to stay loaded in some apps,
                 // making it impossible to start InputLeap again.
-                LOG(CLOG_WARN "shutdown timed out after %d secs, forcefully terminating", (int)elapsed);
+                LOG_WARN("shutdown timed out after %d secs, forcefully terminating", (int)elapsed);
                 TerminateProcess(handle, kExitSuccess);
                 break;
             }
@@ -489,7 +489,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG(CLOG_ERR "could not get process snapshot");
+        LOG_ERR("could not get process snapshot");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -500,7 +500,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG(CLOG_ERR "could not get first process entry");
+        LOG_ERR("could not get first process entry");
         throw std::runtime_error(error_code_to_string_windows(GetLastError()));
     }
 
@@ -527,7 +527,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
             if (err != ERROR_NO_MORE_FILES) {
 
                 // only worry about error if it's not the end of the snapshot
-                LOG(CLOG_ERR "could not get subsiquent process entry");
+                LOG_ERR("could not get subsiquent process entry");
                 throw std::runtime_error(error_code_to_string_windows(GetLastError()));
             }
         }

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -41,8 +41,8 @@ OSXClipboard::OSXClipboard() :
 
     OSStatus createErr = PasteboardCreate(kPasteboardClipboard, &m_pboard);
     if (createErr != noErr) {
-        LOG(CLOG_DEBUG "failed to create clipboard reference: error %i", createErr);
-        LOG(CLOG_ERR "unable to connect to pasteboard, clipboard sharing disabled");
+        LOG_DEBUG("failed to create clipboard reference: error %i", createErr);
+        LOG_ERR("unable to connect to pasteboard, clipboard sharing disabled");
         m_pboard = nullptr;
         return;
 
@@ -50,7 +50,7 @@ OSXClipboard::OSXClipboard() :
 
     OSStatus syncErr = PasteboardSynchronize(m_pboard);
     if (syncErr != noErr) {
-        LOG(CLOG_DEBUG "failed to synchronize clipboard: error %i", syncErr);
+        LOG_DEBUG("failed to synchronize clipboard: error %i", syncErr);
     }
 }
 
@@ -62,13 +62,13 @@ OSXClipboard::~OSXClipboard()
     bool
 OSXClipboard::empty()
 {
-    LOG(CLOG_DEBUG "emptying clipboard");
+    LOG_DEBUG("emptying clipboard");
     if (m_pboard == nullptr)
         return false;
 
     OSStatus err = PasteboardClear(m_pboard);
     if (err != noErr) {
-        LOG(CLOG_DEBUG "failed to clear clipboard: error %i", err);
+        LOG_DEBUG("failed to clear clipboard: error %i", err);
         return false;
     }
 
@@ -82,7 +82,7 @@ OSXClipboard::synchronize()
         return false;
 
     PasteboardSyncFlags flags = PasteboardSynchronize(m_pboard);
-    LOG(CLOG_DEBUG2 "flags: %x", flags);
+    LOG_DEBUG2("flags: %x", flags);
 
     if (flags & kPasteboardModified) {
         return true;
@@ -95,15 +95,15 @@ void OSXClipboard::add(EFormat format, const std::string& data)
     if (m_pboard == nullptr)
         return;
 
-    LOG(CLOG_DEBUG "add %zd bytes to clipboard format: %d", data.size(), format);
+    LOG_DEBUG("add %zd bytes to clipboard format: %d", data.size(), format);
     if (format == IClipboard::kText) {
-        LOG(CLOG_DEBUG " format of data to be added to clipboard was kText");
+        LOG_DEBUG(" format of data to be added to clipboard was kText");
     }
     else if (format == IClipboard::kBitmap) {
-        LOG(CLOG_DEBUG " format of data to be added to clipboard was kBitmap");
+        LOG_DEBUG(" format of data to be added to clipboard was kBitmap");
     }
     else if (format == IClipboard::kHTML) {
-        LOG(CLOG_DEBUG " format of data to be added to clipboard was kHTML");
+        LOG_DEBUG(" format of data to be added to clipboard was kHTML");
     }
 
     for (ConverterList::const_iterator index = m_converters.begin();
@@ -126,7 +126,7 @@ void OSXClipboard::add(EFormat format, const std::string& data)
                 dataRef,
                 kPasteboardFlavorNoFlags);
 
-            LOG(CLOG_DEBUG "added %zd bytes to clipboard format: %d", data.size(), format);
+            LOG_DEBUG("added %zd bytes to clipboard format: %d", data.size(), format);
         }
 
     }
@@ -138,7 +138,7 @@ OSXClipboard::open(Time time) const
     if (m_pboard == nullptr)
         return false;
 
-    LOG(CLOG_DEBUG "opening clipboard");
+    LOG_DEBUG("opening clipboard");
     m_time = time;
     return true;
 }
@@ -146,7 +146,7 @@ OSXClipboard::open(Time time) const
 void
 OSXClipboard::close() const
 {
-    LOG(CLOG_DEBUG "closing clipboard");
+    LOG_DEBUG("closing clipboard");
     /* not needed */
 }
 
@@ -213,7 +213,7 @@ std::string OSXClipboard::get(EFormat format) const
 
     // if no converter then we don't recognize any formats
     if (converter == nullptr) {
-        LOG(CLOG_DEBUG "Unable to find converter for data");
+        LOG_DEBUG("Unable to find converter for data");
         return result;
     }
 
@@ -229,10 +229,10 @@ std::string OSXClipboard::get(EFormat format) const
         result = std::string((char *) CFDataGetBytePtr(buffer), CFDataGetLength(buffer));
     }
     catch (OSStatus err) {
-        LOG(CLOG_DEBUG "exception thrown in OSXClipboard::get MacError (%d)", err);
+        LOG_DEBUG("exception thrown in OSXClipboard::get MacError (%d)", err);
     }
     catch (...) {
-        LOG(CLOG_DEBUG "unknown exception in OSXClipboard::get");
+        LOG_DEBUG("unknown exception in OSXClipboard::get");
         RETHROW_XTHREAD
     }
 

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -41,8 +41,8 @@ OSXClipboard::OSXClipboard() :
 
     OSStatus createErr = PasteboardCreate(kPasteboardClipboard, &m_pboard);
     if (createErr != noErr) {
-        LOG((CLOG_DEBUG "failed to create clipboard reference: error %i", createErr));
-        LOG((CLOG_ERR "unable to connect to pasteboard, clipboard sharing disabled"));
+        LOG(CLOG_DEBUG "failed to create clipboard reference: error %i", createErr);
+        LOG(CLOG_ERR "unable to connect to pasteboard, clipboard sharing disabled");
         m_pboard = nullptr;
         return;
 
@@ -50,7 +50,7 @@ OSXClipboard::OSXClipboard() :
 
     OSStatus syncErr = PasteboardSynchronize(m_pboard);
     if (syncErr != noErr) {
-        LOG((CLOG_DEBUG "failed to synchronize clipboard: error %i", syncErr));
+        LOG(CLOG_DEBUG "failed to synchronize clipboard: error %i", syncErr);
     }
 }
 
@@ -62,13 +62,13 @@ OSXClipboard::~OSXClipboard()
     bool
 OSXClipboard::empty()
 {
-    LOG((CLOG_DEBUG "emptying clipboard"));
+    LOG(CLOG_DEBUG "emptying clipboard");
     if (m_pboard == nullptr)
         return false;
 
     OSStatus err = PasteboardClear(m_pboard);
     if (err != noErr) {
-        LOG((CLOG_DEBUG "failed to clear clipboard: error %i", err));
+        LOG(CLOG_DEBUG "failed to clear clipboard: error %i", err);
         return false;
     }
 
@@ -82,7 +82,7 @@ OSXClipboard::synchronize()
         return false;
 
     PasteboardSyncFlags flags = PasteboardSynchronize(m_pboard);
-    LOG((CLOG_DEBUG2 "flags: %x", flags));
+    LOG(CLOG_DEBUG2 "flags: %x", flags);
 
     if (flags & kPasteboardModified) {
         return true;
@@ -95,15 +95,15 @@ void OSXClipboard::add(EFormat format, const std::string& data)
     if (m_pboard == nullptr)
         return;
 
-    LOG((CLOG_DEBUG "add %zd bytes to clipboard format: %d", data.size(), format));
+    LOG(CLOG_DEBUG "add %zd bytes to clipboard format: %d", data.size(), format);
     if (format == IClipboard::kText) {
-        LOG((CLOG_DEBUG " format of data to be added to clipboard was kText"));
+        LOG(CLOG_DEBUG " format of data to be added to clipboard was kText");
     }
     else if (format == IClipboard::kBitmap) {
-        LOG((CLOG_DEBUG " format of data to be added to clipboard was kBitmap"));
+        LOG(CLOG_DEBUG " format of data to be added to clipboard was kBitmap");
     }
     else if (format == IClipboard::kHTML) {
-        LOG((CLOG_DEBUG " format of data to be added to clipboard was kHTML"));
+        LOG(CLOG_DEBUG " format of data to be added to clipboard was kHTML");
     }
 
     for (ConverterList::const_iterator index = m_converters.begin();
@@ -126,7 +126,7 @@ void OSXClipboard::add(EFormat format, const std::string& data)
                 dataRef,
                 kPasteboardFlavorNoFlags);
 
-            LOG((CLOG_DEBUG "added %zd bytes to clipboard format: %d", data.size(), format));
+            LOG(CLOG_DEBUG "added %zd bytes to clipboard format: %d", data.size(), format);
         }
 
     }
@@ -138,7 +138,7 @@ OSXClipboard::open(Time time) const
     if (m_pboard == nullptr)
         return false;
 
-    LOG((CLOG_DEBUG "opening clipboard"));
+    LOG(CLOG_DEBUG "opening clipboard");
     m_time = time;
     return true;
 }
@@ -146,7 +146,7 @@ OSXClipboard::open(Time time) const
 void
 OSXClipboard::close() const
 {
-    LOG((CLOG_DEBUG "closing clipboard"));
+    LOG(CLOG_DEBUG "closing clipboard");
     /* not needed */
 }
 
@@ -213,7 +213,7 @@ std::string OSXClipboard::get(EFormat format) const
 
     // if no converter then we don't recognize any formats
     if (converter == nullptr) {
-        LOG((CLOG_DEBUG "Unable to find converter for data"));
+        LOG(CLOG_DEBUG "Unable to find converter for data");
         return result;
     }
 
@@ -229,10 +229,10 @@ std::string OSXClipboard::get(EFormat format) const
         result = std::string((char *) CFDataGetBytePtr(buffer), CFDataGetLength(buffer));
     }
     catch (OSStatus err) {
-        LOG((CLOG_DEBUG "exception thrown in OSXClipboard::get MacError (%d)", err));
+        LOG(CLOG_DEBUG "exception thrown in OSXClipboard::get MacError (%d)", err);
     }
     catch (...) {
-        LOG((CLOG_DEBUG "unknown exception in OSXClipboard::get"));
+        LOG(CLOG_DEBUG "unknown exception in OSXClipboard::get");
         RETHROW_XTHREAD
     }
 

--- a/src/lib/platform/OSXClipboardBMPConverter.cpp
+++ b/src/lib/platform/OSXClipboardBMPConverter.cpp
@@ -57,7 +57,7 @@ OSXClipboardBMPConverter::getOSXFormat() const
 
 std::string OSXClipboardBMPConverter::fromIClipboard(const std::string& bmp) const
 {
-    LOG((CLOG_DEBUG1 "ENTER OSXClipboardBMPConverter::doFromIClipboard()"));
+    LOG(CLOG_DEBUG1 "ENTER OSXClipboardBMPConverter::doFromIClipboard()");
     // create BMP image
     std::uint8_t header[14];
     std::uint8_t* dst = header;

--- a/src/lib/platform/OSXClipboardBMPConverter.cpp
+++ b/src/lib/platform/OSXClipboardBMPConverter.cpp
@@ -57,7 +57,7 @@ OSXClipboardBMPConverter::getOSXFormat() const
 
 std::string OSXClipboardBMPConverter::fromIClipboard(const std::string& bmp) const
 {
-    LOG(CLOG_DEBUG1 "ENTER OSXClipboardBMPConverter::doFromIClipboard()");
+    LOG_DEBUG1("ENTER OSXClipboardBMPConverter::doFromIClipboard()");
     // create BMP image
     std::uint8_t header[14];
     std::uint8_t* dst = header;

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -186,7 +186,7 @@ KeyModifierMask OSXKeyState::mapModifiersFromOSX(std::uint32_t mask) const
         outMask |= KeyModifierNumLock;
     }
 
-    LOG(CLOG_DEBUG1 "mask=%04x outMask=%04x", mask, outMask);
+    LOG_DEBUG1("mask=%04x outMask=%04x", mask, outMask);
     return outMask;
 }
 
@@ -294,7 +294,7 @@ OSXKeyState::mapKeyFromEvent(KeyIDs& ids,
         // translate key
         UniCharCount count;
         UniChar chars[2];
-        LOG(CLOG_DEBUG2 "modifiers: %08x", modifiers & 0xffu);
+        LOG_DEBUG2("modifiers: %08x", modifiers & 0xffu);
         OSStatus status = UCKeyTranslate(layout,
                             vkCode & 0xffu, action,
                             (modifiers >> 8) & 0xffu,
@@ -387,7 +387,7 @@ OSXKeyState::pollActiveModifiers() const
         outMask |= KeyModifierNumLock;
     }
 
-    LOG(CLOG_DEBUG1 "mask=%04x outMask=%04x", mask, outMask);
+    LOG_DEBUG1("mask=%04x outMask=%04x", mask, outMask);
     return outMask;
 }
 
@@ -402,7 +402,7 @@ std::int32_t OSXKeyState::pollActiveGroup() const
         return i->second;
     }
 
-    LOG(CLOG_DEBUG "can't get the active group, use the first group instead");
+    LOG_DEBUG("can't get the active group, use the first group instead");
 
     return 0;
 }
@@ -456,13 +456,13 @@ OSXKeyState::getKeyMap(inputleap::KeyMap& keyMap)
         if (layoutValid) {
             OSXUchrKeyResource uchr(resource, keyboardType);
             if (uchr.isValid()) {
-                LOG(CLOG_DEBUG1 "using uchr resource for group %d", g);
+                LOG_DEBUG1("using uchr resource for group %d", g);
                 getKeyMap(keyMap, g, uchr);
                 continue;
             }
         }
 
-        LOG(CLOG_DEBUG1 "no keyboard resource for group %d", g);
+        LOG_DEBUG1("no keyboard resource for group %d", g);
     }
 }
 
@@ -594,7 +594,7 @@ OSXKeyState::fakeKey(const Keystroke& keystroke)
         bool keyDown = keystroke.m_data.m_button.m_press;
         CGKeyCode virtualKey = mapKeyButtonToVirtualKey(button);
 
-        LOG(CLOG_DEBUG1
+        LOG_DEBUG1(
             "  button=0x%04x virtualKey=0x%04x keyDown=%s",
             button, virtualKey, keyDown ? "down" : "up");
 
@@ -606,11 +606,11 @@ OSXKeyState::fakeKey(const Keystroke& keystroke)
     case Keystroke::kGroup: {
         std::int32_t group = keystroke.m_data.m_group.m_group;
         if (keystroke.m_data.m_group.m_absolute) {
-            LOG(CLOG_DEBUG1 "  group %d", group);
+            LOG_DEBUG1("  group %d", group);
             setGroup(group);
         }
         else {
-            LOG(CLOG_DEBUG1 "  group %+d", group);
+            LOG_DEBUG1("  group %+d", group);
             setGroup(getEffectiveGroup(pollActiveGroup(), group));
         }
         break;
@@ -856,7 +856,7 @@ OSXKeyState::getGroups(GroupList& groups) const
     gotLayouts = (n != 0);
 
     if (!gotLayouts) {
-        LOG(CLOG_DEBUG1 "can't get keyboard layouts");
+        LOG_DEBUG1("can't get keyboard layouts");
         return false;
     }
 

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -186,7 +186,7 @@ KeyModifierMask OSXKeyState::mapModifiersFromOSX(std::uint32_t mask) const
         outMask |= KeyModifierNumLock;
     }
 
-    LOG((CLOG_DEBUG1 "mask=%04x outMask=%04x", mask, outMask));
+    LOG(CLOG_DEBUG1 "mask=%04x outMask=%04x", mask, outMask);
     return outMask;
 }
 
@@ -294,7 +294,7 @@ OSXKeyState::mapKeyFromEvent(KeyIDs& ids,
         // translate key
         UniCharCount count;
         UniChar chars[2];
-        LOG((CLOG_DEBUG2 "modifiers: %08x", modifiers & 0xffu));
+        LOG(CLOG_DEBUG2 "modifiers: %08x", modifiers & 0xffu);
         OSStatus status = UCKeyTranslate(layout,
                             vkCode & 0xffu, action,
                             (modifiers >> 8) & 0xffu,
@@ -387,7 +387,7 @@ OSXKeyState::pollActiveModifiers() const
         outMask |= KeyModifierNumLock;
     }
 
-    LOG((CLOG_DEBUG1 "mask=%04x outMask=%04x", mask, outMask));
+    LOG(CLOG_DEBUG1 "mask=%04x outMask=%04x", mask, outMask);
     return outMask;
 }
 
@@ -402,7 +402,7 @@ std::int32_t OSXKeyState::pollActiveGroup() const
         return i->second;
     }
 
-    LOG((CLOG_DEBUG "can't get the active group, use the first group instead"));
+    LOG(CLOG_DEBUG "can't get the active group, use the first group instead");
 
     return 0;
 }
@@ -456,13 +456,13 @@ OSXKeyState::getKeyMap(inputleap::KeyMap& keyMap)
         if (layoutValid) {
             OSXUchrKeyResource uchr(resource, keyboardType);
             if (uchr.isValid()) {
-                LOG((CLOG_DEBUG1 "using uchr resource for group %d", g));
+                LOG(CLOG_DEBUG1 "using uchr resource for group %d", g);
                 getKeyMap(keyMap, g, uchr);
                 continue;
             }
         }
 
-        LOG((CLOG_DEBUG1 "no keyboard resource for group %d", g));
+        LOG(CLOG_DEBUG1 "no keyboard resource for group %d", g);
     }
 }
 
@@ -594,9 +594,9 @@ OSXKeyState::fakeKey(const Keystroke& keystroke)
         bool keyDown = keystroke.m_data.m_button.m_press;
         CGKeyCode virtualKey = mapKeyButtonToVirtualKey(button);
 
-        LOG((CLOG_DEBUG1
+        LOG(CLOG_DEBUG1
             "  button=0x%04x virtualKey=0x%04x keyDown=%s",
-            button, virtualKey, keyDown ? "down" : "up"));
+            button, virtualKey, keyDown ? "down" : "up");
 
         postHIDVirtualKey(virtualKey, keyDown);
 
@@ -606,11 +606,11 @@ OSXKeyState::fakeKey(const Keystroke& keystroke)
     case Keystroke::kGroup: {
         std::int32_t group = keystroke.m_data.m_group.m_group;
         if (keystroke.m_data.m_group.m_absolute) {
-            LOG((CLOG_DEBUG1 "  group %d", group));
+            LOG(CLOG_DEBUG1 "  group %d", group);
             setGroup(group);
         }
         else {
-            LOG((CLOG_DEBUG1 "  group %+d", group));
+            LOG(CLOG_DEBUG1 "  group %+d", group);
             setGroup(getEffectiveGroup(pollActiveGroup(), group));
         }
         break;
@@ -856,7 +856,7 @@ OSXKeyState::getGroups(GroupList& groups) const
     gotLayouts = (n != 0);
 
     if (!gotLayouts) {
-        LOG((CLOG_DEBUG1 "can't get keyboard layouts"));
+        LOG(CLOG_DEBUG1 "can't get keyboard layouts");
         return false;
     }
 

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -144,7 +144,7 @@ OSXScreen::OSXScreen(IEventQueue* events, bool isPrimary, bool autoShowHideCurso
 
 		// create thread for monitoring system power state.
         is_pm_thread_ready_ = false;
-		LOG(CLOG_DEBUG "starting watchSystemPowerThread");
+		LOG_DEBUG("starting watchSystemPowerThread");
         m_pmWatchThread = new Thread([this](){ watchSystemPowerThread(); });
 	}
 	catch (...) {
@@ -182,7 +182,7 @@ OSXScreen::~OSXScreen()
 		}
 
 		// now exit the thread's runloop and wait for it to exit
-		LOG(CLOG_DEBUG "stopping watchSystemPowerThread");
+		LOG_DEBUG("stopping watchSystemPowerThread");
 		CFRunLoopStop(m_pmRunloop);
 		m_pmWatchThread->wait();
 		delete m_pmWatchThread;
@@ -289,7 +289,7 @@ std::uint32_t OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
     // get mac virtual key and modifier mask matching InputLeap key and mask
 	std::uint32_t macKey, macMask;
     if (!m_keyState->map_hot_key_to_mac(key, mask, macKey, macMask)) {
-		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
+		LOG_DEBUG("could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 
@@ -328,13 +328,13 @@ std::uint32_t OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 	if (!okay) {
 		m_oldHotKeyIDs.push_back(id);
 		m_hotKeyToIDMap.erase(HotKeyItem(macKey, macMask));
-		LOG(CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
+		LOG_WARN("failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
 		return 0;
 	}
 
 	m_hotKeys.insert(std::make_pair(id, HotKeyItem(ref, macKey, macMask)));
 
-	LOG(CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
+	LOG_DEBUG("registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
 	return id;
 }
 
@@ -364,10 +364,10 @@ void OSXScreen::unregisterHotKey(std::uint32_t id)
 		}
 	}
 	if (!okay) {
-		LOG(CLOG_WARN "failed to unregister hotkey id=%d", id);
+		LOG_WARN("failed to unregister hotkey id=%d", id);
 	}
 	else {
-		LOG(CLOG_DEBUG "unregistered hotkey id=%d", id);
+		LOG_DEBUG("unregistered hotkey id=%d", id);
 	}
 
 	// discard hot key from map and record old id for reuse
@@ -524,7 +524,7 @@ OSXScreen::fakeMouseButton(ButtonID id, bool press)
 
     EMouseButtonState state = press ? kMouseButtonDown : kMouseButtonUp;
 
-    LOG(CLOG_DEBUG1 "faking mouse button id: %d press: %s", index, press ? "pressed" : "released");
+    LOG_DEBUG1("faking mouse button id: %d press: %s", index, press ? "pressed" : "released");
 
     MouseButtonEventMapType thisButtonMap = MouseButtonEventMap[index];
     CGEventType type = thisButtonMap[state];
@@ -571,15 +571,15 @@ void OSXScreen::get_drop_target_thread()
 	}
 
     if (cstr != nullptr) {
-		LOG(CLOG_DEBUG "drop target: %s", cstr);
+		LOG_DEBUG("drop target: %s", cstr);
 		m_dropTarget = cstr;
 	}
 	else {
-		LOG(CLOG_ERR "failed to get drop target");
+		LOG_ERR("failed to get drop target");
 		m_dropTarget.clear();
 	}
 #else
-	LOG(CLOG_WARN "drag drop not supported");
+	LOG_WARN("drag drop not supported");
 #endif
 	m_fakeDraggingStarted = false;
 }
@@ -653,7 +653,7 @@ void OSXScreen::fakeMouseWheel(std::int32_t xDelta, std::int32_t yDelta) const
 void
 OSXScreen::showCursor()
 {
-	LOG(CLOG_DEBUG "showing cursor");
+	LOG_DEBUG("showing cursor");
 
     CFStringRef propertyString = CFStringCreateWithCString(nullptr, "SetsCursorInBackground",
                                                            kCFStringEncodingMacRoman);
@@ -666,7 +666,7 @@ OSXScreen::showCursor()
 
 	CGError error = CGDisplayShowCursor(m_displayID);
 	if (error != kCGErrorSuccess) {
-		LOG(CLOG_ERR "failed to show cursor, error=%d", error);
+		LOG_ERR("failed to show cursor, error=%d", error);
 	}
 
 	// appears to fix "mouse randomly not showing" bug
@@ -680,7 +680,7 @@ OSXScreen::showCursor()
 void
 OSXScreen::hideCursor()
 {
-	LOG(CLOG_DEBUG "hiding cursor");
+	LOG_DEBUG("hiding cursor");
 
     CFStringRef propertyString = CFStringCreateWithCString(nullptr, "SetsCursorInBackground",
                                                            kCFStringEncodingMacRoman);
@@ -693,7 +693,7 @@ OSXScreen::hideCursor()
 
 	CGError error = CGDisplayHideCursor(m_displayID);
 	if (error != kCGErrorSuccess) {
-		LOG(CLOG_ERR "failed to hide cursor, error=%d", error);
+		LOG_ERR("failed to hide cursor, error=%d", error);
 	}
 
 	// appears to fix "mouse randomly not hiding" bug
@@ -741,12 +741,12 @@ OSXScreen::enable()
 	}
 
 	if (!m_eventTapPort) {
-		LOG(CLOG_ERR "failed to create quartz event tap");
+		LOG_ERR("failed to create quartz event tap");
 	}
 
 	m_eventTapRLSR = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, m_eventTapPort, 0);
 	if (!m_eventTapRLSR) {
-		LOG(CLOG_ERR "failed to create a CFRunLoopSourceRef for the quartz event tap");
+		LOG_ERR("failed to create a CFRunLoopSourceRef for the quartz event tap");
 	}
 
 	CFRunLoopAddSource(CFRunLoopGetCurrent(), m_eventTapRLSR, kCFRunLoopDefaultMode);
@@ -842,7 +842,7 @@ OSXScreen::leave()
                 std::string info;
 				std::uint32_t fileCount = DragInformation::setupDragInfo(dragFileList, info);
 				client->sendDragInfo(fileCount, info, info.size());
-				LOG(CLOG_DEBUG "send dragging file to server");
+				LOG_DEBUG("send dragging file to server");
 
 				// TODO: what to do with multiple file or even
 				// a folder
@@ -867,7 +867,7 @@ bool
 OSXScreen::setClipboard(ClipboardID, const IClipboard* src)
 {
     if (src != nullptr) {
-		LOG(CLOG_DEBUG "setting clipboard");
+		LOG_DEBUG("setting clipboard");
 		Clipboard::copy(&m_pasteboard, src);
 	}
 	return true;
@@ -876,9 +876,9 @@ OSXScreen::setClipboard(ClipboardID, const IClipboard* src)
 void
 OSXScreen::checkClipboards()
 {
-	LOG(CLOG_DEBUG2 "checking clipboard");
+	LOG_DEBUG2("checking clipboard");
 	if (m_pasteboard.synchronize()) {
-		LOG(CLOG_DEBUG "clipboard changed");
+		LOG_DEBUG("clipboard changed");
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardClipboard);
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardSelection);
 	}
@@ -1001,19 +1001,19 @@ void OSXScreen::handle_system_event(const Event& event)
         SendEventToEventTarget(*carbonEvent, nullptr);
 		switch (GetEventKind(*carbonEvent)) {
 		case kEventWindowActivated:
-			LOG(CLOG_DEBUG1 "window activated");
+			LOG_DEBUG1("window activated");
 			break;
 
 		case kEventWindowDeactivated:
-			LOG(CLOG_DEBUG1 "window deactivated");
+			LOG_DEBUG1("window deactivated");
 			break;
 
 		case kEventWindowFocusAcquired:
-			LOG(CLOG_DEBUG1 "focus acquired");
+			LOG_DEBUG1("focus acquired");
 			break;
 
 		case kEventWindowFocusRelinquish:
-			LOG(CLOG_DEBUG1 "focus released");
+			LOG_DEBUG1("focus released");
 			break;
 		}
 		break;
@@ -1027,7 +1027,7 @@ void OSXScreen::handle_system_event(const Event& event)
 bool
 OSXScreen::onMouseMove(CGFloat mx, CGFloat my)
 {
-	LOG(CLOG_DEBUG2 "mouse move %+f,%+f", mx, my);
+	LOG_DEBUG2("mouse move %+f,%+f", mx, my);
 
 	CGFloat x = mx - m_xCursor;
 	CGFloat y = my - m_yCursor;
@@ -1063,7 +1063,7 @@ OSXScreen::onMouseMove(CGFloat mx, CGFloat my)
 			 x + bogusZoneSize > m_x + m_w - m_xCenter ||
 			-y + bogusZoneSize > m_yCenter - m_y ||
 			 y + bogusZoneSize > m_y + m_h - m_yCenter) {
-			LOG(CLOG_DEBUG "dropped bogus motion %+.2f,%+.2f", x, y);
+			LOG_DEBUG("dropped bogus motion %+.2f,%+.2f", x, y);
 		}
 		else {
 			// send motion
@@ -1095,7 +1095,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
     ButtonID button = map_button_from_osx(macButton);
 
 	if (pressed) {
-		LOG(CLOG_DEBUG1 "event: button press button=%d", button);
+		LOG_DEBUG1("event: button press button=%d", button);
 		if (button != kButtonNone) {
 			KeyModifierMask mask = m_keyState->getActiveModifiers();
             sendEvent(EventType::PRIMARY_SCREEN_BUTTON_DOWN,
@@ -1103,7 +1103,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
 		}
 	}
 	else {
-		LOG(CLOG_DEBUG1 "event: button release button=%d", button);
+		LOG_DEBUG1("event: button release button=%d", button);
 		if (button != kButtonNone) {
 			KeyModifierMask mask = m_keyState->getActiveModifiers();
             sendEvent(EventType::PRIMARY_SCREEN_BUTTON_UP,
@@ -1132,7 +1132,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
 		m_buttonState.set(kButtonLeft - 1, state);
 		if (pressed) {
 			m_draggingFilename.clear();
-			LOG(CLOG_DEBUG2 "dragging file directory is cleared");
+			LOG_DEBUG2("dragging file directory is cleared");
 		}
 		else {
 			if (m_fakeDraggingStarted) {
@@ -1148,7 +1148,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
 
 bool OSXScreen::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta) const
 {
-	LOG(CLOG_DEBUG1 "event: button wheel delta=%+d,%+d", xDelta, yDelta);
+	LOG_DEBUG1("event: button wheel delta=%+d,%+d", xDelta, yDelta);
     sendEvent(EventType::PRIMARY_SCREEN_WHEEL,
               create_event_data<WheelInfo>(WheelInfo{xDelta, yDelta}));
 	return true;
@@ -1172,11 +1172,11 @@ OSXScreen::displayReconfigurationCallback(CGDirectDisplayID displayID, CGDisplay
 		kCGDisplayMirrorFlag | kCGDisplayUnMirrorFlag |
 		kCGDisplayDesktopShapeChangedFlag;
 
-	LOG(CLOG_DEBUG1 "event: display was reconfigured: %x %x %x", flags, mask, flags & mask);
+	LOG_DEBUG1("event: display was reconfigured: %x %x %x", flags, mask, flags & mask);
 
 	if (flags & mask) { /* Something actually did change */
 
-		LOG(CLOG_DEBUG1 "event: screen changed shape; refreshing dimensions");
+		LOG_DEBUG1("event: screen changed shape; refreshing dimensions");
 		screen->updateScreenShape(displayID, flags);
 	}
 }
@@ -1189,7 +1189,7 @@ OSXScreen::onKey(CGEventRef event)
 	// get the key and active modifiers
 	std::uint32_t virtualKey = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
 	CGEventFlags macMask = CGEventGetFlags(event);
-	LOG(CLOG_DEBUG1 "event: Key event kind: %d, keycode=%d", eventKind, virtualKey);
+	LOG_DEBUG1("event: Key event kind: %d, keycode=%d", eventKind, virtualKey);
 
 	// Special handling to track state of modifiers
 	if (eventKind == kCGEventFlagsChanged) {
@@ -1295,11 +1295,11 @@ OSXScreen::onMediaKey(CGEventRef event)
 	bool isRepeat;
 
 	if (!getMediaKeyEventInfo (event, &keyID, &down, &isRepeat)) {
-		LOG(CLOG_ERR "Failed to decode media key event");
+		LOG_ERR("Failed to decode media key event");
 		return;
 	}
 
-	LOG(CLOG_DEBUG2 "Media key event: keyID=0x%02x, %s, repeat=%s",
+	LOG_DEBUG2("Media key event: keyID=0x%02x, %s, repeat=%s",
 						keyID, (down ? "down": "up"),
 						(isRepeat ? "yes" : "no"));
 
@@ -1513,7 +1513,7 @@ OSXScreen::updateScreenShape()
 	// We want to notify the peer screen whether we are primary screen or not
     sendEvent(EventType::SCREEN_SHAPE_CHANGED);
 
-	LOG(CLOG_DEBUG "screen shape: center=%d,%d size=%dx%d on %u %s",
+	LOG_DEBUG("screen shape: center=%d,%d size=%dx%d on %u %s",
          m_x, m_y, m_w, m_h, displayCount,
          (displayCount == 1) ? "display" : "displays");
 }
@@ -1538,11 +1538,11 @@ OSXScreen::userSwitchCallback(EventHandlerCallRef nextHandler,
 	IEventQueue* events = screen->getEvents();
 
 	if (kind == kEventSystemUserSessionDeactivated) {
-		LOG(CLOG_DEBUG "user session deactivated");
+		LOG_DEBUG("user session deactivated");
         events->add_event(EventType::SCREEN_SUSPEND, screen->get_event_target());
 	}
 	else if (kind == kEventSystemUserSessionActivated) {
-		LOG(CLOG_DEBUG "user session activated");
+		LOG_DEBUG("user session activated");
         events->add_event(EventType::SCREEN_RESUME, screen->get_event_target());
 	}
 	return (CallNextEventHandler(nextHandler, theEvent));
@@ -1569,7 +1569,7 @@ void OSXScreen::watchSystemPowerThread()
 	m_pmRootPort = IORegisterForSystemPower(this, &notificationPortRef,
 											powerChangeCallback, &notifier);
 	if (m_pmRootPort == 0) {
-		LOG(CLOG_WARN "IORegisterForSystemPower failed");
+		LOG_WARN("IORegisterForSystemPower failed");
 	}
 	else {
 		runloopSourceRef =
@@ -1589,13 +1589,13 @@ void OSXScreen::watchSystemPowerThread()
     // setting is_pm_thread_ready_ to true otherwise the parent thread will
 	// block waiting for it.
 	if (m_pmRootPort == 0) {
-		LOG(CLOG_WARN "failed to init watchSystemPowerThread");
+		LOG_WARN("failed to init watchSystemPowerThread");
 		return;
 	}
 
-	LOG(CLOG_DEBUG "started watchSystemPowerThread");
+	LOG_DEBUG("started watchSystemPowerThread");
 
-	LOG(CLOG_DEBUG "waiting for event loop");
+	LOG_DEBUG("waiting for event loop");
 	m_events->waitForReady();
 
 #if defined(MAC_OS_X_VERSION_10_7)
@@ -1605,7 +1605,7 @@ void OSXScreen::watchSystemPowerThread()
 
 			// we signalling carbon loop ready before starting
 			// unless we know how to do it within the loop
-			LOG(CLOG_DEBUG "signalling carbon loop ready");
+			LOG_DEBUG("signalling carbon loop ready");
 
             is_carbon_loop_ready_ = true;
             cardon_loop_ready_cv_.notify_one();
@@ -1614,9 +1614,9 @@ void OSXScreen::watchSystemPowerThread()
 #endif
 
 	// start the run loop
-	LOG(CLOG_DEBUG "starting carbon loop");
+	LOG_DEBUG("starting carbon loop");
 	CFRunLoopRun();
-	LOG(CLOG_DEBUG "carbon loop has stopped");
+	LOG_DEBUG("carbon loop has stopped");
 
 	// cleanup
 	if (notificationPortRef) {
@@ -1629,7 +1629,7 @@ void OSXScreen::watchSystemPowerThread()
     std::lock_guard<std::mutex> lock(pm_mutex_);
 	IODeregisterForSystemPower(&notifier);
 	m_pmRootPort = 0;
-	LOG(CLOG_DEBUG "stopped watchSystemPowerThread");
+	LOG_DEBUG("stopped watchSystemPowerThread");
 }
 
 void
@@ -1653,7 +1653,7 @@ OSXScreen::handlePowerChangeRequest(natural_t messageType, void* messageArg)
 		return;
 
 	case kIOMessageSystemHasPoweredOn:
-		LOG(CLOG_DEBUG "system wakeup");
+		LOG_DEBUG("system wakeup");
         m_events->add_event(EventType::SCREEN_RESUME, get_event_target());
 		break;
 
@@ -1677,7 +1677,7 @@ void OSXScreen::handle_confirm_sleep(const Event& event)
             m_events->add_event(EventType::SCREEN_SUSPEND, get_event_target(),
                                 nullptr, Event::kDeliverImmediately);
 
-			LOG(CLOG_DEBUG "system will sleep");
+			LOG_DEBUG("system will sleep");
 			IOAllowPowerChange(m_pmRootPort, messageArg);
 		}
 	}
@@ -1829,7 +1829,7 @@ OSXScreen::handleCGInputEventSecondary(
 		CGPoint pos = CGEventGetLocation(event);
 		if (pos.x != screen->m_xCenter || pos.y != screen->m_yCenter) {
 
-			LOG(CLOG_DEBUG "show cursor on secondary, type=%d pos=%.2f,%.2f",
+			LOG_DEBUG("show cursor on secondary, type=%d pos=%.2f,%.2f",
 					type, pos.x, pos.y);
 			screen->showCursor();
 		}
@@ -1885,26 +1885,26 @@ OSXScreen::handleCGInputEvent(CGEventTapProxy proxy,
 		case kCGEventTapDisabledByTimeout:
 			// Re-enable our event-tap
 			CGEventTapEnable(screen->m_eventTapPort, true);
-			LOG(CLOG_INFO "quartz event tap was disabled by timeout, re-enabling");
+			LOG_INFO("quartz event tap was disabled by timeout, re-enabling");
 			break;
 		case kCGEventTapDisabledByUserInput:
-			LOG(CLOG_ERR "quartz event tap was disabled by user input");
+			LOG_ERR("quartz event tap was disabled by user input");
 			break;
 		case NX_NULLEVENT:
 			break;
 		default:
 			if (type == NX_SYSDEFINED) {
 			if (isMediaKeyEvent (event)) {
-				LOG(CLOG_DEBUG2 "detected media key event");
+				LOG_DEBUG2("detected media key event");
 				screen->onMediaKey (event);
 			} else {
-				LOG(CLOG_DEBUG2 "ignoring unknown system defined event");
+				LOG_DEBUG2("ignoring unknown system defined event");
 				return event;
 			}
 			break;
 			}
 
-			LOG(CLOG_DEBUG3 "unknown quartz event type: 0x%02x", type);
+			LOG_DEBUG3("unknown quartz event type: 0x%02x", type);
 	}
 
 	if (screen->m_isOnScreen) {
@@ -1985,7 +1985,7 @@ OSXScreen::fakeDraggingFiles(DragFileList fileList)
 #if defined(MAC_OS_X_VERSION_10_7)
 	fakeDragging(fileExt.c_str(), m_xCursor, m_yCursor);
 #else
-	LOG(CLOG_WARN "drag drop not supported");
+	LOG_WARN("drag drop not supported");
 #endif
 }
 
@@ -1999,7 +1999,7 @@ std::string& OSXScreen::getDraggingFilename()
 			m_draggingFilename.clear();
 		}
 		else {
-			LOG(CLOG_DEBUG "drag info: %s", info);
+			LOG_DEBUG("drag info: %s", info);
 			CFRelease(dragInfo);
             std::string fileList = info;
 			m_draggingFilename = fileList;
@@ -2018,20 +2018,20 @@ OSXScreen::waitForCarbonLoop() const
 {
 #if defined(MAC_OS_X_VERSION_10_7)
     if (is_carbon_loop_ready_) {
-		LOG(CLOG_DEBUG "carbon loop already ready");
+		LOG_DEBUG("carbon loop already ready");
 		return;
 	}
 
     std::unique_lock<std::mutex> lock(carbon_loop_mutex_);
 
-	LOG(CLOG_DEBUG "waiting for carbon loop");
+	LOG_DEBUG("waiting for carbon loop");
 
     while (!cardon_loop_ready_cv_.wait_for(lock, std::chrono::seconds{kCarbonLoopWaitTimeout},
                                            [this](){ return is_carbon_loop_ready_; })) {
-        LOG(CLOG_DEBUG "carbon loop not ready, waiting again");
+        LOG_DEBUG("carbon loop not ready, waiting again");
     }
 
-	LOG(CLOG_DEBUG "carbon loop ready");
+	LOG_DEBUG("carbon loop ready");
 #endif
 
 }
@@ -2063,7 +2063,7 @@ logCursorVisibility()
 {
 	// CGCursorIsVisible is probably deprecated because its unreliable.
 	if (!CGCursorIsVisible()) {
-		LOG(CLOG_WARN "cursor may not be visible");
+		LOG_WARN("cursor may not be visible");
 	}
 }
 

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -144,7 +144,7 @@ OSXScreen::OSXScreen(IEventQueue* events, bool isPrimary, bool autoShowHideCurso
 
 		// create thread for monitoring system power state.
         is_pm_thread_ready_ = false;
-		LOG((CLOG_DEBUG "starting watchSystemPowerThread"));
+		LOG(CLOG_DEBUG "starting watchSystemPowerThread");
         m_pmWatchThread = new Thread([this](){ watchSystemPowerThread(); });
 	}
 	catch (...) {
@@ -182,7 +182,7 @@ OSXScreen::~OSXScreen()
 		}
 
 		// now exit the thread's runloop and wait for it to exit
-		LOG((CLOG_DEBUG "stopping watchSystemPowerThread"));
+		LOG(CLOG_DEBUG "stopping watchSystemPowerThread");
 		CFRunLoopStop(m_pmRunloop);
 		m_pmWatchThread->wait();
 		delete m_pmWatchThread;
@@ -289,7 +289,7 @@ std::uint32_t OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
     // get mac virtual key and modifier mask matching InputLeap key and mask
 	std::uint32_t macKey, macMask;
     if (!m_keyState->map_hot_key_to_mac(key, mask, macKey, macMask)) {
-		LOG((CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask));
+		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 
@@ -328,13 +328,13 @@ std::uint32_t OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 	if (!okay) {
 		m_oldHotKeyIDs.push_back(id);
 		m_hotKeyToIDMap.erase(HotKeyItem(macKey, macMask));
-		LOG((CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask));
+		LOG(CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
 		return 0;
 	}
 
 	m_hotKeys.insert(std::make_pair(id, HotKeyItem(ref, macKey, macMask)));
 
-	LOG((CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id));
+	LOG(CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
 	return id;
 }
 
@@ -364,10 +364,10 @@ void OSXScreen::unregisterHotKey(std::uint32_t id)
 		}
 	}
 	if (!okay) {
-		LOG((CLOG_WARN "failed to unregister hotkey id=%d", id));
+		LOG(CLOG_WARN "failed to unregister hotkey id=%d", id);
 	}
 	else {
-		LOG((CLOG_DEBUG "unregistered hotkey id=%d", id));
+		LOG(CLOG_DEBUG "unregistered hotkey id=%d", id);
 	}
 
 	// discard hot key from map and record old id for reuse
@@ -524,7 +524,7 @@ OSXScreen::fakeMouseButton(ButtonID id, bool press)
 
     EMouseButtonState state = press ? kMouseButtonDown : kMouseButtonUp;
 
-    LOG((CLOG_DEBUG1 "faking mouse button id: %d press: %s", index, press ? "pressed" : "released"));
+    LOG(CLOG_DEBUG1 "faking mouse button id: %d press: %s", index, press ? "pressed" : "released");
 
     MouseButtonEventMapType thisButtonMap = MouseButtonEventMap[index];
     CGEventType type = thisButtonMap[state];
@@ -571,15 +571,15 @@ void OSXScreen::get_drop_target_thread()
 	}
 
     if (cstr != nullptr) {
-		LOG((CLOG_DEBUG "drop target: %s", cstr));
+		LOG(CLOG_DEBUG "drop target: %s", cstr);
 		m_dropTarget = cstr;
 	}
 	else {
-		LOG((CLOG_ERR "failed to get drop target"));
+		LOG(CLOG_ERR "failed to get drop target");
 		m_dropTarget.clear();
 	}
 #else
-	LOG((CLOG_WARN "drag drop not supported"));
+	LOG(CLOG_WARN "drag drop not supported");
 #endif
 	m_fakeDraggingStarted = false;
 }
@@ -653,7 +653,7 @@ void OSXScreen::fakeMouseWheel(std::int32_t xDelta, std::int32_t yDelta) const
 void
 OSXScreen::showCursor()
 {
-	LOG((CLOG_DEBUG "showing cursor"));
+	LOG(CLOG_DEBUG "showing cursor");
 
     CFStringRef propertyString = CFStringCreateWithCString(nullptr, "SetsCursorInBackground",
                                                            kCFStringEncodingMacRoman);
@@ -666,7 +666,7 @@ OSXScreen::showCursor()
 
 	CGError error = CGDisplayShowCursor(m_displayID);
 	if (error != kCGErrorSuccess) {
-		LOG((CLOG_ERR "failed to show cursor, error=%d", error));
+		LOG(CLOG_ERR "failed to show cursor, error=%d", error);
 	}
 
 	// appears to fix "mouse randomly not showing" bug
@@ -680,7 +680,7 @@ OSXScreen::showCursor()
 void
 OSXScreen::hideCursor()
 {
-	LOG((CLOG_DEBUG "hiding cursor"));
+	LOG(CLOG_DEBUG "hiding cursor");
 
     CFStringRef propertyString = CFStringCreateWithCString(nullptr, "SetsCursorInBackground",
                                                            kCFStringEncodingMacRoman);
@@ -693,7 +693,7 @@ OSXScreen::hideCursor()
 
 	CGError error = CGDisplayHideCursor(m_displayID);
 	if (error != kCGErrorSuccess) {
-		LOG((CLOG_ERR "failed to hide cursor, error=%d", error));
+		LOG(CLOG_ERR "failed to hide cursor, error=%d", error);
 	}
 
 	// appears to fix "mouse randomly not hiding" bug
@@ -741,12 +741,12 @@ OSXScreen::enable()
 	}
 
 	if (!m_eventTapPort) {
-		LOG((CLOG_ERR "failed to create quartz event tap"));
+		LOG(CLOG_ERR "failed to create quartz event tap");
 	}
 
 	m_eventTapRLSR = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, m_eventTapPort, 0);
 	if (!m_eventTapRLSR) {
-		LOG((CLOG_ERR "failed to create a CFRunLoopSourceRef for the quartz event tap"));
+		LOG(CLOG_ERR "failed to create a CFRunLoopSourceRef for the quartz event tap");
 	}
 
 	CFRunLoopAddSource(CFRunLoopGetCurrent(), m_eventTapRLSR, kCFRunLoopDefaultMode);
@@ -842,7 +842,7 @@ OSXScreen::leave()
                 std::string info;
 				std::uint32_t fileCount = DragInformation::setupDragInfo(dragFileList, info);
 				client->sendDragInfo(fileCount, info, info.size());
-				LOG((CLOG_DEBUG "send dragging file to server"));
+				LOG(CLOG_DEBUG "send dragging file to server");
 
 				// TODO: what to do with multiple file or even
 				// a folder
@@ -867,7 +867,7 @@ bool
 OSXScreen::setClipboard(ClipboardID, const IClipboard* src)
 {
     if (src != nullptr) {
-		LOG((CLOG_DEBUG "setting clipboard"));
+		LOG(CLOG_DEBUG "setting clipboard");
 		Clipboard::copy(&m_pasteboard, src);
 	}
 	return true;
@@ -876,9 +876,9 @@ OSXScreen::setClipboard(ClipboardID, const IClipboard* src)
 void
 OSXScreen::checkClipboards()
 {
-	LOG((CLOG_DEBUG2 "checking clipboard"));
+	LOG(CLOG_DEBUG2 "checking clipboard");
 	if (m_pasteboard.synchronize()) {
-		LOG((CLOG_DEBUG "clipboard changed"));
+		LOG(CLOG_DEBUG "clipboard changed");
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardClipboard);
         sendClipboardEvent(EventType::CLIPBOARD_GRABBED, kClipboardSelection);
 	}
@@ -1001,19 +1001,19 @@ void OSXScreen::handle_system_event(const Event& event)
         SendEventToEventTarget(*carbonEvent, nullptr);
 		switch (GetEventKind(*carbonEvent)) {
 		case kEventWindowActivated:
-			LOG((CLOG_DEBUG1 "window activated"));
+			LOG(CLOG_DEBUG1 "window activated");
 			break;
 
 		case kEventWindowDeactivated:
-			LOG((CLOG_DEBUG1 "window deactivated"));
+			LOG(CLOG_DEBUG1 "window deactivated");
 			break;
 
 		case kEventWindowFocusAcquired:
-			LOG((CLOG_DEBUG1 "focus acquired"));
+			LOG(CLOG_DEBUG1 "focus acquired");
 			break;
 
 		case kEventWindowFocusRelinquish:
-			LOG((CLOG_DEBUG1 "focus released"));
+			LOG(CLOG_DEBUG1 "focus released");
 			break;
 		}
 		break;
@@ -1027,7 +1027,7 @@ void OSXScreen::handle_system_event(const Event& event)
 bool
 OSXScreen::onMouseMove(CGFloat mx, CGFloat my)
 {
-	LOG((CLOG_DEBUG2 "mouse move %+f,%+f", mx, my));
+	LOG(CLOG_DEBUG2 "mouse move %+f,%+f", mx, my);
 
 	CGFloat x = mx - m_xCursor;
 	CGFloat y = my - m_yCursor;
@@ -1063,7 +1063,7 @@ OSXScreen::onMouseMove(CGFloat mx, CGFloat my)
 			 x + bogusZoneSize > m_x + m_w - m_xCenter ||
 			-y + bogusZoneSize > m_yCenter - m_y ||
 			 y + bogusZoneSize > m_y + m_h - m_yCenter) {
-			LOG((CLOG_DEBUG "dropped bogus motion %+.2f,%+.2f", x, y));
+			LOG(CLOG_DEBUG "dropped bogus motion %+.2f,%+.2f", x, y);
 		}
 		else {
 			// send motion
@@ -1095,7 +1095,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
     ButtonID button = map_button_from_osx(macButton);
 
 	if (pressed) {
-		LOG((CLOG_DEBUG1 "event: button press button=%d", button));
+		LOG(CLOG_DEBUG1 "event: button press button=%d", button);
 		if (button != kButtonNone) {
 			KeyModifierMask mask = m_keyState->getActiveModifiers();
             sendEvent(EventType::PRIMARY_SCREEN_BUTTON_DOWN,
@@ -1103,7 +1103,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
 		}
 	}
 	else {
-		LOG((CLOG_DEBUG1 "event: button release button=%d", button));
+		LOG(CLOG_DEBUG1 "event: button release button=%d", button);
 		if (button != kButtonNone) {
 			KeyModifierMask mask = m_keyState->getActiveModifiers();
             sendEvent(EventType::PRIMARY_SCREEN_BUTTON_UP,
@@ -1132,7 +1132,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
 		m_buttonState.set(kButtonLeft - 1, state);
 		if (pressed) {
 			m_draggingFilename.clear();
-			LOG((CLOG_DEBUG2 "dragging file directory is cleared"));
+			LOG(CLOG_DEBUG2 "dragging file directory is cleared");
 		}
 		else {
 			if (m_fakeDraggingStarted) {
@@ -1148,7 +1148,7 @@ bool OSXScreen::onMouseButton(bool pressed, std::uint16_t macButton)
 
 bool OSXScreen::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta) const
 {
-	LOG((CLOG_DEBUG1 "event: button wheel delta=%+d,%+d", xDelta, yDelta));
+	LOG(CLOG_DEBUG1 "event: button wheel delta=%+d,%+d", xDelta, yDelta);
     sendEvent(EventType::PRIMARY_SCREEN_WHEEL,
               create_event_data<WheelInfo>(WheelInfo{xDelta, yDelta}));
 	return true;
@@ -1172,11 +1172,11 @@ OSXScreen::displayReconfigurationCallback(CGDirectDisplayID displayID, CGDisplay
 		kCGDisplayMirrorFlag | kCGDisplayUnMirrorFlag |
 		kCGDisplayDesktopShapeChangedFlag;
 
-	LOG((CLOG_DEBUG1 "event: display was reconfigured: %x %x %x", flags, mask, flags & mask));
+	LOG(CLOG_DEBUG1 "event: display was reconfigured: %x %x %x", flags, mask, flags & mask);
 
 	if (flags & mask) { /* Something actually did change */
 
-		LOG((CLOG_DEBUG1 "event: screen changed shape; refreshing dimensions"));
+		LOG(CLOG_DEBUG1 "event: screen changed shape; refreshing dimensions");
 		screen->updateScreenShape(displayID, flags);
 	}
 }
@@ -1189,7 +1189,7 @@ OSXScreen::onKey(CGEventRef event)
 	// get the key and active modifiers
 	std::uint32_t virtualKey = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
 	CGEventFlags macMask = CGEventGetFlags(event);
-	LOG((CLOG_DEBUG1 "event: Key event kind: %d, keycode=%d", eventKind, virtualKey));
+	LOG(CLOG_DEBUG1 "event: Key event kind: %d, keycode=%d", eventKind, virtualKey);
 
 	// Special handling to track state of modifiers
 	if (eventKind == kCGEventFlagsChanged) {
@@ -1295,13 +1295,13 @@ OSXScreen::onMediaKey(CGEventRef event)
 	bool isRepeat;
 
 	if (!getMediaKeyEventInfo (event, &keyID, &down, &isRepeat)) {
-		LOG ((CLOG_ERR "Failed to decode media key event"));
+		LOG(CLOG_ERR "Failed to decode media key event");
 		return;
 	}
 
-	LOG ((CLOG_DEBUG2 "Media key event: keyID=0x%02x, %s, repeat=%s",
+	LOG(CLOG_DEBUG2 "Media key event: keyID=0x%02x, %s, repeat=%s",
 						keyID, (down ? "down": "up"),
-						(isRepeat ? "yes" : "no")));
+						(isRepeat ? "yes" : "no"));
 
 	KeyButton button = 0;
 	KeyModifierMask mask = m_keyState->getActiveModifiers();
@@ -1513,9 +1513,9 @@ OSXScreen::updateScreenShape()
 	// We want to notify the peer screen whether we are primary screen or not
     sendEvent(EventType::SCREEN_SHAPE_CHANGED);
 
-	LOG((CLOG_DEBUG "screen shape: center=%d,%d size=%dx%d on %u %s",
+	LOG(CLOG_DEBUG "screen shape: center=%d,%d size=%dx%d on %u %s",
          m_x, m_y, m_w, m_h, displayCount,
-         (displayCount == 1) ? "display" : "displays"));
+         (displayCount == 1) ? "display" : "displays");
 }
 
 #pragma mark -
@@ -1538,11 +1538,11 @@ OSXScreen::userSwitchCallback(EventHandlerCallRef nextHandler,
 	IEventQueue* events = screen->getEvents();
 
 	if (kind == kEventSystemUserSessionDeactivated) {
-		LOG((CLOG_DEBUG "user session deactivated"));
+		LOG(CLOG_DEBUG "user session deactivated");
         events->add_event(EventType::SCREEN_SUSPEND, screen->get_event_target());
 	}
 	else if (kind == kEventSystemUserSessionActivated) {
-		LOG((CLOG_DEBUG "user session activated"));
+		LOG(CLOG_DEBUG "user session activated");
         events->add_event(EventType::SCREEN_RESUME, screen->get_event_target());
 	}
 	return (CallNextEventHandler(nextHandler, theEvent));
@@ -1569,7 +1569,7 @@ void OSXScreen::watchSystemPowerThread()
 	m_pmRootPort = IORegisterForSystemPower(this, &notificationPortRef,
 											powerChangeCallback, &notifier);
 	if (m_pmRootPort == 0) {
-		LOG((CLOG_WARN "IORegisterForSystemPower failed"));
+		LOG(CLOG_WARN "IORegisterForSystemPower failed");
 	}
 	else {
 		runloopSourceRef =
@@ -1589,13 +1589,13 @@ void OSXScreen::watchSystemPowerThread()
     // setting is_pm_thread_ready_ to true otherwise the parent thread will
 	// block waiting for it.
 	if (m_pmRootPort == 0) {
-		LOG((CLOG_WARN "failed to init watchSystemPowerThread"));
+		LOG(CLOG_WARN "failed to init watchSystemPowerThread");
 		return;
 	}
 
-	LOG((CLOG_DEBUG "started watchSystemPowerThread"));
+	LOG(CLOG_DEBUG "started watchSystemPowerThread");
 
-	LOG((CLOG_DEBUG "waiting for event loop"));
+	LOG(CLOG_DEBUG "waiting for event loop");
 	m_events->waitForReady();
 
 #if defined(MAC_OS_X_VERSION_10_7)
@@ -1605,7 +1605,7 @@ void OSXScreen::watchSystemPowerThread()
 
 			// we signalling carbon loop ready before starting
 			// unless we know how to do it within the loop
-			LOG((CLOG_DEBUG "signalling carbon loop ready"));
+			LOG(CLOG_DEBUG "signalling carbon loop ready");
 
             is_carbon_loop_ready_ = true;
             cardon_loop_ready_cv_.notify_one();
@@ -1614,9 +1614,9 @@ void OSXScreen::watchSystemPowerThread()
 #endif
 
 	// start the run loop
-	LOG((CLOG_DEBUG "starting carbon loop"));
+	LOG(CLOG_DEBUG "starting carbon loop");
 	CFRunLoopRun();
-	LOG((CLOG_DEBUG "carbon loop has stopped"));
+	LOG(CLOG_DEBUG "carbon loop has stopped");
 
 	// cleanup
 	if (notificationPortRef) {
@@ -1629,7 +1629,7 @@ void OSXScreen::watchSystemPowerThread()
     std::lock_guard<std::mutex> lock(pm_mutex_);
 	IODeregisterForSystemPower(&notifier);
 	m_pmRootPort = 0;
-	LOG((CLOG_DEBUG "stopped watchSystemPowerThread"));
+	LOG(CLOG_DEBUG "stopped watchSystemPowerThread");
 }
 
 void
@@ -1653,7 +1653,7 @@ OSXScreen::handlePowerChangeRequest(natural_t messageType, void* messageArg)
 		return;
 
 	case kIOMessageSystemHasPoweredOn:
-		LOG((CLOG_DEBUG "system wakeup"));
+		LOG(CLOG_DEBUG "system wakeup");
         m_events->add_event(EventType::SCREEN_RESUME, get_event_target());
 		break;
 
@@ -1677,7 +1677,7 @@ void OSXScreen::handle_confirm_sleep(const Event& event)
             m_events->add_event(EventType::SCREEN_SUSPEND, get_event_target(),
                                 nullptr, Event::kDeliverImmediately);
 
-			LOG((CLOG_DEBUG "system will sleep"));
+			LOG(CLOG_DEBUG "system will sleep");
 			IOAllowPowerChange(m_pmRootPort, messageArg);
 		}
 	}
@@ -1829,8 +1829,8 @@ OSXScreen::handleCGInputEventSecondary(
 		CGPoint pos = CGEventGetLocation(event);
 		if (pos.x != screen->m_xCenter || pos.y != screen->m_yCenter) {
 
-			LOG((CLOG_DEBUG "show cursor on secondary, type=%d pos=%.2f,%.2f",
-					type, pos.x, pos.y));
+			LOG(CLOG_DEBUG "show cursor on secondary, type=%d pos=%.2f,%.2f",
+					type, pos.x, pos.y);
 			screen->showCursor();
 		}
 	}
@@ -1885,26 +1885,26 @@ OSXScreen::handleCGInputEvent(CGEventTapProxy proxy,
 		case kCGEventTapDisabledByTimeout:
 			// Re-enable our event-tap
 			CGEventTapEnable(screen->m_eventTapPort, true);
-			LOG((CLOG_INFO "quartz event tap was disabled by timeout, re-enabling"));
+			LOG(CLOG_INFO "quartz event tap was disabled by timeout, re-enabling");
 			break;
 		case kCGEventTapDisabledByUserInput:
-			LOG((CLOG_ERR "quartz event tap was disabled by user input"));
+			LOG(CLOG_ERR "quartz event tap was disabled by user input");
 			break;
 		case NX_NULLEVENT:
 			break;
 		default:
 			if (type == NX_SYSDEFINED) {
 			if (isMediaKeyEvent (event)) {
-				LOG((CLOG_DEBUG2 "detected media key event"));
+				LOG(CLOG_DEBUG2 "detected media key event");
 				screen->onMediaKey (event);
 			} else {
-				LOG((CLOG_DEBUG2 "ignoring unknown system defined event"));
+				LOG(CLOG_DEBUG2 "ignoring unknown system defined event");
 				return event;
 			}
 			break;
 			}
 
-			LOG((CLOG_DEBUG3 "unknown quartz event type: 0x%02x", type));
+			LOG(CLOG_DEBUG3 "unknown quartz event type: 0x%02x", type);
 	}
 
 	if (screen->m_isOnScreen) {
@@ -1985,7 +1985,7 @@ OSXScreen::fakeDraggingFiles(DragFileList fileList)
 #if defined(MAC_OS_X_VERSION_10_7)
 	fakeDragging(fileExt.c_str(), m_xCursor, m_yCursor);
 #else
-	LOG((CLOG_WARN "drag drop not supported"));
+	LOG(CLOG_WARN "drag drop not supported");
 #endif
 }
 
@@ -1999,7 +1999,7 @@ std::string& OSXScreen::getDraggingFilename()
 			m_draggingFilename.clear();
 		}
 		else {
-			LOG((CLOG_DEBUG "drag info: %s", info));
+			LOG(CLOG_DEBUG "drag info: %s", info);
 			CFRelease(dragInfo);
             std::string fileList = info;
 			m_draggingFilename = fileList;
@@ -2018,20 +2018,20 @@ OSXScreen::waitForCarbonLoop() const
 {
 #if defined(MAC_OS_X_VERSION_10_7)
     if (is_carbon_loop_ready_) {
-		LOG((CLOG_DEBUG "carbon loop already ready"));
+		LOG(CLOG_DEBUG "carbon loop already ready");
 		return;
 	}
 
     std::unique_lock<std::mutex> lock(carbon_loop_mutex_);
 
-	LOG((CLOG_DEBUG "waiting for carbon loop"));
+	LOG(CLOG_DEBUG "waiting for carbon loop");
 
     while (!cardon_loop_ready_cv_.wait_for(lock, std::chrono::seconds{kCarbonLoopWaitTimeout},
                                            [this](){ return is_carbon_loop_ready_; })) {
-        LOG((CLOG_DEBUG "carbon loop not ready, waiting again"));
+        LOG(CLOG_DEBUG "carbon loop not ready, waiting again");
     }
 
-	LOG((CLOG_DEBUG "carbon loop ready"));
+	LOG(CLOG_DEBUG "carbon loop ready");
 #endif
 
 }
@@ -2063,7 +2063,7 @@ logCursorVisibility()
 {
 	// CGCursorIsVisible is probably deprecated because its unreliable.
 	if (!CGCursorIsVisible()) {
-		LOG((CLOG_WARN "cursor may not be visible"));
+		LOG(CLOG_WARN "cursor may not be visible");
 	}
 }
 

--- a/src/lib/platform/OSXScreenSaver.cpp
+++ b/src/lib/platform/OSXScreenSaver.cpp
@@ -107,7 +107,7 @@ OSXScreenSaver::processLaunched(ProcessSerialNumber psn)
 {
     if (testProcessName("ScreenSaverEngine", psn)) {
         m_screenSaverPSN = psn;
-        LOG(CLOG_DEBUG1 "ScreenSaverEngine launched. Enabled=%d", m_enabled);
+        LOG_DEBUG1("ScreenSaverEngine launched. Enabled=%d", m_enabled);
         if (m_enabled) {
             m_events->add_event(EventType::PRIMARY_SCREEN_SAVER_ACTIVATED, event_target_);
         }
@@ -119,7 +119,7 @@ OSXScreenSaver::processTerminated(ProcessSerialNumber psn)
 {
     if (m_screenSaverPSN.highLongOfPSN == psn.highLongOfPSN &&
         m_screenSaverPSN.lowLongOfPSN  == psn.lowLongOfPSN) {
-        LOG(CLOG_DEBUG1 "ScreenSaverEngine terminated. Enabled=%d", m_enabled);
+        LOG_DEBUG1("ScreenSaverEngine terminated. Enabled=%d", m_enabled);
         if (m_enabled) {
             m_events->add_event(EventType::PRIMARY_SCREEN_SAVER_DEACTIVATED, event_target_);
         }

--- a/src/lib/platform/OSXScreenSaver.cpp
+++ b/src/lib/platform/OSXScreenSaver.cpp
@@ -107,7 +107,7 @@ OSXScreenSaver::processLaunched(ProcessSerialNumber psn)
 {
     if (testProcessName("ScreenSaverEngine", psn)) {
         m_screenSaverPSN = psn;
-        LOG((CLOG_DEBUG1 "ScreenSaverEngine launched. Enabled=%d", m_enabled));
+        LOG(CLOG_DEBUG1 "ScreenSaverEngine launched. Enabled=%d", m_enabled);
         if (m_enabled) {
             m_events->add_event(EventType::PRIMARY_SCREEN_SAVER_ACTIVATED, event_target_);
         }
@@ -119,7 +119,7 @@ OSXScreenSaver::processTerminated(ProcessSerialNumber psn)
 {
     if (m_screenSaverPSN.highLongOfPSN == psn.highLongOfPSN &&
         m_screenSaverPSN.lowLongOfPSN  == psn.lowLongOfPSN) {
-        LOG((CLOG_DEBUG1 "ScreenSaverEngine terminated. Enabled=%d", m_enabled));
+        LOG(CLOG_DEBUG1 "ScreenSaverEngine terminated. Enabled=%d", m_enabled);
         if (m_enabled) {
             m_events->add_event(EventType::PRIMARY_SCREEN_SAVER_DEACTIVATED, event_target_);
         }

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -93,7 +93,7 @@ int PortalInputCapture::fake_eis_fd()
     auto path = std::getenv("LIBEI_SOCKET");
 
     if (!path) {
-        LOG(CLOG_DEBUG "Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset");
+        LOG_DEBUG("Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset");
         return -1;
     }
 
@@ -110,7 +110,7 @@ int PortalInputCapture::fake_eis_fd()
 
     auto result = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
     if (result != 0) {
-        LOG(CLOG_DEBUG "Faked EIS fd failed: %s", strerror(errno));
+        LOG_DEBUG("Faked EIS fd failed: %s", strerror(errno));
     }
 
     return sock;
@@ -118,7 +118,7 @@ int PortalInputCapture::fake_eis_fd()
 
 void PortalInputCapture::cb_session_closed(XdpSession* session)
 {
-    LOG(CLOG_ERR "Our InputCapture session was closed, exiting.");
+    LOG_ERR("Our InputCapture session was closed, exiting.");
     g_main_loop_quit(glib_main_loop_);
     events_->add_event(EventType::QUIT);
 
@@ -128,12 +128,12 @@ void PortalInputCapture::cb_session_closed(XdpSession* session)
 
 void PortalInputCapture::cb_init_input_capture_session(GObject* object, GAsyncResult* res)
 {
-    LOG(CLOG_DEBUG "Session ready");
+    LOG_DEBUG("Session ready");
     g_autoptr(GError) error = nullptr;
 
     auto session = xdp_portal_create_input_capture_session_finish(XDP_PORTAL(object), res, &error);
     if (!session) {
-        LOG(CLOG_ERR "Failed to initialize InputCapture session, quitting: %s", error->message);
+        LOG_ERR("Failed to initialize InputCapture session, quitting: %s", error->message);
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
         return;
@@ -143,7 +143,7 @@ void PortalInputCapture::cb_init_input_capture_session(GObject* object, GAsyncRe
 
     auto fd = xdp_input_capture_session_connect_to_eis(session, &error);
     if (fd < 0) {
-            LOG(CLOG_ERR "Failed to connect to EIS: %s", error->message);
+            LOG_ERR("Failed to connect to EIS: %s", error->message);
 
             // FIXME: Development hack to avoid having to assemble all parts just for
             // testing this code.
@@ -198,7 +198,7 @@ void PortalInputCapture::cb_set_pointer_barriers(GObject* object, GAsyncResult* 
 
                     g_object_get(G_OBJECT(*elem), "x1", &x1, "x2", &x2, "y1", &y1, "y2", &y2, nullptr);
 
-                    LOG(CLOG_WARN "Failed to apply barrier %d (%d/%d-%d/%d)", id, x1, y1, x2, y2);
+                    LOG_WARN("Failed to apply barrier %d (%d/%d-%d/%d)", id, x1, y1, x2, y2);
                     g_object_unref(*elem);
                     barriers_.erase(elem);
                     break;
@@ -215,7 +215,7 @@ void PortalInputCapture::cb_set_pointer_barriers(GObject* object, GAsyncResult* 
 
 gboolean PortalInputCapture::init_input_capture_session()
 {
-    LOG(CLOG_DEBUG "Setting up the InputCapture session");
+    LOG_DEBUG("Setting up the InputCapture session");
     xdp_portal_create_input_capture_session(
                 portal_,
                 nullptr, // parent
@@ -232,7 +232,7 @@ gboolean PortalInputCapture::init_input_capture_session()
 void PortalInputCapture::enable()
 {
     if (!enabled_) {
-        LOG(CLOG_DEBUG "Enabling the InputCapture session");
+        LOG_DEBUG("Enabling the InputCapture session");
         xdp_input_capture_session_enable(session_);
         enabled_ = true;
     }
@@ -241,7 +241,7 @@ void PortalInputCapture::enable()
 void PortalInputCapture::disable()
 {
     if (enabled_) {
-        LOG(CLOG_DEBUG "Disabling the InputCapture session");
+        LOG_DEBUG("Disabling the InputCapture session");
         xdp_input_capture_session_disable(session_);
         enabled_ = false;
     }
@@ -249,21 +249,21 @@ void PortalInputCapture::disable()
 
 void PortalInputCapture::release()
 {
-    LOG(CLOG_DEBUG "Releasing InputCapture with activation id %d", activation_id_);
+    LOG_DEBUG("Releasing InputCapture with activation id %d", activation_id_);
     xdp_input_capture_session_release(session_, activation_id_);
     is_active_ = false;
 }
 
 void PortalInputCapture::release(double x, double y)
 {
-    LOG(CLOG_DEBUG "Releasing InputCapture with activation id %d at (%.1f,%.1f)", activation_id_, x, y);
+    LOG_DEBUG("Releasing InputCapture with activation id %d at (%.1f,%.1f)", activation_id_, x, y);
     xdp_input_capture_session_release_at(session_, activation_id_, x, y);
     is_active_ = false;
 }
 
 void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session)
 {
-    LOG(CLOG_DEBUG "PortalInputCapture::cb_disabled");
+    LOG_DEBUG("PortalInputCapture::cb_disabled");
 
     if (!enabled_)
         return; // Nothing to do
@@ -286,18 +286,18 @@ void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session)
 void PortalInputCapture::cb_activated(XdpInputCaptureSession* session, std::uint32_t activation_id,
                                       GVariant* options)
 {
-    LOG(CLOG_DEBUG "PortalInputCapture::cb_activated() activation_id=%d", activation_id);
+    LOG_DEBUG("PortalInputCapture::cb_activated() activation_id=%d", activation_id);
 
     if (options) {
         gdouble x, y;
         if (g_variant_lookup(options, "cursor_position", "(dd)", &x, &y)) {
             screen_->warpCursor((int) x, (int) y);
         } else {
-            LOG(CLOG_WARN "Failed to get cursor_position");
+            LOG_WARN("Failed to get cursor_position");
         }
     }
     else {
-        LOG(CLOG_WARN "Activation has no options!");
+        LOG_WARN("Activation has no options!");
     }
     activation_id_ = activation_id;
     is_active_ = true;
@@ -306,7 +306,7 @@ void PortalInputCapture::cb_activated(XdpInputCaptureSession* session, std::uint
 void PortalInputCapture::cb_deactivated(XdpInputCaptureSession* session,
                                         std::uint32_t activation_id, GVariant* options)
 {
-    LOG(CLOG_DEBUG "PortalInputCapture::cb_deactivated() activation id=%i", activation_id);
+    LOG_DEBUG("PortalInputCapture::cb_deactivated() activation id=%i", activation_id);
     is_active_ = false;
 }
 
@@ -322,7 +322,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         gint x, y;
         g_object_get(zones->data, "width", &w, "height", &h, "x", &x, "y", &y, nullptr  );
 
-        LOG(CLOG_DEBUG "Zone at %dx%d@%d,%d", w, h, x, y);
+        LOG_DEBUG("Zone at %dx%d@%d,%d", w, h, x, y);
 
         int x1, x2, y1, y2;
 
@@ -336,7 +336,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x + w - 1;
         y2 = y;
-        LOG(CLOG_DEBUG "Barrier (top) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
+        LOG_DEBUG("Barrier (top) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -350,7 +350,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x + w;
         y2 = y + h - 1;
-        LOG(CLOG_DEBUG "Barrier (right) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
+        LOG_DEBUG("Barrier (right) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -364,7 +364,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x;
         y2 = y + h - 1;
-        LOG(CLOG_DEBUG "Barrier (left) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
+        LOG_DEBUG("Barrier (left) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -378,7 +378,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y + h;
         x2 = x + w - 1;
         y2 = y + h;
-        LOG(CLOG_DEBUG "Barrier (bottom) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
+        LOG_DEBUG("Barrier (bottom) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -410,14 +410,14 @@ void PortalInputCapture::glib_thread()
 {
     auto context = g_main_loop_get_context(glib_main_loop_);
 
-    LOG(CLOG_DEBUG "GLib thread running");
+    LOG_DEBUG("GLib thread running");
 
     while (g_main_loop_is_running(glib_main_loop_)) {
         Thread::testCancel();
         g_main_context_iteration(context, true);
     }
 
-    LOG(CLOG_DEBUG "Shutting down GLib thread");
+    LOG_DEBUG("Shutting down GLib thread");
 }
 
 } // namespace inputleap

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -93,7 +93,7 @@ int PortalInputCapture::fake_eis_fd()
     auto path = std::getenv("LIBEI_SOCKET");
 
     if (!path) {
-        LOG((CLOG_DEBUG "Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset"));
+        LOG(CLOG_DEBUG "Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset");
         return -1;
     }
 
@@ -110,7 +110,7 @@ int PortalInputCapture::fake_eis_fd()
 
     auto result = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
     if (result != 0) {
-        LOG((CLOG_DEBUG "Faked EIS fd failed: %s", strerror(errno)));
+        LOG(CLOG_DEBUG "Faked EIS fd failed: %s", strerror(errno));
     }
 
     return sock;
@@ -118,7 +118,7 @@ int PortalInputCapture::fake_eis_fd()
 
 void PortalInputCapture::cb_session_closed(XdpSession* session)
 {
-    LOG((CLOG_ERR "Our InputCapture session was closed, exiting."));
+    LOG(CLOG_ERR "Our InputCapture session was closed, exiting.");
     g_main_loop_quit(glib_main_loop_);
     events_->add_event(EventType::QUIT);
 
@@ -128,12 +128,12 @@ void PortalInputCapture::cb_session_closed(XdpSession* session)
 
 void PortalInputCapture::cb_init_input_capture_session(GObject* object, GAsyncResult* res)
 {
-    LOG((CLOG_DEBUG "Session ready"));
+    LOG(CLOG_DEBUG "Session ready");
     g_autoptr(GError) error = nullptr;
 
     auto session = xdp_portal_create_input_capture_session_finish(XDP_PORTAL(object), res, &error);
     if (!session) {
-        LOG((CLOG_ERR "Failed to initialize InputCapture session, quitting: %s", error->message));
+        LOG(CLOG_ERR "Failed to initialize InputCapture session, quitting: %s", error->message);
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
         return;
@@ -143,7 +143,7 @@ void PortalInputCapture::cb_init_input_capture_session(GObject* object, GAsyncRe
 
     auto fd = xdp_input_capture_session_connect_to_eis(session, &error);
     if (fd < 0) {
-            LOG((CLOG_ERR "Failed to connect to EIS: %s", error->message));
+            LOG(CLOG_ERR "Failed to connect to EIS: %s", error->message);
 
             // FIXME: Development hack to avoid having to assemble all parts just for
             // testing this code.
@@ -198,7 +198,7 @@ void PortalInputCapture::cb_set_pointer_barriers(GObject* object, GAsyncResult* 
 
                     g_object_get(G_OBJECT(*elem), "x1", &x1, "x2", &x2, "y1", &y1, "y2", &y2, nullptr);
 
-                    LOG((CLOG_WARN "Failed to apply barrier %d (%d/%d-%d/%d)", id, x1, y1, x2, y2));
+                    LOG(CLOG_WARN "Failed to apply barrier %d (%d/%d-%d/%d)", id, x1, y1, x2, y2);
                     g_object_unref(*elem);
                     barriers_.erase(elem);
                     break;
@@ -215,7 +215,7 @@ void PortalInputCapture::cb_set_pointer_barriers(GObject* object, GAsyncResult* 
 
 gboolean PortalInputCapture::init_input_capture_session()
 {
-    LOG((CLOG_DEBUG "Setting up the InputCapture session"));
+    LOG(CLOG_DEBUG "Setting up the InputCapture session");
     xdp_portal_create_input_capture_session(
                 portal_,
                 nullptr, // parent
@@ -232,7 +232,7 @@ gboolean PortalInputCapture::init_input_capture_session()
 void PortalInputCapture::enable()
 {
     if (!enabled_) {
-        LOG((CLOG_DEBUG "Enabling the InputCapture session"));
+        LOG(CLOG_DEBUG "Enabling the InputCapture session");
         xdp_input_capture_session_enable(session_);
         enabled_ = true;
     }
@@ -241,7 +241,7 @@ void PortalInputCapture::enable()
 void PortalInputCapture::disable()
 {
     if (enabled_) {
-        LOG((CLOG_DEBUG "Disabling the InputCapture session"));
+        LOG(CLOG_DEBUG "Disabling the InputCapture session");
         xdp_input_capture_session_disable(session_);
         enabled_ = false;
     }
@@ -249,21 +249,21 @@ void PortalInputCapture::disable()
 
 void PortalInputCapture::release()
 {
-    LOG((CLOG_DEBUG "Releasing InputCapture with activation id %d", activation_id_));
+    LOG(CLOG_DEBUG "Releasing InputCapture with activation id %d", activation_id_);
     xdp_input_capture_session_release(session_, activation_id_);
     is_active_ = false;
 }
 
 void PortalInputCapture::release(double x, double y)
 {
-    LOG((CLOG_DEBUG "Releasing InputCapture with activation id %d at (%.1f,%.1f)", activation_id_, x, y));
+    LOG(CLOG_DEBUG "Releasing InputCapture with activation id %d at (%.1f,%.1f)", activation_id_, x, y);
     xdp_input_capture_session_release_at(session_, activation_id_, x, y);
     is_active_ = false;
 }
 
 void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session)
 {
-    LOG((CLOG_DEBUG "PortalInputCapture::cb_disabled"));
+    LOG(CLOG_DEBUG "PortalInputCapture::cb_disabled");
 
     if (!enabled_)
         return; // Nothing to do
@@ -286,18 +286,18 @@ void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session)
 void PortalInputCapture::cb_activated(XdpInputCaptureSession* session, std::uint32_t activation_id,
                                       GVariant* options)
 {
-    LOG((CLOG_DEBUG "PortalInputCapture::cb_activated() activation_id=%d", activation_id));
+    LOG(CLOG_DEBUG "PortalInputCapture::cb_activated() activation_id=%d", activation_id);
 
     if (options) {
         gdouble x, y;
         if (g_variant_lookup(options, "cursor_position", "(dd)", &x, &y)) {
             screen_->warpCursor((int) x, (int) y);
         } else {
-            LOG((CLOG_WARN "Failed to get cursor_position"));
+            LOG(CLOG_WARN "Failed to get cursor_position");
         }
     }
     else {
-        LOG((CLOG_WARN "Activation has no options!"));
+        LOG(CLOG_WARN "Activation has no options!");
     }
     activation_id_ = activation_id;
     is_active_ = true;
@@ -306,7 +306,7 @@ void PortalInputCapture::cb_activated(XdpInputCaptureSession* session, std::uint
 void PortalInputCapture::cb_deactivated(XdpInputCaptureSession* session,
                                         std::uint32_t activation_id, GVariant* options)
 {
-    LOG((CLOG_DEBUG "PortalInputCapture::cb_deactivated() activation id=%i", activation_id));
+    LOG(CLOG_DEBUG "PortalInputCapture::cb_deactivated() activation id=%i", activation_id);
     is_active_ = false;
 }
 
@@ -322,7 +322,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         gint x, y;
         g_object_get(zones->data, "width", &w, "height", &h, "x", &x, "y", &y, nullptr  );
 
-        LOG((CLOG_DEBUG "Zone at %dx%d@%d,%d", w, h, x, y));
+        LOG(CLOG_DEBUG "Zone at %dx%d@%d,%d", w, h, x, y);
 
         int x1, x2, y1, y2;
 
@@ -336,7 +336,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x + w - 1;
         y2 = y;
-        LOG((CLOG_DEBUG "Barrier (top) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG(CLOG_DEBUG "Barrier (top) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -350,7 +350,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x + w;
         y2 = y + h - 1;
-        LOG((CLOG_DEBUG "Barrier (right) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG(CLOG_DEBUG "Barrier (right) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -364,7 +364,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y;
         x2 = x;
         y2 = y + h - 1;
-        LOG((CLOG_DEBUG "Barrier (left) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG(CLOG_DEBUG "Barrier (left) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -378,7 +378,7 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession* session, GVari
         y1 = y + h;
         x2 = x + w - 1;
         y2 = y + h;
-        LOG((CLOG_DEBUG "Barrier (bottom) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2));
+        LOG(CLOG_DEBUG "Barrier (bottom) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
         barriers_.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
                             g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER,
                                          "id", id,
@@ -410,14 +410,14 @@ void PortalInputCapture::glib_thread()
 {
     auto context = g_main_loop_get_context(glib_main_loop_);
 
-    LOG((CLOG_DEBUG "GLib thread running"));
+    LOG(CLOG_DEBUG "GLib thread running");
 
     while (g_main_loop_is_running(glib_main_loop_)) {
         Thread::testCancel();
         g_main_context_iteration(context, true);
     }
 
-    LOG((CLOG_DEBUG "Shutting down GLib thread"));
+    LOG(CLOG_DEBUG "Shutting down GLib thread");
 }
 
 } // namespace inputleap

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -72,7 +72,7 @@ int PortalRemoteDesktop::fake_eis_fd()
     auto path = std::getenv("LIBEI_SOCKET");
 
     if (!path) {
-        LOG(CLOG_DEBUG "Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset");
+        LOG_DEBUG("Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset");
         return -1;
     }
 
@@ -89,14 +89,14 @@ int PortalRemoteDesktop::fake_eis_fd()
 
     auto result = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
     if (result != 0)
-        LOG(CLOG_DEBUG "Faked EIS fd failed: %s", strerror(errno));
+        LOG_DEBUG("Faked EIS fd failed: %s", strerror(errno));
 
     return sock;
 }
 
 void PortalRemoteDesktop::cb_session_closed(XdpSession* session)
 {
-    LOG(CLOG_ERR "Our RemoteDesktop session was closed, exiting.");
+    LOG_ERR("Our RemoteDesktop session was closed, exiting.");
     g_main_loop_quit(glib_main_loop_);
     events_->add_event(EventType::QUIT);
 
@@ -109,7 +109,7 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
     auto session = XDP_SESSION(object);
     auto success = xdp_session_start_finish(session, res, &error);
     if (!success) {
-        LOG(CLOG_ERR "Failed to start session");
+        LOG_ERR("Failed to start session");
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
     }
@@ -122,7 +122,7 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
     fd = xdp_session_connect_to_eis(session, &error);
 #endif
     if (fd < 0) {
-        LOG(CLOG_ERR "Failed to connect to EIS: %s", error->message);
+        LOG_ERR("Failed to connect to EIS: %s", error->message);
 
         // FIXME: Development hack to avoid having to assemble all parts just for
         // testing this code.
@@ -142,12 +142,12 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
 
 void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsyncResult* res)
 {
-    LOG(CLOG_DEBUG "Session ready");
+    LOG_DEBUG("Session ready");
     g_autoptr(GError) error = nullptr;
 
     auto session = xdp_portal_create_remote_desktop_session_finish(XDP_PORTAL(object), res, &error);
     if (!session) {
-        LOG(CLOG_ERR "Failed to initialize RemoteDesktop session, quitting: %s", error->message);
+        LOG_ERR("Failed to initialize RemoteDesktop session, quitting: %s", error->message);
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
         return;
@@ -172,7 +172,7 @@ void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsync
 
 gboolean PortalRemoteDesktop::init_remote_desktop_session()
 {
-    LOG(CLOG_DEBUG "Setting up the RemoteDesktop session");
+    LOG_DEBUG("Setting up the RemoteDesktop session");
     xdp_portal_create_remote_desktop_session(
                 portal_,
                 static_cast<XdpDeviceType>(XDP_DEVICE_POINTER | XDP_DEVICE_KEYBOARD),

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -72,7 +72,7 @@ int PortalRemoteDesktop::fake_eis_fd()
     auto path = std::getenv("LIBEI_SOCKET");
 
     if (!path) {
-        LOG((CLOG_DEBUG "Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset"));
+        LOG(CLOG_DEBUG "Cannot fake EIS socket, LIBEI_SOCKET environment variable is unset");
         return -1;
     }
 
@@ -89,14 +89,14 @@ int PortalRemoteDesktop::fake_eis_fd()
 
     auto result = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
     if (result != 0)
-        LOG((CLOG_DEBUG "Faked EIS fd failed: %s", strerror(errno)));
+        LOG(CLOG_DEBUG "Faked EIS fd failed: %s", strerror(errno));
 
     return sock;
 }
 
 void PortalRemoteDesktop::cb_session_closed(XdpSession* session)
 {
-    LOG((CLOG_ERR "Our RemoteDesktop session was closed, exiting."));
+    LOG(CLOG_ERR "Our RemoteDesktop session was closed, exiting.");
     g_main_loop_quit(glib_main_loop_);
     events_->add_event(EventType::QUIT);
 
@@ -109,7 +109,7 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
     auto session = XDP_SESSION(object);
     auto success = xdp_session_start_finish(session, res, &error);
     if (!success) {
-        LOG((CLOG_ERR "Failed to start session"));
+        LOG(CLOG_ERR "Failed to start session");
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
     }
@@ -122,7 +122,7 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
     fd = xdp_session_connect_to_eis(session, &error);
 #endif
     if (fd < 0) {
-        LOG((CLOG_ERR "Failed to connect to EIS: %s", error->message));
+        LOG(CLOG_ERR "Failed to connect to EIS: %s", error->message);
 
         // FIXME: Development hack to avoid having to assemble all parts just for
         // testing this code.
@@ -142,12 +142,12 @@ void PortalRemoteDesktop::cb_session_started(GObject* object, GAsyncResult* res)
 
 void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsyncResult* res)
 {
-    LOG((CLOG_DEBUG "Session ready"));
+    LOG(CLOG_DEBUG "Session ready");
     g_autoptr(GError) error = nullptr;
 
     auto session = xdp_portal_create_remote_desktop_session_finish(XDP_PORTAL(object), res, &error);
     if (!session) {
-        LOG((CLOG_ERR "Failed to initialize RemoteDesktop session, quitting: %s", error->message));
+        LOG(CLOG_ERR "Failed to initialize RemoteDesktop session, quitting: %s", error->message);
         g_main_loop_quit(glib_main_loop_);
         events_->add_event(EventType::QUIT);
         return;
@@ -172,7 +172,7 @@ void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsync
 
 gboolean PortalRemoteDesktop::init_remote_desktop_session()
 {
-    LOG((CLOG_DEBUG "Setting up the RemoteDesktop session"));
+    LOG(CLOG_DEBUG "Setting up the RemoteDesktop session");
     xdp_portal_create_remote_desktop_session(
                 portal_,
                 static_cast<XdpDeviceType>(XDP_DEVICE_POINTER | XDP_DEVICE_KEYBOARD),

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -123,7 +123,7 @@ XWindowsClipboard::~XWindowsClipboard()
 void
 XWindowsClipboard::lost(Time time)
 {
-    LOG((CLOG_DEBUG "lost clipboard %d ownership at %d", m_id, time));
+    LOG(CLOG_DEBUG "lost clipboard %d ownership at %d", m_id, time);
     if (m_owner) {
         m_owner    = false;
         m_timeLost = time;
@@ -139,7 +139,7 @@ XWindowsClipboard::addRequest(Window owner, Window requestor,
     // at the given time.
     bool success = false;
     if (owner == m_window) {
-        LOG((CLOG_DEBUG1 "request for clipboard %ld, target %s by 0x%08lx (property=%s)", m_selection, XWindowsUtil::atomToString(m_display, target).c_str(), requestor, XWindowsUtil::atomToString(m_display, property).c_str()));
+        LOG(CLOG_DEBUG1 "request for clipboard %ld, target %s by 0x%08lx (property=%s)", m_selection, XWindowsUtil::atomToString(m_display, target).c_str(), requestor, XWindowsUtil::atomToString(m_display, property).c_str());
         if (wasOwnedAtTime(time)) {
             if (target == m_atomMultiple) {
                 // add a multiple request.  property may not be None
@@ -156,13 +156,13 @@ XWindowsClipboard::addRequest(Window owner, Window requestor,
             }
         }
         else {
-            LOG((CLOG_DEBUG1 "failed, not owned at time %ld", time));
+            LOG(CLOG_DEBUG1 "failed, not owned at time %ld", time);
         }
     }
 
     if (!success) {
         // send failure
-        LOG((CLOG_DEBUG1 "failed"));
+        LOG(CLOG_DEBUG1 "failed");
         insertReply(new Reply(requestor, target, time));
     }
 
@@ -210,14 +210,14 @@ XWindowsClipboard::addSimpleRequest(Window requestor,
 
     if (type != None) {
         // success
-        LOG((CLOG_DEBUG1 "success"));
+        LOG(CLOG_DEBUG1 "success");
         insertReply(new Reply(requestor, target, time,
                                 property, data, type, format));
         return true;
     }
     else {
         // failure
-        LOG((CLOG_DEBUG1 "failed"));
+        LOG(CLOG_DEBUG1 "failed");
         insertReply(new Reply(requestor, target, time));
         return false;
     }
@@ -232,7 +232,7 @@ XWindowsClipboard::processRequest(Window requestor,
         // unknown requestor window
         return false;
     }
-    LOG((CLOG_DEBUG1 "received property %s delete from 0x08%lx", XWindowsUtil::atomToString(m_display, property).c_str(), requestor));
+    LOG(CLOG_DEBUG1 "received property %s delete from 0x08%lx", XWindowsUtil::atomToString(m_display, property).c_str(), requestor);
 
     // find the property in the known requests.  it should be the
     // first property but we'll check 'em all if we have to.
@@ -287,12 +287,12 @@ XWindowsClipboard::empty()
 {
     assert(m_open);
 
-    LOG((CLOG_DEBUG "empty clipboard %d", m_id));
+    LOG(CLOG_DEBUG "empty clipboard %d", m_id);
 
     // assert ownership of clipboard
     m_impl->XSetSelectionOwner(m_display, m_selection, m_window, m_time);
     if (m_impl->XGetSelectionOwner(m_display, m_selection) != m_window) {
-        LOG((CLOG_DEBUG "failed to grab clipboard %d", m_id));
+        LOG(CLOG_DEBUG "failed to grab clipboard %d", m_id);
         return false;
     }
 
@@ -310,7 +310,7 @@ XWindowsClipboard::empty()
 
     // we're the owner now
     m_owner = true;
-    LOG((CLOG_DEBUG "grabbed clipboard %d", m_id));
+    LOG(CLOG_DEBUG "grabbed clipboard %d", m_id);
 
     return true;
 }
@@ -320,7 +320,7 @@ void XWindowsClipboard::add(EFormat format, const std::string& data)
     assert(m_open);
     assert(m_owner);
 
-    LOG((CLOG_DEBUG "add %zd bytes to clipboard %d format: %d", data.size(), m_id, format));
+    LOG(CLOG_DEBUG "add %zd bytes to clipboard %d format: %d", data.size(), m_id, format);
 
     m_data[format]  = data;
     m_added[format] = true;
@@ -332,11 +332,11 @@ bool
 XWindowsClipboard::open(Time time) const
 {
     if (m_open) {
-        LOG((CLOG_DEBUG "failed to open clipboard: already opened"));
+        LOG(CLOG_DEBUG "failed to open clipboard: already opened");
         return false;
     }
 
-    LOG((CLOG_DEBUG "open clipboard %d", m_id));
+    LOG(CLOG_DEBUG "open clipboard %d", m_id);
 
     // assume not motif
     m_motif = false;
@@ -350,7 +350,7 @@ XWindowsClipboard::open(Time time) const
         // check if motif owns the selection.  unlock motif clipboard
         // if it does not.
         m_motif = motifOwnsClipboard();
-        LOG((CLOG_DEBUG1 "motif does %sown clipboard", m_motif ? "" : "not "));
+        LOG(CLOG_DEBUG1 "motif does %sown clipboard", m_motif ? "" : "not ");
         if (!m_motif) {
             motifUnlockClipboard();
         }
@@ -371,7 +371,7 @@ XWindowsClipboard::close() const
 {
     assert(m_open);
 
-    LOG((CLOG_DEBUG "close clipboard %d", m_id));
+    LOG(CLOG_DEBUG "close clipboard %d", m_id);
 
     // unlock clipboard
     if (m_motif) {
@@ -428,14 +428,14 @@ XWindowsClipboard::getConverter(Atom target, bool onlyIfNotAdded) const
         }
     }
     if (converter == nullptr) {
-        LOG((CLOG_DEBUG1 "  no converter for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+        LOG(CLOG_DEBUG1 "  no converter for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
         return nullptr;
     }
 
     // optionally skip already handled targets
     if (onlyIfNotAdded) {
         if (m_added[converter->getFormat()]) {
-            LOG((CLOG_DEBUG1 "  skipping handled format %d", converter->getFormat()));
+            LOG(CLOG_DEBUG1 "  skipping handled format %d", converter->getFormat());
             return nullptr;
         }
     }
@@ -515,7 +515,7 @@ XWindowsClipboard::doFillCache()
 void
 XWindowsClipboard::icccmFillCache()
 {
-    LOG((CLOG_DEBUG "ICCCM fill clipboard %d", m_id));
+    LOG(CLOG_DEBUG "ICCCM fill clipboard %d", m_id);
 
     // see if we can get the list of available formats from the selection.
     // if not then use a default list of formats.  note that some clipboard
@@ -526,7 +526,7 @@ XWindowsClipboard::icccmFillCache()
     std::string data;
     if (!icccmGetSelection(atomTargets, &target, &data) ||
         (target != m_atomAtom && target != m_atomTargets)) {
-        LOG((CLOG_DEBUG1 "selection doesn't support TARGETS"));
+        LOG(CLOG_DEBUG1 "selection doesn't support TARGETS");
         data = "";
         XWindowsUtil::appendAtomData(data, XA_STRING);
     }
@@ -534,7 +534,7 @@ XWindowsClipboard::icccmFillCache()
     XWindowsUtil::convertAtomProperty(data);
     const Atom* targets = reinterpret_cast<const Atom*>(data.data()); // TODO: Safe?
     const std::uint32_t numTargets = data.size() / sizeof(Atom);
-    LOG((CLOG_DEBUG "  available targets: %s", XWindowsUtil::atomsToString(m_display, targets, numTargets).c_str()));
+    LOG(CLOG_DEBUG "  available targets: %s", XWindowsUtil::atomsToString(m_display, targets, numTargets).c_str());
 
     // try each converter in order (because they're in order of
     // preference).
@@ -561,24 +561,24 @@ XWindowsClipboard::icccmFillCache()
         IClipboard::EFormat format = converter->getFormat();
         std::string targetData;
         if (!icccmGetSelection(target, &actualTarget, &targetData)) {
-            LOG((CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            LOG(CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
             continue;
         }
 
         if (actualTarget != target) {
-            LOG((CLOG_DEBUG1 "  target %s not same as actual target %s",
+            LOG(CLOG_DEBUG1 "  target %s not same as actual target %s",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
-                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str());
             m_added[format] = false;
             continue;
         }
 
         if (targetData.empty()) {
             m_added[format] = false;
-            LOG((CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)",
+            LOG(CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
-                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str());
              continue;
         }
 
@@ -586,9 +586,9 @@ XWindowsClipboard::icccmFillCache()
             // add to clipboard and note we've done it
             m_data[format]  = converter->toIClipboard(targetData);
             m_added[format] = true;
-            LOG((CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+            LOG(CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes");
         } else {
-            LOG((CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            LOG(CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
         }
     }
@@ -605,12 +605,12 @@ XWindowsClipboard::icccmGetSelection(Atom target,
     CICCCMGetClipboard getter(m_window, m_time, m_atomData);
     if (!getter.readClipboard(m_display, m_selection,
                                 target, actualTarget, data)) {
-        LOG((CLOG_DEBUG1 "can't get data for selection target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+        LOG(CLOG_DEBUG1 "can't get data for selection target %s", XWindowsUtil::atomToString(m_display, target).c_str());
         LOGC(getter.m_error, (CLOG_WARN "ICCCM violation by clipboard owner"));
         return false;
     }
     else if (*actualTarget == None) {
-        LOG((CLOG_DEBUG1 "selection conversion failed for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+        LOG(CLOG_DEBUG1 "selection conversion failed for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
         return false;
     }
     return true;
@@ -624,12 +624,12 @@ XWindowsClipboard::icccmGetTime() const
     if (icccmGetSelection(m_atomTimestamp, &actualTarget, &data) &&
         actualTarget == m_atomInteger) {
         Time time = *reinterpret_cast<const Time*>(data.data());
-        LOG((CLOG_DEBUG1 "got ICCCM time %d", time));
+        LOG(CLOG_DEBUG1 "got ICCCM time %d", time);
         return time;
     }
     else {
         // no timestamp
-        LOG((CLOG_DEBUG1 "can't get ICCCM time"));
+        LOG(CLOG_DEBUG1 "can't get ICCCM time");
         return 0;
     }
 }
@@ -640,7 +640,7 @@ XWindowsClipboard::motifLockClipboard() const
     // fail if anybody owns the lock (even us, so this is non-recursive)
     Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
     if (lockOwner != None) {
-        LOG((CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner));
+        LOG(CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner);
         return false;
     }
 
@@ -652,18 +652,18 @@ XWindowsClipboard::motifLockClipboard() const
     m_impl->XSetSelectionOwner(m_display, m_atomMotifClipLock, m_window, time);
     lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
     if (lockOwner != m_window) {
-        LOG((CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner));
+        LOG(CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner);
         return false;
     }
 
-    LOG((CLOG_DEBUG1 "locked motif clipboard"));
+    LOG(CLOG_DEBUG1 "locked motif clipboard");
     return true;
 }
 
 void
 XWindowsClipboard::motifUnlockClipboard() const
 {
-    LOG((CLOG_DEBUG1 "unlocked motif clipboard"));
+    LOG(CLOG_DEBUG1 "unlocked motif clipboard");
 
     // fail if we don't own the lock
     Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
@@ -715,7 +715,7 @@ XWindowsClipboard::motifOwnsClipboard() const
 void
 XWindowsClipboard::motifFillCache()
 {
-    LOG((CLOG_DEBUG "Motif fill clipboard %d", m_id));
+    LOG(CLOG_DEBUG "Motif fill clipboard %d", m_id);
 
     // get the Motif clipboard header property from the root window
     Atom target;
@@ -823,24 +823,24 @@ XWindowsClipboard::motifFillCache()
         IClipboard::EFormat format = converter->getFormat();
         std::string targetData;
         if (!motifGetSelection(&motifFormat, &actualTarget, &targetData)) {
-            LOG((CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            LOG(CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
             continue;
         }
 
         if (actualTarget != target) {
-            LOG((CLOG_DEBUG1 "  target %s not same as actual target %s",
+            LOG(CLOG_DEBUG1 "  target %s not same as actual target %s",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
-                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str());
             m_added[format] = false;
             continue;
         }
 
         if (targetData.empty()) {
             m_added[format] = false;
-            LOG((CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)",
+            LOG(CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
-                XWindowsUtil::atomToString(m_display, actualTarget).c_str()));
+                XWindowsUtil::atomToString(m_display, actualTarget).c_str());
             continue;
         }
 
@@ -848,9 +848,9 @@ XWindowsClipboard::motifFillCache()
             // add to clipboard and note we've done it
             m_data[format]  = converter->toIClipboard(targetData);
             m_added[format] = true;
-            LOG((CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes"));
+            LOG(CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes");
         } else {
-            LOG((CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
+            LOG(CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
         }
     }
@@ -1044,14 +1044,14 @@ XWindowsClipboard::sendReply(Reply* reply)
 
     // bail out immediately if reply is done
     if (reply->m_done) {
-        LOG((CLOG_DEBUG1 "clipboard: finished reply to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG(CLOG_DEBUG1 "clipboard: finished reply to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
         return true;
     }
 
     // start in failed state if property is None
     bool failed = (reply->m_property == None);
     if (!failed) {
-        LOG((CLOG_DEBUG1 "clipboard: setting property on 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG(CLOG_DEBUG1 "clipboard: setting property on 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
 
         // send using INCR if already sending incrementally or if reply
         // is too large, otherwise just send it.
@@ -1100,7 +1100,7 @@ XWindowsClipboard::sendReply(Reply* reply)
     // the final zero-length property.
     // FIXME -- how do you gracefully cancel an incremental transfer?
     if (failed) {
-        LOG((CLOG_DEBUG1 "clipboard: sending failure to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG(CLOG_DEBUG1 "clipboard: sending failure to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
         reply->m_done = true;
         if (reply->m_property != None) {
             XWindowsUtil::ErrorLock lock(m_display);
@@ -1130,7 +1130,7 @@ XWindowsClipboard::sendReply(Reply* reply)
 
     // send notification if we haven't yet
     if (!reply->m_replied) {
-        LOG((CLOG_DEBUG1 "clipboard: sending notify to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property));
+        LOG(CLOG_DEBUG1 "clipboard: sending notify to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
         reply->m_replied = true;
 
         // dump every property on the requestor window to the debug2
@@ -1142,14 +1142,14 @@ XWindowsClipboard::sendReply(Reply* reply)
             int n;
             Atom* props = m_impl->XListProperties(m_display, reply->m_requestor,
                                                   &n);
-            LOG((CLOG_DEBUG2 "properties of 0x%08lx:", reply->m_requestor));
+            LOG(CLOG_DEBUG2 "properties of 0x%08lx:", reply->m_requestor);
             for (int i = 0; i < n; ++i) {
                 Atom target;
                 std::string data;
                 char* name = m_impl->XGetAtomName(m_display, props[i]);
                 if (!XWindowsUtil::getWindowProperty(m_display, reply->m_requestor,
                                                      props[i], &data, &target, nullptr, False)) {
-                    LOG((CLOG_DEBUG2 "  %s: <can't read property>", name));
+                    LOG(CLOG_DEBUG2 "  %s: <can't read property>", name);
                 }
                 else {
                     // if there are any non-ascii characters in string
@@ -1170,7 +1170,7 @@ XWindowsClipboard::sendReply(Reply* reply)
                         }
                     }
                     char* type = m_impl->XGetAtomName(m_display, target);
-                    LOG((CLOG_DEBUG2 "  %s (%s): %s", name, type, data.c_str()));
+                    LOG(CLOG_DEBUG2 "  %s (%s): %s", name, type, data.c_str());
                     if (type != nullptr) {
                         m_impl->XFree(type);
                     }
@@ -1331,7 +1331,7 @@ XWindowsClipboard::CICCCMGetClipboard::readClipboard(Display* display,
     assert(actualTarget != nullptr);
     assert(data != nullptr);
 
-    LOG((CLOG_DEBUG1 "request selection=%s, target=%s, window=%lx", XWindowsUtil::atomToString(display, selection).c_str(), XWindowsUtil::atomToString(display, target).c_str(), m_requestor));
+    LOG(CLOG_DEBUG1 "request selection=%s, target=%s, window=%lx", XWindowsUtil::atomToString(display, selection).c_str(), XWindowsUtil::atomToString(display, target).c_str(), m_requestor);
 
     m_atomNone = XInternAtom(display, "NONE", False);
     m_atomIncr = XInternAtom(display, "INCR", False);
@@ -1411,7 +1411,7 @@ XWindowsClipboard::CICCCMGetClipboard::readClipboard(Display* display,
     XSelectInput(display, m_requestor, attr.your_event_mask);
 
     // return success or failure
-    LOG((CLOG_DEBUG1 "request %s after %fs", m_failed ? "failed" : "succeeded", timeout.getTime()));
+    LOG(CLOG_DEBUG1 "request %s after %fs", m_failed ? "failed" : "succeeded", timeout.getTime());
     return !m_failed;
 }
 
@@ -1503,14 +1503,14 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
     else if (m_incr) {
         // if first incremental chunk then save target
         if (oldSize == 0) {
-            LOG((CLOG_DEBUG1 "  INCR first chunk, target %s", XWindowsUtil::atomToString(display, target).c_str()));
+            LOG(CLOG_DEBUG1 "  INCR first chunk, target %s", XWindowsUtil::atomToString(display, target).c_str());
             *m_actualTarget = target;
         }
 
         // secondary chunks must have the same target
         else {
             if (target != *m_actualTarget) {
-                LOG((CLOG_WARN "  INCR target mismatch"));
+                LOG(CLOG_WARN "  INCR target mismatch");
                 m_failed = true;
                 m_error  = true;
             }
@@ -1518,20 +1518,20 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
 
         // note if this is the final chunk
         if (m_data->size() == oldSize) {
-            LOG((CLOG_DEBUG1 "  INCR final chunk: %zd bytes total", m_data->size()));
+            LOG(CLOG_DEBUG1 "  INCR final chunk: %zd bytes total", m_data->size());
             m_done = true;
         }
     }
 
     // not incremental;  save the target.
     else {
-        LOG((CLOG_DEBUG1 "  target %s", XWindowsUtil::atomToString(display, target).c_str()));
+        LOG(CLOG_DEBUG1 "  target %s", XWindowsUtil::atomToString(display, target).c_str());
         *m_actualTarget = target;
         m_done          = true;
     }
 
     // this event has been processed
-    LOGC(!m_incr, (CLOG_DEBUG1 "  got data, %zd bytes", m_data->size()));
+    LOGC(!m_incr, CLOG_DEBUG1 "  got data, %zd bytes", m_data->size());
     return true;
 }
 

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -123,7 +123,7 @@ XWindowsClipboard::~XWindowsClipboard()
 void
 XWindowsClipboard::lost(Time time)
 {
-    LOG(CLOG_DEBUG "lost clipboard %d ownership at %d", m_id, time);
+    LOG_DEBUG("lost clipboard %d ownership at %d", m_id, time);
     if (m_owner) {
         m_owner    = false;
         m_timeLost = time;
@@ -139,7 +139,7 @@ XWindowsClipboard::addRequest(Window owner, Window requestor,
     // at the given time.
     bool success = false;
     if (owner == m_window) {
-        LOG(CLOG_DEBUG1 "request for clipboard %ld, target %s by 0x%08lx (property=%s)", m_selection, XWindowsUtil::atomToString(m_display, target).c_str(), requestor, XWindowsUtil::atomToString(m_display, property).c_str());
+        LOG_DEBUG1("request for clipboard %ld, target %s by 0x%08lx (property=%s)", m_selection, XWindowsUtil::atomToString(m_display, target).c_str(), requestor, XWindowsUtil::atomToString(m_display, property).c_str());
         if (wasOwnedAtTime(time)) {
             if (target == m_atomMultiple) {
                 // add a multiple request.  property may not be None
@@ -156,13 +156,13 @@ XWindowsClipboard::addRequest(Window owner, Window requestor,
             }
         }
         else {
-            LOG(CLOG_DEBUG1 "failed, not owned at time %ld", time);
+            LOG_DEBUG1("failed, not owned at time %ld", time);
         }
     }
 
     if (!success) {
         // send failure
-        LOG(CLOG_DEBUG1 "failed");
+        LOG_DEBUG1("failed");
         insertReply(new Reply(requestor, target, time));
     }
 
@@ -210,14 +210,14 @@ XWindowsClipboard::addSimpleRequest(Window requestor,
 
     if (type != None) {
         // success
-        LOG(CLOG_DEBUG1 "success");
+        LOG_DEBUG1("success");
         insertReply(new Reply(requestor, target, time,
                                 property, data, type, format));
         return true;
     }
     else {
         // failure
-        LOG(CLOG_DEBUG1 "failed");
+        LOG_DEBUG1("failed");
         insertReply(new Reply(requestor, target, time));
         return false;
     }
@@ -232,7 +232,7 @@ XWindowsClipboard::processRequest(Window requestor,
         // unknown requestor window
         return false;
     }
-    LOG(CLOG_DEBUG1 "received property %s delete from 0x08%lx", XWindowsUtil::atomToString(m_display, property).c_str(), requestor);
+    LOG_DEBUG1("received property %s delete from 0x08%lx", XWindowsUtil::atomToString(m_display, property).c_str(), requestor);
 
     // find the property in the known requests.  it should be the
     // first property but we'll check 'em all if we have to.
@@ -287,12 +287,12 @@ XWindowsClipboard::empty()
 {
     assert(m_open);
 
-    LOG(CLOG_DEBUG "empty clipboard %d", m_id);
+    LOG_DEBUG("empty clipboard %d", m_id);
 
     // assert ownership of clipboard
     m_impl->XSetSelectionOwner(m_display, m_selection, m_window, m_time);
     if (m_impl->XGetSelectionOwner(m_display, m_selection) != m_window) {
-        LOG(CLOG_DEBUG "failed to grab clipboard %d", m_id);
+        LOG_DEBUG("failed to grab clipboard %d", m_id);
         return false;
     }
 
@@ -310,7 +310,7 @@ XWindowsClipboard::empty()
 
     // we're the owner now
     m_owner = true;
-    LOG(CLOG_DEBUG "grabbed clipboard %d", m_id);
+    LOG_DEBUG("grabbed clipboard %d", m_id);
 
     return true;
 }
@@ -320,7 +320,7 @@ void XWindowsClipboard::add(EFormat format, const std::string& data)
     assert(m_open);
     assert(m_owner);
 
-    LOG(CLOG_DEBUG "add %zd bytes to clipboard %d format: %d", data.size(), m_id, format);
+    LOG_DEBUG("add %zd bytes to clipboard %d format: %d", data.size(), m_id, format);
 
     m_data[format]  = data;
     m_added[format] = true;
@@ -332,11 +332,11 @@ bool
 XWindowsClipboard::open(Time time) const
 {
     if (m_open) {
-        LOG(CLOG_DEBUG "failed to open clipboard: already opened");
+        LOG_DEBUG("failed to open clipboard: already opened");
         return false;
     }
 
-    LOG(CLOG_DEBUG "open clipboard %d", m_id);
+    LOG_DEBUG("open clipboard %d", m_id);
 
     // assume not motif
     m_motif = false;
@@ -350,7 +350,7 @@ XWindowsClipboard::open(Time time) const
         // check if motif owns the selection.  unlock motif clipboard
         // if it does not.
         m_motif = motifOwnsClipboard();
-        LOG(CLOG_DEBUG1 "motif does %sown clipboard", m_motif ? "" : "not ");
+        LOG_DEBUG1("motif does %sown clipboard", m_motif ? "" : "not ");
         if (!m_motif) {
             motifUnlockClipboard();
         }
@@ -371,7 +371,7 @@ XWindowsClipboard::close() const
 {
     assert(m_open);
 
-    LOG(CLOG_DEBUG "close clipboard %d", m_id);
+    LOG_DEBUG("close clipboard %d", m_id);
 
     // unlock clipboard
     if (m_motif) {
@@ -428,14 +428,14 @@ XWindowsClipboard::getConverter(Atom target, bool onlyIfNotAdded) const
         }
     }
     if (converter == nullptr) {
-        LOG(CLOG_DEBUG1 "  no converter for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+        LOG_DEBUG1("  no converter for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
         return nullptr;
     }
 
     // optionally skip already handled targets
     if (onlyIfNotAdded) {
         if (m_added[converter->getFormat()]) {
-            LOG(CLOG_DEBUG1 "  skipping handled format %d", converter->getFormat());
+            LOG_DEBUG1("  skipping handled format %d", converter->getFormat());
             return nullptr;
         }
     }
@@ -515,7 +515,7 @@ XWindowsClipboard::doFillCache()
 void
 XWindowsClipboard::icccmFillCache()
 {
-    LOG(CLOG_DEBUG "ICCCM fill clipboard %d", m_id);
+    LOG_DEBUG("ICCCM fill clipboard %d", m_id);
 
     // see if we can get the list of available formats from the selection.
     // if not then use a default list of formats.  note that some clipboard
@@ -526,7 +526,7 @@ XWindowsClipboard::icccmFillCache()
     std::string data;
     if (!icccmGetSelection(atomTargets, &target, &data) ||
         (target != m_atomAtom && target != m_atomTargets)) {
-        LOG(CLOG_DEBUG1 "selection doesn't support TARGETS");
+        LOG_DEBUG1("selection doesn't support TARGETS");
         data = "";
         XWindowsUtil::appendAtomData(data, XA_STRING);
     }
@@ -534,7 +534,7 @@ XWindowsClipboard::icccmFillCache()
     XWindowsUtil::convertAtomProperty(data);
     const Atom* targets = reinterpret_cast<const Atom*>(data.data()); // TODO: Safe?
     const std::uint32_t numTargets = data.size() / sizeof(Atom);
-    LOG(CLOG_DEBUG "  available targets: %s", XWindowsUtil::atomsToString(m_display, targets, numTargets).c_str());
+    LOG_DEBUG("  available targets: %s", XWindowsUtil::atomsToString(m_display, targets, numTargets).c_str());
 
     // try each converter in order (because they're in order of
     // preference).
@@ -561,13 +561,13 @@ XWindowsClipboard::icccmFillCache()
         IClipboard::EFormat format = converter->getFormat();
         std::string targetData;
         if (!icccmGetSelection(target, &actualTarget, &targetData)) {
-            LOG(CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+            LOG_DEBUG1("  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
             continue;
         }
 
         if (actualTarget != target) {
-            LOG(CLOG_DEBUG1 "  target %s not same as actual target %s",
+            LOG_DEBUG1("  target %s not same as actual target %s",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
                 XWindowsUtil::atomToString(m_display, actualTarget).c_str());
             m_added[format] = false;
@@ -576,7 +576,7 @@ XWindowsClipboard::icccmFillCache()
 
         if (targetData.empty()) {
             m_added[format] = false;
-            LOG(CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)",
+            LOG_DEBUG1("  no targetdata for target %s (actual target %s)",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
                 XWindowsUtil::atomToString(m_display, actualTarget).c_str());
              continue;
@@ -586,9 +586,9 @@ XWindowsClipboard::icccmFillCache()
             // add to clipboard and note we've done it
             m_data[format]  = converter->toIClipboard(targetData);
             m_added[format] = true;
-            LOG(CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes");
+            LOG_DEBUG("  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes");
         } else {
-            LOG(CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+            LOG_DEBUG1("  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
         }
     }
@@ -605,12 +605,12 @@ XWindowsClipboard::icccmGetSelection(Atom target,
     CICCCMGetClipboard getter(m_window, m_time, m_atomData);
     if (!getter.readClipboard(m_display, m_selection,
                                 target, actualTarget, data)) {
-        LOG(CLOG_DEBUG1 "can't get data for selection target %s", XWindowsUtil::atomToString(m_display, target).c_str());
-        LOGC(getter.m_error, (CLOG_WARN "ICCCM violation by clipboard owner"));
+        LOG_DEBUG1("can't get data for selection target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+        if (getter.m_error) LOG_WARN("ICCCM violation by clipboard owner");
         return false;
     }
     else if (*actualTarget == None) {
-        LOG(CLOG_DEBUG1 "selection conversion failed for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+        LOG_DEBUG1("selection conversion failed for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
         return false;
     }
     return true;
@@ -624,12 +624,12 @@ XWindowsClipboard::icccmGetTime() const
     if (icccmGetSelection(m_atomTimestamp, &actualTarget, &data) &&
         actualTarget == m_atomInteger) {
         Time time = *reinterpret_cast<const Time*>(data.data());
-        LOG(CLOG_DEBUG1 "got ICCCM time %d", time);
+        LOG_DEBUG1("got ICCCM time %d", time);
         return time;
     }
     else {
         // no timestamp
-        LOG(CLOG_DEBUG1 "can't get ICCCM time");
+        LOG_DEBUG1("can't get ICCCM time");
         return 0;
     }
 }
@@ -640,7 +640,7 @@ XWindowsClipboard::motifLockClipboard() const
     // fail if anybody owns the lock (even us, so this is non-recursive)
     Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
     if (lockOwner != None) {
-        LOG(CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner);
+        LOG_DEBUG1("motif lock owner 0x%08lx", lockOwner);
         return false;
     }
 
@@ -652,18 +652,18 @@ XWindowsClipboard::motifLockClipboard() const
     m_impl->XSetSelectionOwner(m_display, m_atomMotifClipLock, m_window, time);
     lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
     if (lockOwner != m_window) {
-        LOG(CLOG_DEBUG1 "motif lock owner 0x%08lx", lockOwner);
+        LOG_DEBUG1("motif lock owner 0x%08lx", lockOwner);
         return false;
     }
 
-    LOG(CLOG_DEBUG1 "locked motif clipboard");
+    LOG_DEBUG1("locked motif clipboard");
     return true;
 }
 
 void
 XWindowsClipboard::motifUnlockClipboard() const
 {
-    LOG(CLOG_DEBUG1 "unlocked motif clipboard");
+    LOG_DEBUG1("unlocked motif clipboard");
 
     // fail if we don't own the lock
     Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
@@ -715,7 +715,7 @@ XWindowsClipboard::motifOwnsClipboard() const
 void
 XWindowsClipboard::motifFillCache()
 {
-    LOG(CLOG_DEBUG "Motif fill clipboard %d", m_id);
+    LOG_DEBUG("Motif fill clipboard %d", m_id);
 
     // get the Motif clipboard header property from the root window
     Atom target;
@@ -823,13 +823,13 @@ XWindowsClipboard::motifFillCache()
         IClipboard::EFormat format = converter->getFormat();
         std::string targetData;
         if (!motifGetSelection(&motifFormat, &actualTarget, &targetData)) {
-            LOG(CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+            LOG_DEBUG1("  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
             continue;
         }
 
         if (actualTarget != target) {
-            LOG(CLOG_DEBUG1 "  target %s not same as actual target %s",
+            LOG_DEBUG1("  target %s not same as actual target %s",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
                 XWindowsUtil::atomToString(m_display, actualTarget).c_str());
             m_added[format] = false;
@@ -838,7 +838,7 @@ XWindowsClipboard::motifFillCache()
 
         if (targetData.empty()) {
             m_added[format] = false;
-            LOG(CLOG_DEBUG1 "  no targetdata for target %s (actual target %s)",
+            LOG_DEBUG1("  no targetdata for target %s (actual target %s)",
                 XWindowsUtil::atomToString(m_display, target).c_str(),
                 XWindowsUtil::atomToString(m_display, actualTarget).c_str());
             continue;
@@ -848,9 +848,9 @@ XWindowsClipboard::motifFillCache()
             // add to clipboard and note we've done it
             m_data[format]  = converter->toIClipboard(targetData);
             m_added[format] = true;
-            LOG(CLOG_DEBUG "  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes");
+            LOG_DEBUG("  added format %d for target %s (%zu %s)", format, XWindowsUtil::atomToString(m_display, target).c_str(), targetData.size(), targetData.size() == 1 ? "byte" : "bytes");
         } else {
-            LOG(CLOG_DEBUG1 "  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
+            LOG_DEBUG1("  no clipboard data for target %s", XWindowsUtil::atomToString(m_display, target).c_str());
             m_added[format] = false;
         }
     }
@@ -1044,14 +1044,14 @@ XWindowsClipboard::sendReply(Reply* reply)
 
     // bail out immediately if reply is done
     if (reply->m_done) {
-        LOG(CLOG_DEBUG1 "clipboard: finished reply to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
+        LOG_DEBUG1("clipboard: finished reply to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
         return true;
     }
 
     // start in failed state if property is None
     bool failed = (reply->m_property == None);
     if (!failed) {
-        LOG(CLOG_DEBUG1 "clipboard: setting property on 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
+        LOG_DEBUG1("clipboard: setting property on 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
 
         // send using INCR if already sending incrementally or if reply
         // is too large, otherwise just send it.
@@ -1100,7 +1100,7 @@ XWindowsClipboard::sendReply(Reply* reply)
     // the final zero-length property.
     // FIXME -- how do you gracefully cancel an incremental transfer?
     if (failed) {
-        LOG(CLOG_DEBUG1 "clipboard: sending failure to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
+        LOG_DEBUG1("clipboard: sending failure to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
         reply->m_done = true;
         if (reply->m_property != None) {
             XWindowsUtil::ErrorLock lock(m_display);
@@ -1130,7 +1130,7 @@ XWindowsClipboard::sendReply(Reply* reply)
 
     // send notification if we haven't yet
     if (!reply->m_replied) {
-        LOG(CLOG_DEBUG1 "clipboard: sending notify to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
+        LOG_DEBUG1("clipboard: sending notify to 0x%08lx,%ld,%ld", reply->m_requestor, reply->m_target, reply->m_property);
         reply->m_replied = true;
 
         // dump every property on the requestor window to the debug2
@@ -1142,14 +1142,14 @@ XWindowsClipboard::sendReply(Reply* reply)
             int n;
             Atom* props = m_impl->XListProperties(m_display, reply->m_requestor,
                                                   &n);
-            LOG(CLOG_DEBUG2 "properties of 0x%08lx:", reply->m_requestor);
+            LOG_DEBUG2("properties of 0x%08lx:", reply->m_requestor);
             for (int i = 0; i < n; ++i) {
                 Atom target;
                 std::string data;
                 char* name = m_impl->XGetAtomName(m_display, props[i]);
                 if (!XWindowsUtil::getWindowProperty(m_display, reply->m_requestor,
                                                      props[i], &data, &target, nullptr, False)) {
-                    LOG(CLOG_DEBUG2 "  %s: <can't read property>", name);
+                    LOG_DEBUG2("  %s: <can't read property>", name);
                 }
                 else {
                     // if there are any non-ascii characters in string
@@ -1170,7 +1170,7 @@ XWindowsClipboard::sendReply(Reply* reply)
                         }
                     }
                     char* type = m_impl->XGetAtomName(m_display, target);
-                    LOG(CLOG_DEBUG2 "  %s (%s): %s", name, type, data.c_str());
+                    LOG_DEBUG2("  %s (%s): %s", name, type, data.c_str());
                     if (type != nullptr) {
                         m_impl->XFree(type);
                     }
@@ -1331,7 +1331,7 @@ XWindowsClipboard::CICCCMGetClipboard::readClipboard(Display* display,
     assert(actualTarget != nullptr);
     assert(data != nullptr);
 
-    LOG(CLOG_DEBUG1 "request selection=%s, target=%s, window=%lx", XWindowsUtil::atomToString(display, selection).c_str(), XWindowsUtil::atomToString(display, target).c_str(), m_requestor);
+    LOG_DEBUG1("request selection=%s, target=%s, window=%lx", XWindowsUtil::atomToString(display, selection).c_str(), XWindowsUtil::atomToString(display, target).c_str(), m_requestor);
 
     m_atomNone = XInternAtom(display, "NONE", False);
     m_atomIncr = XInternAtom(display, "INCR", False);
@@ -1411,7 +1411,7 @@ XWindowsClipboard::CICCCMGetClipboard::readClipboard(Display* display,
     XSelectInput(display, m_requestor, attr.your_event_mask);
 
     // return success or failure
-    LOG(CLOG_DEBUG1 "request %s after %fs", m_failed ? "failed" : "succeeded", timeout.getTime());
+    LOG_DEBUG1("request %s after %fs", m_failed ? "failed" : "succeeded", timeout.getTime());
     return !m_failed;
 }
 
@@ -1503,14 +1503,14 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
     else if (m_incr) {
         // if first incremental chunk then save target
         if (oldSize == 0) {
-            LOG(CLOG_DEBUG1 "  INCR first chunk, target %s", XWindowsUtil::atomToString(display, target).c_str());
+            LOG_DEBUG1("  INCR first chunk, target %s", XWindowsUtil::atomToString(display, target).c_str());
             *m_actualTarget = target;
         }
 
         // secondary chunks must have the same target
         else {
             if (target != *m_actualTarget) {
-                LOG(CLOG_WARN "  INCR target mismatch");
+                LOG_WARN("  INCR target mismatch");
                 m_failed = true;
                 m_error  = true;
             }
@@ -1518,20 +1518,20 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
 
         // note if this is the final chunk
         if (m_data->size() == oldSize) {
-            LOG(CLOG_DEBUG1 "  INCR final chunk: %zd bytes total", m_data->size());
+            LOG_DEBUG1("  INCR final chunk: %zd bytes total", m_data->size());
             m_done = true;
         }
     }
 
     // not incremental;  save the target.
     else {
-        LOG(CLOG_DEBUG1 "  target %s", XWindowsUtil::atomToString(display, target).c_str());
+        LOG_DEBUG1("  target %s", XWindowsUtil::atomToString(display, target).c_str());
         *m_actualTarget = target;
         m_done          = true;
     }
 
     // this event has been processed
-    LOGC(!m_incr, CLOG_DEBUG1 "  got data, %zd bytes", m_data->size());
+    if (!m_incr) LOG_DEBUG1("  got data, %zd bytes", m_data->size());
     return true;
 }
 

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -110,14 +110,14 @@ XWindowsKeyState::setAutoRepeat(const XKeyboardState& state)
 KeyModifierMask
 XWindowsKeyState::mapModifiersFromX(unsigned int state) const
 {
-    LOG(CLOG_DEBUG2 "mapping state: %i", state);
+    LOG_DEBUG2("mapping state: %i", state);
     std::uint32_t offset = 8 * getGroupFromState(state);
     KeyModifierMask mask = 0;
     for (int i = 0; i < 8; ++i) {
         if ((state & (1u << i)) != 0) {
-            LOG(CLOG_DEBUG2 "|= modifier: %i", offset + i);
+            LOG_DEBUG2("|= modifier: %i", offset + i);
             if (offset + i >= m_modifierFromX.size()) {
-                LOG(CLOG_ERR "m_modifierFromX is too small (%zd) for the "
+                LOG_ERR("m_modifierFromX is too small (%zd) for the "
                     "requested offset (%d)", m_modifierFromX.size(), offset+i);
             } else {
                 mask |= m_modifierFromX[offset + i];
@@ -238,14 +238,14 @@ XWindowsKeyState::fakeKey(const Keystroke& keystroke)
 {
     switch (keystroke.m_type) {
     case Keystroke::kButton:
-        LOG(CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up");
+        LOG_DEBUG1("  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up");
         if (keystroke.m_data.m_button.m_repeat) {
             int c = keystroke.m_data.m_button.m_button;
             int i = (c >> 3);
             int b = 1 << (c & 7);
             if (m_keyboardState.global_auto_repeat == AutoRepeatModeOff ||
                 (c!=113 && c!=116 && (m_keyboardState.auto_repeats[i] & b) == 0)) {
-                LOG(CLOG_DEBUG1 "  discard autorepeat");
+                LOG_DEBUG1("  discard autorepeat");
                 break;
             }
         }
@@ -256,32 +256,32 @@ XWindowsKeyState::fakeKey(const Keystroke& keystroke)
 
     case Keystroke::kGroup:
         if (keystroke.m_data.m_group.m_absolute) {
-            LOG(CLOG_DEBUG1 "  group %d", keystroke.m_data.m_group.m_group);
+            LOG_DEBUG1("  group %d", keystroke.m_data.m_group.m_group);
             if (m_xkb != nullptr) {
                 if (m_impl->XkbLockGroup(m_display, XkbUseCoreKbd,
                                          keystroke.m_data.m_group.m_group
                                          ) == False) {
-                    LOG(CLOG_DEBUG1 "XkbLockGroup request not sent");
+                    LOG_DEBUG1("XkbLockGroup request not sent");
                 }
             }
             else
             {
-                LOG(CLOG_DEBUG1 "  ignored");
+                LOG_DEBUG1("  ignored");
             }
         }
         else {
-            LOG(CLOG_DEBUG1 "  group %+d", keystroke.m_data.m_group.m_group);
+            LOG_DEBUG1("  group %+d", keystroke.m_data.m_group.m_group);
             if (m_xkb != nullptr) {
                 if (m_impl->XkbLockGroup(m_display, XkbUseCoreKbd,
                                          getEffectiveGroup(pollActiveGroup(),
                                          keystroke.m_data.m_group.m_group)
                                          ) == False) {
-                    LOG(CLOG_DEBUG1 "XkbLockGroup request not sent");
+                    LOG_DEBUG1("XkbLockGroup request not sent");
                 }
             }
             else
             {
-                LOG(CLOG_DEBUG1 "  ignored");
+                LOG_DEBUG1("  ignored");
             }
         }
         break;
@@ -297,7 +297,7 @@ XWindowsKeyState::updateKeysymMap(inputleap::KeyMap& keyMap)
     // there are up to 4 keysyms per keycode
     static const int maxKeysyms = 4;
 
-    LOG(CLOG_DEBUG1 "non-XKB mapping");
+    LOG_DEBUG1("non-XKB mapping");
 
     // prepare map from X modifier to KeyModifierMask.  certain bits
     // are predefined.
@@ -549,7 +549,7 @@ XWindowsKeyState::updateKeysymMapXKB(inputleap::KeyMap& keyMap)
         }
     };
 
-    LOG(CLOG_DEBUG1 "XKB mapping");
+    LOG_DEBUG1("XKB mapping");
 
     // find the number of groups
     int maxNumGroups = 0;

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -110,15 +110,15 @@ XWindowsKeyState::setAutoRepeat(const XKeyboardState& state)
 KeyModifierMask
 XWindowsKeyState::mapModifiersFromX(unsigned int state) const
 {
-    LOG((CLOG_DEBUG2 "mapping state: %i", state));
+    LOG(CLOG_DEBUG2 "mapping state: %i", state);
     std::uint32_t offset = 8 * getGroupFromState(state);
     KeyModifierMask mask = 0;
     for (int i = 0; i < 8; ++i) {
         if ((state & (1u << i)) != 0) {
-            LOG((CLOG_DEBUG2 "|= modifier: %i", offset + i));
+            LOG(CLOG_DEBUG2 "|= modifier: %i", offset + i);
             if (offset + i >= m_modifierFromX.size()) {
-                LOG((CLOG_ERR "m_modifierFromX is too small (%zd) for the "
-                    "requested offset (%d)", m_modifierFromX.size(), offset+i));
+                LOG(CLOG_ERR "m_modifierFromX is too small (%zd) for the "
+                    "requested offset (%d)", m_modifierFromX.size(), offset+i);
             } else {
                 mask |= m_modifierFromX[offset + i];
             }
@@ -238,14 +238,14 @@ XWindowsKeyState::fakeKey(const Keystroke& keystroke)
 {
     switch (keystroke.m_type) {
     case Keystroke::kButton:
-        LOG((CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up"));
+        LOG(CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client, keystroke.m_data.m_button.m_press ? "down" : "up");
         if (keystroke.m_data.m_button.m_repeat) {
             int c = keystroke.m_data.m_button.m_button;
             int i = (c >> 3);
             int b = 1 << (c & 7);
             if (m_keyboardState.global_auto_repeat == AutoRepeatModeOff ||
                 (c!=113 && c!=116 && (m_keyboardState.auto_repeats[i] & b) == 0)) {
-                LOG((CLOG_DEBUG1 "  discard autorepeat"));
+                LOG(CLOG_DEBUG1 "  discard autorepeat");
                 break;
             }
         }
@@ -256,32 +256,32 @@ XWindowsKeyState::fakeKey(const Keystroke& keystroke)
 
     case Keystroke::kGroup:
         if (keystroke.m_data.m_group.m_absolute) {
-            LOG((CLOG_DEBUG1 "  group %d", keystroke.m_data.m_group.m_group));
+            LOG(CLOG_DEBUG1 "  group %d", keystroke.m_data.m_group.m_group);
             if (m_xkb != nullptr) {
                 if (m_impl->XkbLockGroup(m_display, XkbUseCoreKbd,
                                          keystroke.m_data.m_group.m_group
                                          ) == False) {
-                    LOG((CLOG_DEBUG1 "XkbLockGroup request not sent"));
+                    LOG(CLOG_DEBUG1 "XkbLockGroup request not sent");
                 }
             }
             else
             {
-                LOG((CLOG_DEBUG1 "  ignored"));
+                LOG(CLOG_DEBUG1 "  ignored");
             }
         }
         else {
-            LOG((CLOG_DEBUG1 "  group %+d", keystroke.m_data.m_group.m_group));
+            LOG(CLOG_DEBUG1 "  group %+d", keystroke.m_data.m_group.m_group);
             if (m_xkb != nullptr) {
                 if (m_impl->XkbLockGroup(m_display, XkbUseCoreKbd,
                                          getEffectiveGroup(pollActiveGroup(),
                                          keystroke.m_data.m_group.m_group)
                                          ) == False) {
-                    LOG((CLOG_DEBUG1 "XkbLockGroup request not sent"));
+                    LOG(CLOG_DEBUG1 "XkbLockGroup request not sent");
                 }
             }
             else
             {
-                LOG((CLOG_DEBUG1 "  ignored"));
+                LOG(CLOG_DEBUG1 "  ignored");
             }
         }
         break;
@@ -297,7 +297,7 @@ XWindowsKeyState::updateKeysymMap(inputleap::KeyMap& keyMap)
     // there are up to 4 keysyms per keycode
     static const int maxKeysyms = 4;
 
-    LOG((CLOG_DEBUG1 "non-XKB mapping"));
+    LOG(CLOG_DEBUG1 "non-XKB mapping");
 
     // prepare map from X modifier to KeyModifierMask.  certain bits
     // are predefined.
@@ -549,7 +549,7 @@ XWindowsKeyState::updateKeysymMapXKB(inputleap::KeyMap& keyMap)
         }
     };
 
-    LOG((CLOG_DEBUG1 "XKB mapping"));
+    LOG(CLOG_DEBUG1 "XKB mapping");
 
     // find the number of groups
     int maxNumGroups = 0;

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -116,8 +116,8 @@ XWindowsScreen::XWindowsScreen(
                                 m_window, get_event_target(), events);
         m_keyState    = new XWindowsKeyState(m_impl, m_display, m_xkb, events,
                                              m_keyMap);
-		LOG(CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_xinerama ? "(xinerama)" : "");
-		LOG(CLOG_DEBUG "window is 0x%08lx", m_window);
+		LOG_DEBUG("screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_xinerama ? "(xinerama)" : "");
+		LOG_DEBUG("window is 0x%08lx", m_window);
 	}
 	catch (...) {
         if (m_display != nullptr) {
@@ -418,11 +418,11 @@ XWindowsScreen::setOptions(const OptionsList& options)
     for (std::uint32_t i = 0, n = options.size(); i < n; i += 2) {
 		if (options[i] == kOptionXTestXineramaUnaware) {
 			m_xtestIsXineramaUnaware = (options[i + 1] != 0);
-			LOG(CLOG_DEBUG1 "XTest is Xinerama unaware %s", m_xtestIsXineramaUnaware ? "true" : "false");
+			LOG_DEBUG1("XTest is Xinerama unaware %s", m_xtestIsXineramaUnaware ? "true" : "false");
 		}
 		else if (options[i] == kOptionScreenPreserveFocus) {
 			m_preserveFocus = (options[i + 1] != 0);
-			LOG(CLOG_DEBUG1 "Preserve Focus = %s", m_preserveFocus ? "true" : "false");
+			LOG_DEBUG1("Preserve Focus = %s", m_preserveFocus ? "true" : "false");
 		}
 	}
 }
@@ -515,7 +515,7 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 	// only allow certain modifiers
 	if ((mask & ~(KeyModifierShift | KeyModifierControl |
 				  KeyModifierAlt   | KeyModifierSuper)) != 0) {
-		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
+		LOG_DEBUG("could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 
@@ -528,14 +528,14 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 	unsigned int modifiers;
 	if (!m_keyState->mapModifiersToX(mask, modifiers)) {
 		// can't map all modifiers
-		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
+		LOG_DEBUG("could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 	XWindowsKeyState::KeycodeList keycodes;
 	m_keyState->mapKeyToKeycodes(key, keycodes);
 	if (key != kKeyNone && keycodes.empty()) {
 		// can't map key
-		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
+		LOG_DEBUG("could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 
@@ -696,11 +696,11 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 
 		m_oldHotKeyIDs.push_back(id);
 		m_hotKeys.erase(id);
-		LOG(CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
+		LOG_WARN("failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
 		return 0;
 	}
 
-	LOG(CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
+	LOG_DEBUG("registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
 	return id;
 }
 
@@ -724,10 +724,10 @@ void XWindowsScreen::unregisterHotKey(std::uint32_t id)
 		}
 	}
 	if (err) {
-		LOG(CLOG_WARN "failed to unregister hotkey id=%d", id);
+		LOG_WARN("failed to unregister hotkey id=%d", id);
 	}
 	else {
-		LOG(CLOG_DEBUG "unregistered hotkey id=%d", id);
+		LOG_DEBUG("unregistered hotkey id=%d", id);
 	}
 
 	// discard hot key from map and record old id for reuse
@@ -865,7 +865,7 @@ XWindowsScreen::openDisplay(const char* displayName)
 	}
 
 	// open the display
-	LOG(CLOG_DEBUG "XOpenDisplay(\"%s\")", displayName);
+	LOG_DEBUG("XOpenDisplay(\"%s\")", displayName);
     Display* display = m_impl->XOpenDisplay(displayName);
     if (display == nullptr) {
 		throw XScreenUnavailable(60.0);
@@ -876,7 +876,7 @@ XWindowsScreen::openDisplay(const char* displayName)
 		int majorOpcode, firstEvent, firstError;
         if (!m_impl->XQueryExtension(display, XTestExtensionName,
 							&majorOpcode, &firstEvent, &firstError)) {
-			LOG(CLOG_ERR "XTEST extension not available");
+			LOG_ERR("XTEST extension not available");
             m_impl->XCloseDisplay(display);
 			throw XScreenOpenFailure();
 		}
@@ -1015,7 +1015,7 @@ XWindowsScreen::openIM()
 	// open the input methods
     XIM im = m_impl->XOpenIM(m_display, nullptr, nullptr, nullptr);
     if (im == nullptr) {
-		LOG(CLOG_INFO "no support for IM");
+		LOG_INFO("no support for IM");
 		return;
 	}
 
@@ -1024,7 +1024,7 @@ XWindowsScreen::openIM()
 	XIMStyles* styles;
     if (m_impl->XGetIMValues(im, XNQueryInputStyle, &styles) != nullptr ||
         styles == nullptr) {
-		LOG(CLOG_WARN "cannot get IM styles");
+		LOG_WARN("cannot get IM styles");
         m_impl->XCloseIM(im);
 		return;
 	}
@@ -1039,7 +1039,7 @@ XWindowsScreen::openIM()
 	}
 	XFree(styles);
 	if (style == 0) {
-		LOG(CLOG_INFO "no supported IM styles");
+		LOG_INFO("no supported IM styles");
         m_impl->XCloseIM(im);
 		return;
 	}
@@ -1047,7 +1047,7 @@ XWindowsScreen::openIM()
 	// create an input context for the style and tell it about our window
     XIC ic = m_impl->XCreateIC(im, XNInputStyle, style, XNClientWindow, m_window);
     if (ic == nullptr) {
-		LOG(CLOG_WARN "cannot create IC");
+		LOG_WARN("cannot create IC");
         m_impl->XCloseIM(im);
 		return;
 	}
@@ -1055,7 +1055,7 @@ XWindowsScreen::openIM()
 	// find out the events we must select for and do so
 	unsigned long mask;
     if (m_impl->XGetICValues(ic, XNFilterEvents, &mask) != nullptr) {
-		LOG(CLOG_WARN "cannot get IC filter events");
+		LOG_WARN("cannot get IC filter events");
         m_impl->XDestroyIC(ic);
         m_impl->XCloseIM(im);
 		return;
@@ -1336,7 +1336,7 @@ XWindowsScreen::handle_system_event(const Event& event)
 				return;
 
 			case XkbStateNotify:
-				LOG(CLOG_INFO "group change: %d", xkbEvent->state.group);
+				LOG_INFO("group change: %d", xkbEvent->state.group);
                 m_keyState->setActiveGroup(static_cast<std::int32_t>(xkbEvent->state.group));
 				return;
             default:
@@ -1348,7 +1348,7 @@ XWindowsScreen::handle_system_event(const Event& event)
 			if (xevent->type == m_xrandrEventBase + RRScreenChangeNotify ||
 			    (xevent->type == m_xrandrEventBase + RRNotify &&
 			     reinterpret_cast<XRRNotifyEvent *>(xevent)->subtype == RRNotify_CrtcChange)) {
-				LOG(CLOG_INFO "XRRScreenChangeNotifyEvent or RRNotify_CrtcChange received");
+				LOG_INFO("XRRScreenChangeNotifyEvent or RRNotify_CrtcChange received");
 
 				// we're required to call back into XLib so XLib can update its internal state
 				XRRUpdateConfiguration(xevent);
@@ -1375,7 +1375,7 @@ XWindowsScreen::handle_system_event(const Event& event)
 void
 XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 {
-	LOG(CLOG_DEBUG1 "event: KeyPress code=%d, state=0x%04x", xkey.keycode, xkey.state);
+	LOG_DEBUG1("event: KeyPress code=%d, state=0x%04x", xkey.keycode, xkey.state);
 	const KeyModifierMask mask = m_keyState->mapModifiersFromX(xkey.state);
 	KeyID key                  = mapKeyFromX(&xkey);
 	if (key != kKeyNone) {
@@ -1384,7 +1384,7 @@ XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 			(mask & (KeyModifierControl | KeyModifierAlt)) ==
 					(KeyModifierControl | KeyModifierAlt)) {
 			// pretend it's ctrl+alt+del
-			LOG(CLOG_DEBUG "emulate ctrl+alt+del");
+			LOG_DEBUG("emulate ctrl+alt+del");
 			key = kKeyDelete;
 		}
 
@@ -1397,7 +1397,7 @@ XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 			keycode = static_cast<KeyButton>(m_lastKeycode);
 			if (keycode == 0) {
 				// no keycode
-				LOG(CLOG_DEBUG1 "event: KeyPress no keycode");
+				LOG_DEBUG1("event: KeyPress no keycode");
 				return;
 			}
 		}
@@ -1413,7 +1413,7 @@ XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 		}
 	}
     else {
-		LOG(CLOG_DEBUG1 "can't map keycode to key id");
+		LOG_DEBUG1("can't map keycode to key id");
     }
 }
 
@@ -1428,7 +1428,7 @@ XWindowsScreen::onKeyRelease(XKeyEvent& xkey, bool isRepeat)
 			(mask & (KeyModifierControl | KeyModifierAlt)) ==
 					(KeyModifierControl | KeyModifierAlt)) {
 			// pretend it's ctrl+alt+del and ignore autorepeat
-			LOG(CLOG_DEBUG "emulate ctrl+alt+del");
+			LOG_DEBUG("emulate ctrl+alt+del");
 			key      = kKeyDelete;
 			isRepeat = false;
 		}
@@ -1436,7 +1436,7 @@ XWindowsScreen::onKeyRelease(XKeyEvent& xkey, bool isRepeat)
 		KeyButton keycode = static_cast<KeyButton>(xkey.keycode);
 		if (!isRepeat) {
 			// no press event follows so it's a plain release
-			LOG(CLOG_DEBUG1 "event: KeyRelease code=%d, state=0x%04x", keycode, xkey.state);
+			LOG_DEBUG1("event: KeyRelease code=%d, state=0x%04x", keycode, xkey.state);
             m_keyState->sendKeyEvent(get_event_target(),
 							false, false, key, mask, 1, keycode);
 		}
@@ -1445,7 +1445,7 @@ XWindowsScreen::onKeyRelease(XKeyEvent& xkey, bool isRepeat)
 			// we could attempt to count the already queued
 			// repeats but we'll just send a repeat of 1.
 			// note that we discard the press event.
-			LOG(CLOG_DEBUG1 "event: repeat code=%d, state=0x%04x", keycode, xkey.state);
+			LOG_DEBUG1("event: repeat code=%d, state=0x%04x", keycode, xkey.state);
             m_keyState->sendKeyEvent(get_event_target(),
 							false, true, key, mask, 1, keycode);
 		}
@@ -1485,7 +1485,7 @@ XWindowsScreen::onHotKey(XKeyEvent& xkey, bool isRepeat)
 void
 XWindowsScreen::onMousePress(const XButtonEvent& xbutton)
 {
-	LOG(CLOG_DEBUG1 "event: ButtonPress button=%d", xbutton.button);
+	LOG_DEBUG1("event: ButtonPress button=%d", xbutton.button);
 	ButtonID button      = mapButtonFromX(&xbutton);
 	KeyModifierMask mask = m_keyState->mapModifiersFromX(xbutton.state);
 	if (button != kButtonNone) {
@@ -1497,7 +1497,7 @@ XWindowsScreen::onMousePress(const XButtonEvent& xbutton)
 void
 XWindowsScreen::onMouseRelease(const XButtonEvent& xbutton)
 {
-	LOG(CLOG_DEBUG1 "event: ButtonRelease button=%d", xbutton.button);
+	LOG_DEBUG1("event: ButtonRelease button=%d", xbutton.button);
 	ButtonID button      = mapButtonFromX(&xbutton);
 	KeyModifierMask mask = m_keyState->mapModifiersFromX(xbutton.state);
 	if (button != kButtonNone) {
@@ -1529,7 +1529,7 @@ XWindowsScreen::onMouseRelease(const XButtonEvent& xbutton)
 void
 XWindowsScreen::onMouseMove(const XMotionEvent& xmotion)
 {
-	LOG(CLOG_DEBUG2 "event: MotionNotify %d,%d", xmotion.x_root, xmotion.y_root);
+	LOG_DEBUG2("event: MotionNotify %d,%d", xmotion.x_root, xmotion.y_root);
 
 	// compute motion delta (relative to the last known
 	// mouse position)
@@ -1551,7 +1551,7 @@ XWindowsScreen::onMouseMove(const XMotionEvent& xmotion)
 		do {
             m_impl->XMaskEvent(m_display, PointerMotionMask, &xevent);
 			if (cntr++ > 10) {
-				LOG(CLOG_WARN "too many discarded events! %d", cntr);
+				LOG_WARN("too many discarded events! %d", cntr);
 				break;
 			}
 		} while (!xevent.xany.send_event);
@@ -1716,7 +1716,7 @@ XWindowsScreen::ioErrorHandler(Display*)
 	// down.  X forces us to exit at this point which is annoying.
 	// we'll pretend as if we won't exit so we try to make sure we
 	// don't access the display anymore.
-	LOG(CLOG_CRIT "X display has unexpectedly disconnected");
+	LOG_CRIT("X display has unexpectedly disconnected");
 	s_screen->onError();
 	return 0;
 }
@@ -1818,11 +1818,11 @@ XWindowsScreen::mapKeyFromX(XKeyEvent* event) const
         m_impl->XLookupString(event, dummy, 0, &keysym, nullptr);
 	}
 
-	LOG(CLOG_DEBUG2 "mapped code=%d to keysym=0x%04lx", event->keycode, keysym);
+	LOG_DEBUG2("mapped code=%d to keysym=0x%04lx", event->keycode, keysym);
 
 	// convert key
 	KeyID result = XWindowsUtil::mapKeySymToKeyID(keysym);
-	LOG(CLOG_DEBUG2 "mapped keysym=0x%04lx to keyID=%d", keysym, result);
+	LOG_DEBUG2("mapped keysym=0x%04lx to keyID=%d", keysym, result);
 	return result;
 }
 
@@ -1893,7 +1893,7 @@ void XWindowsScreen::warpCursorNoFlush(std::int32_t x, std::int32_t y)
     m_impl->XSendEvent(m_display, m_window, False, 0, &eventAfter);
     m_impl->XSync(m_display, False);
 
-	LOG(CLOG_DEBUG2 "warped to %d,%d", x, y);
+	LOG_DEBUG2("warped to %d,%d", x, y);
 }
 
 void
@@ -1945,15 +1945,15 @@ XWindowsScreen::grabMouseAndKeyboard()
 								GrabModeAsync, GrabModeAsync, CurrentTime);
 			assert(result != GrabNotViewable);
 			if (result != GrabSuccess) {
-				LOG(CLOG_DEBUG2 "waiting to grab keyboard");
+				LOG_DEBUG2("waiting to grab keyboard");
                 inputleap::this_thread_sleep(0.05);
 				if (timer.getTime() >= s_timeout) {
-					LOG(CLOG_DEBUG2 "grab keyboard timed out");
+					LOG_DEBUG2("grab keyboard timed out");
 					return false;
 				}
 			}
 		} while (result != GrabSuccess);
-		LOG(CLOG_DEBUG2 "grabbed keyboard");
+		LOG_DEBUG2("grabbed keyboard");
 
 		// now the mouse --- use event_mask to get EnterNotify, LeaveNotify events
         result = m_impl->XGrabPointer(m_display, m_window, False, event_mask,
@@ -1963,16 +1963,16 @@ XWindowsScreen::grabMouseAndKeyboard()
 		if (result != GrabSuccess) {
 			// back off to avoid grab deadlock
             m_impl->XUngrabKeyboard(m_display, CurrentTime);
-			LOG(CLOG_DEBUG2 "ungrabbed keyboard, waiting to grab pointer");
+			LOG_DEBUG2("ungrabbed keyboard, waiting to grab pointer");
             inputleap::this_thread_sleep(0.05);
 			if (timer.getTime() >= s_timeout) {
-				LOG(CLOG_DEBUG2 "grab pointer timed out");
+				LOG_DEBUG2("grab pointer timed out");
 				return false;
 			}
 		}
 	} while (result != GrabSuccess);
 
-	LOG(CLOG_DEBUG1 "grabbed pointer and keyboard");
+	LOG_DEBUG1("grabbed pointer and keyboard");
 	return true;
 }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -116,8 +116,8 @@ XWindowsScreen::XWindowsScreen(
                                 m_window, get_event_target(), events);
         m_keyState    = new XWindowsKeyState(m_impl, m_display, m_xkb, events,
                                              m_keyMap);
-		LOG((CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_xinerama ? "(xinerama)" : ""));
-		LOG((CLOG_DEBUG "window is 0x%08lx", m_window));
+		LOG(CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_xinerama ? "(xinerama)" : "");
+		LOG(CLOG_DEBUG "window is 0x%08lx", m_window);
 	}
 	catch (...) {
         if (m_display != nullptr) {
@@ -418,11 +418,11 @@ XWindowsScreen::setOptions(const OptionsList& options)
     for (std::uint32_t i = 0, n = options.size(); i < n; i += 2) {
 		if (options[i] == kOptionXTestXineramaUnaware) {
 			m_xtestIsXineramaUnaware = (options[i + 1] != 0);
-			LOG((CLOG_DEBUG1 "XTest is Xinerama unaware %s", m_xtestIsXineramaUnaware ? "true" : "false"));
+			LOG(CLOG_DEBUG1 "XTest is Xinerama unaware %s", m_xtestIsXineramaUnaware ? "true" : "false");
 		}
 		else if (options[i] == kOptionScreenPreserveFocus) {
 			m_preserveFocus = (options[i + 1] != 0);
-			LOG((CLOG_DEBUG1 "Preserve Focus = %s", m_preserveFocus ? "true" : "false"));
+			LOG(CLOG_DEBUG1 "Preserve Focus = %s", m_preserveFocus ? "true" : "false");
 		}
 	}
 }
@@ -515,7 +515,7 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 	// only allow certain modifiers
 	if ((mask & ~(KeyModifierShift | KeyModifierControl |
 				  KeyModifierAlt   | KeyModifierSuper)) != 0) {
-		LOG((CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask));
+		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 
@@ -528,14 +528,14 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 	unsigned int modifiers;
 	if (!m_keyState->mapModifiersToX(mask, modifiers)) {
 		// can't map all modifiers
-		LOG((CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask));
+		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 	XWindowsKeyState::KeycodeList keycodes;
 	m_keyState->mapKeyToKeycodes(key, keycodes);
 	if (key != kKeyNone && keycodes.empty()) {
 		// can't map key
-		LOG((CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask));
+		LOG(CLOG_DEBUG "could not map hotkey id=%04x mask=%04x", key, mask);
 		return 0;
 	}
 
@@ -696,11 +696,11 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 
 		m_oldHotKeyIDs.push_back(id);
 		m_hotKeys.erase(id);
-		LOG((CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask));
+		LOG(CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask);
 		return 0;
 	}
 
-	LOG((CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id));
+	LOG(CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", inputleap::KeyMap::formatKey(key, mask).c_str(), key, mask, id);
 	return id;
 }
 
@@ -724,10 +724,10 @@ void XWindowsScreen::unregisterHotKey(std::uint32_t id)
 		}
 	}
 	if (err) {
-		LOG((CLOG_WARN "failed to unregister hotkey id=%d", id));
+		LOG(CLOG_WARN "failed to unregister hotkey id=%d", id);
 	}
 	else {
-		LOG((CLOG_DEBUG "unregistered hotkey id=%d", id));
+		LOG(CLOG_DEBUG "unregistered hotkey id=%d", id);
 	}
 
 	// discard hot key from map and record old id for reuse
@@ -865,7 +865,7 @@ XWindowsScreen::openDisplay(const char* displayName)
 	}
 
 	// open the display
-	LOG((CLOG_DEBUG "XOpenDisplay(\"%s\")", displayName));
+	LOG(CLOG_DEBUG "XOpenDisplay(\"%s\")", displayName);
     Display* display = m_impl->XOpenDisplay(displayName);
     if (display == nullptr) {
 		throw XScreenUnavailable(60.0);
@@ -876,7 +876,7 @@ XWindowsScreen::openDisplay(const char* displayName)
 		int majorOpcode, firstEvent, firstError;
         if (!m_impl->XQueryExtension(display, XTestExtensionName,
 							&majorOpcode, &firstEvent, &firstError)) {
-			LOG((CLOG_ERR "XTEST extension not available"));
+			LOG(CLOG_ERR "XTEST extension not available");
             m_impl->XCloseDisplay(display);
 			throw XScreenOpenFailure();
 		}
@@ -1015,7 +1015,7 @@ XWindowsScreen::openIM()
 	// open the input methods
     XIM im = m_impl->XOpenIM(m_display, nullptr, nullptr, nullptr);
     if (im == nullptr) {
-		LOG((CLOG_INFO "no support for IM"));
+		LOG(CLOG_INFO "no support for IM");
 		return;
 	}
 
@@ -1024,7 +1024,7 @@ XWindowsScreen::openIM()
 	XIMStyles* styles;
     if (m_impl->XGetIMValues(im, XNQueryInputStyle, &styles) != nullptr ||
         styles == nullptr) {
-		LOG((CLOG_WARN "cannot get IM styles"));
+		LOG(CLOG_WARN "cannot get IM styles");
         m_impl->XCloseIM(im);
 		return;
 	}
@@ -1039,7 +1039,7 @@ XWindowsScreen::openIM()
 	}
 	XFree(styles);
 	if (style == 0) {
-		LOG((CLOG_INFO "no supported IM styles"));
+		LOG(CLOG_INFO "no supported IM styles");
         m_impl->XCloseIM(im);
 		return;
 	}
@@ -1047,7 +1047,7 @@ XWindowsScreen::openIM()
 	// create an input context for the style and tell it about our window
     XIC ic = m_impl->XCreateIC(im, XNInputStyle, style, XNClientWindow, m_window);
     if (ic == nullptr) {
-		LOG((CLOG_WARN "cannot create IC"));
+		LOG(CLOG_WARN "cannot create IC");
         m_impl->XCloseIM(im);
 		return;
 	}
@@ -1055,7 +1055,7 @@ XWindowsScreen::openIM()
 	// find out the events we must select for and do so
 	unsigned long mask;
     if (m_impl->XGetICValues(ic, XNFilterEvents, &mask) != nullptr) {
-		LOG((CLOG_WARN "cannot get IC filter events"));
+		LOG(CLOG_WARN "cannot get IC filter events");
         m_impl->XDestroyIC(ic);
         m_impl->XCloseIM(im);
 		return;
@@ -1336,7 +1336,7 @@ XWindowsScreen::handle_system_event(const Event& event)
 				return;
 
 			case XkbStateNotify:
-				LOG((CLOG_INFO "group change: %d", xkbEvent->state.group));
+				LOG(CLOG_INFO "group change: %d", xkbEvent->state.group);
                 m_keyState->setActiveGroup(static_cast<std::int32_t>(xkbEvent->state.group));
 				return;
             default:
@@ -1348,7 +1348,7 @@ XWindowsScreen::handle_system_event(const Event& event)
 			if (xevent->type == m_xrandrEventBase + RRScreenChangeNotify ||
 			    (xevent->type == m_xrandrEventBase + RRNotify &&
 			     reinterpret_cast<XRRNotifyEvent *>(xevent)->subtype == RRNotify_CrtcChange)) {
-				LOG((CLOG_INFO "XRRScreenChangeNotifyEvent or RRNotify_CrtcChange received"));
+				LOG(CLOG_INFO "XRRScreenChangeNotifyEvent or RRNotify_CrtcChange received");
 
 				// we're required to call back into XLib so XLib can update its internal state
 				XRRUpdateConfiguration(xevent);
@@ -1375,7 +1375,7 @@ XWindowsScreen::handle_system_event(const Event& event)
 void
 XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 {
-	LOG((CLOG_DEBUG1 "event: KeyPress code=%d, state=0x%04x", xkey.keycode, xkey.state));
+	LOG(CLOG_DEBUG1 "event: KeyPress code=%d, state=0x%04x", xkey.keycode, xkey.state);
 	const KeyModifierMask mask = m_keyState->mapModifiersFromX(xkey.state);
 	KeyID key                  = mapKeyFromX(&xkey);
 	if (key != kKeyNone) {
@@ -1384,7 +1384,7 @@ XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 			(mask & (KeyModifierControl | KeyModifierAlt)) ==
 					(KeyModifierControl | KeyModifierAlt)) {
 			// pretend it's ctrl+alt+del
-			LOG((CLOG_DEBUG "emulate ctrl+alt+del"));
+			LOG(CLOG_DEBUG "emulate ctrl+alt+del");
 			key = kKeyDelete;
 		}
 
@@ -1397,7 +1397,7 @@ XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 			keycode = static_cast<KeyButton>(m_lastKeycode);
 			if (keycode == 0) {
 				// no keycode
-				LOG((CLOG_DEBUG1 "event: KeyPress no keycode"));
+				LOG(CLOG_DEBUG1 "event: KeyPress no keycode");
 				return;
 			}
 		}
@@ -1413,7 +1413,7 @@ XWindowsScreen::onKeyPress(XKeyEvent& xkey)
 		}
 	}
     else {
-		LOG((CLOG_DEBUG1 "can't map keycode to key id"));
+		LOG(CLOG_DEBUG1 "can't map keycode to key id");
     }
 }
 
@@ -1428,7 +1428,7 @@ XWindowsScreen::onKeyRelease(XKeyEvent& xkey, bool isRepeat)
 			(mask & (KeyModifierControl | KeyModifierAlt)) ==
 					(KeyModifierControl | KeyModifierAlt)) {
 			// pretend it's ctrl+alt+del and ignore autorepeat
-			LOG((CLOG_DEBUG "emulate ctrl+alt+del"));
+			LOG(CLOG_DEBUG "emulate ctrl+alt+del");
 			key      = kKeyDelete;
 			isRepeat = false;
 		}
@@ -1436,7 +1436,7 @@ XWindowsScreen::onKeyRelease(XKeyEvent& xkey, bool isRepeat)
 		KeyButton keycode = static_cast<KeyButton>(xkey.keycode);
 		if (!isRepeat) {
 			// no press event follows so it's a plain release
-			LOG((CLOG_DEBUG1 "event: KeyRelease code=%d, state=0x%04x", keycode, xkey.state));
+			LOG(CLOG_DEBUG1 "event: KeyRelease code=%d, state=0x%04x", keycode, xkey.state);
             m_keyState->sendKeyEvent(get_event_target(),
 							false, false, key, mask, 1, keycode);
 		}
@@ -1445,7 +1445,7 @@ XWindowsScreen::onKeyRelease(XKeyEvent& xkey, bool isRepeat)
 			// we could attempt to count the already queued
 			// repeats but we'll just send a repeat of 1.
 			// note that we discard the press event.
-			LOG((CLOG_DEBUG1 "event: repeat code=%d, state=0x%04x", keycode, xkey.state));
+			LOG(CLOG_DEBUG1 "event: repeat code=%d, state=0x%04x", keycode, xkey.state);
             m_keyState->sendKeyEvent(get_event_target(),
 							false, true, key, mask, 1, keycode);
 		}
@@ -1485,7 +1485,7 @@ XWindowsScreen::onHotKey(XKeyEvent& xkey, bool isRepeat)
 void
 XWindowsScreen::onMousePress(const XButtonEvent& xbutton)
 {
-	LOG((CLOG_DEBUG1 "event: ButtonPress button=%d", xbutton.button));
+	LOG(CLOG_DEBUG1 "event: ButtonPress button=%d", xbutton.button);
 	ButtonID button      = mapButtonFromX(&xbutton);
 	KeyModifierMask mask = m_keyState->mapModifiersFromX(xbutton.state);
 	if (button != kButtonNone) {
@@ -1497,7 +1497,7 @@ XWindowsScreen::onMousePress(const XButtonEvent& xbutton)
 void
 XWindowsScreen::onMouseRelease(const XButtonEvent& xbutton)
 {
-	LOG((CLOG_DEBUG1 "event: ButtonRelease button=%d", xbutton.button));
+	LOG(CLOG_DEBUG1 "event: ButtonRelease button=%d", xbutton.button);
 	ButtonID button      = mapButtonFromX(&xbutton);
 	KeyModifierMask mask = m_keyState->mapModifiersFromX(xbutton.state);
 	if (button != kButtonNone) {
@@ -1529,7 +1529,7 @@ XWindowsScreen::onMouseRelease(const XButtonEvent& xbutton)
 void
 XWindowsScreen::onMouseMove(const XMotionEvent& xmotion)
 {
-	LOG((CLOG_DEBUG2 "event: MotionNotify %d,%d", xmotion.x_root, xmotion.y_root));
+	LOG(CLOG_DEBUG2 "event: MotionNotify %d,%d", xmotion.x_root, xmotion.y_root);
 
 	// compute motion delta (relative to the last known
 	// mouse position)
@@ -1551,7 +1551,7 @@ XWindowsScreen::onMouseMove(const XMotionEvent& xmotion)
 		do {
             m_impl->XMaskEvent(m_display, PointerMotionMask, &xevent);
 			if (cntr++ > 10) {
-				LOG((CLOG_WARN "too many discarded events! %d", cntr));
+				LOG(CLOG_WARN "too many discarded events! %d", cntr);
 				break;
 			}
 		} while (!xevent.xany.send_event);
@@ -1716,7 +1716,7 @@ XWindowsScreen::ioErrorHandler(Display*)
 	// down.  X forces us to exit at this point which is annoying.
 	// we'll pretend as if we won't exit so we try to make sure we
 	// don't access the display anymore.
-	LOG((CLOG_CRIT "X display has unexpectedly disconnected"));
+	LOG(CLOG_CRIT "X display has unexpectedly disconnected");
 	s_screen->onError();
 	return 0;
 }
@@ -1818,11 +1818,11 @@ XWindowsScreen::mapKeyFromX(XKeyEvent* event) const
         m_impl->XLookupString(event, dummy, 0, &keysym, nullptr);
 	}
 
-	LOG((CLOG_DEBUG2 "mapped code=%d to keysym=0x%04lx", event->keycode, keysym));
+	LOG(CLOG_DEBUG2 "mapped code=%d to keysym=0x%04lx", event->keycode, keysym);
 
 	// convert key
 	KeyID result = XWindowsUtil::mapKeySymToKeyID(keysym);
-	LOG((CLOG_DEBUG2 "mapped keysym=0x%04lx to keyID=%d", keysym, result));
+	LOG(CLOG_DEBUG2 "mapped keysym=0x%04lx to keyID=%d", keysym, result);
 	return result;
 }
 
@@ -1893,7 +1893,7 @@ void XWindowsScreen::warpCursorNoFlush(std::int32_t x, std::int32_t y)
     m_impl->XSendEvent(m_display, m_window, False, 0, &eventAfter);
     m_impl->XSync(m_display, False);
 
-	LOG((CLOG_DEBUG2 "warped to %d,%d", x, y));
+	LOG(CLOG_DEBUG2 "warped to %d,%d", x, y);
 }
 
 void
@@ -1945,15 +1945,15 @@ XWindowsScreen::grabMouseAndKeyboard()
 								GrabModeAsync, GrabModeAsync, CurrentTime);
 			assert(result != GrabNotViewable);
 			if (result != GrabSuccess) {
-				LOG((CLOG_DEBUG2 "waiting to grab keyboard"));
+				LOG(CLOG_DEBUG2 "waiting to grab keyboard");
                 inputleap::this_thread_sleep(0.05);
 				if (timer.getTime() >= s_timeout) {
-					LOG((CLOG_DEBUG2 "grab keyboard timed out"));
+					LOG(CLOG_DEBUG2 "grab keyboard timed out");
 					return false;
 				}
 			}
 		} while (result != GrabSuccess);
-		LOG((CLOG_DEBUG2 "grabbed keyboard"));
+		LOG(CLOG_DEBUG2 "grabbed keyboard");
 
 		// now the mouse --- use event_mask to get EnterNotify, LeaveNotify events
         result = m_impl->XGrabPointer(m_display, m_window, False, event_mask,
@@ -1963,16 +1963,16 @@ XWindowsScreen::grabMouseAndKeyboard()
 		if (result != GrabSuccess) {
 			// back off to avoid grab deadlock
             m_impl->XUngrabKeyboard(m_display, CurrentTime);
-			LOG((CLOG_DEBUG2 "ungrabbed keyboard, waiting to grab pointer"));
+			LOG(CLOG_DEBUG2 "ungrabbed keyboard, waiting to grab pointer");
             inputleap::this_thread_sleep(0.05);
 			if (timer.getTime() >= s_timeout) {
-				LOG((CLOG_DEBUG2 "grab pointer timed out"));
+				LOG(CLOG_DEBUG2 "grab pointer timed out");
 				return false;
 			}
 		}
 	} while (result != GrabSuccess);
 
-	LOG((CLOG_DEBUG1 "grabbed pointer and keyboard"));
+	LOG(CLOG_DEBUG1 "grabbed pointer and keyboard");
 	return true;
 }
 

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -79,7 +79,7 @@ XWindowsScreenSaver::XWindowsScreenSaver(IXWindowsImpl* impl, Display* display,
                              m_rootEventMask | SubstructureNotifyMask);
     }
     if (error) {
-        LOG(CLOG_DEBUG "didn't set root event mask");
+        LOG_DEBUG("didn't set root event mask");
         m_rootEventMask = 0;
     }
 
@@ -152,7 +152,7 @@ XWindowsScreenSaver::handleXEvent(const XEvent* xevent)
     case DestroyNotify:
         if (xevent->xdestroywindow.window == m_xscreensaver) {
             // xscreensaver is gone
-            LOG(CLOG_DEBUG "xscreensaver died");
+            LOG_DEBUG("xscreensaver died");
             setXScreenSaver(None);
             return true;
         }
@@ -319,7 +319,7 @@ XWindowsScreenSaver::findXScreenSaver()
 void
 XWindowsScreenSaver::setXScreenSaver(Window window)
 {
-    LOG(CLOG_DEBUG "xscreensaver window: 0x%08lx", window);
+    LOG_DEBUG("xscreensaver window: 0x%08lx", window);
 
     // save window
     m_xscreensaver = window;
@@ -362,7 +362,7 @@ void
 XWindowsScreenSaver::setXScreenSaverActive(bool activated)
 {
     if (m_xscreensaverActive != activated) {
-        LOG(CLOG_DEBUG "xscreensaver %s on window 0x%08lx", activated ? "activated" : "deactivated", m_xscreensaver);
+        LOG_DEBUG("xscreensaver %s on window 0x%08lx", activated ? "activated" : "deactivated", m_xscreensaver);
         m_xscreensaverActive = activated;
 
         // if screen saver was activated forcefully (i.e. against
@@ -395,7 +395,7 @@ XWindowsScreenSaver::sendXScreenSaverCommand(Atom cmd, long arg1, long arg2)
     event.xclient.data.l[3]    = 0;
     event.xclient.data.l[4]    = 0;
 
-    LOG(CLOG_DEBUG "send xscreensaver command: %ld %ld %ld", static_cast<long>(cmd), arg1, arg2);
+    LOG_DEBUG("send xscreensaver command: %ld %ld %ld", static_cast<long>(cmd), arg1, arg2);
     bool error = false;
     {
         XWindowsUtil::ErrorLock lock(m_display, &error);

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -79,7 +79,7 @@ XWindowsScreenSaver::XWindowsScreenSaver(IXWindowsImpl* impl, Display* display,
                              m_rootEventMask | SubstructureNotifyMask);
     }
     if (error) {
-        LOG((CLOG_DEBUG "didn't set root event mask"));
+        LOG(CLOG_DEBUG "didn't set root event mask");
         m_rootEventMask = 0;
     }
 
@@ -152,7 +152,7 @@ XWindowsScreenSaver::handleXEvent(const XEvent* xevent)
     case DestroyNotify:
         if (xevent->xdestroywindow.window == m_xscreensaver) {
             // xscreensaver is gone
-            LOG((CLOG_DEBUG "xscreensaver died"));
+            LOG(CLOG_DEBUG "xscreensaver died");
             setXScreenSaver(None);
             return true;
         }
@@ -319,7 +319,7 @@ XWindowsScreenSaver::findXScreenSaver()
 void
 XWindowsScreenSaver::setXScreenSaver(Window window)
 {
-    LOG((CLOG_DEBUG "xscreensaver window: 0x%08lx", window));
+    LOG(CLOG_DEBUG "xscreensaver window: 0x%08lx", window);
 
     // save window
     m_xscreensaver = window;
@@ -362,7 +362,7 @@ void
 XWindowsScreenSaver::setXScreenSaverActive(bool activated)
 {
     if (m_xscreensaverActive != activated) {
-        LOG((CLOG_DEBUG "xscreensaver %s on window 0x%08lx", activated ? "activated" : "deactivated", m_xscreensaver));
+        LOG(CLOG_DEBUG "xscreensaver %s on window 0x%08lx", activated ? "activated" : "deactivated", m_xscreensaver);
         m_xscreensaverActive = activated;
 
         // if screen saver was activated forcefully (i.e. against
@@ -395,7 +395,7 @@ XWindowsScreenSaver::sendXScreenSaverCommand(Atom cmd, long arg1, long arg2)
     event.xclient.data.l[3]    = 0;
     event.xclient.data.l[4]    = 0;
 
-    LOG((CLOG_DEBUG "send xscreensaver command: %ld %ld %ld", static_cast<long>(cmd), arg1, arg2));
+    LOG(CLOG_DEBUG "send xscreensaver command: %ld %ld %ld", static_cast<long>(cmd), arg1, arg2);
     bool error = false;
     {
         XWindowsUtil::ErrorLock lock(m_display, &error);

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1411,11 +1411,11 @@ bool XWindowsUtil::getWindowProperty(Display* display, Window window, Atom prope
     }
 
     if (okay) {
-        LOG((CLOG_DEBUG2 "read property %ld on window 0x%08lx: bytes=%zd", property, window, (data == nullptr) ? 0 : data->size()));
+        LOG(CLOG_DEBUG2 "read property %ld on window 0x%08lx: bytes=%zd", property, window, (data == nullptr) ? 0 : data->size());
         return true;
     }
     else {
-        LOG((CLOG_DEBUG2 "can't read property %ld on window 0x%08lx", property, window));
+        LOG(CLOG_DEBUG2 "can't read property %ld on window 0x%08lx", property, window);
         return false;
     }
 }
@@ -1815,7 +1815,7 @@ XWindowsUtil::ErrorLock::ignoreHandler(Display* display, XErrorEvent* e, void*)
 {
     char errtxt[1024];
     XGetErrorText(display, e->error_code, errtxt, 1023);
-    LOG((CLOG_DEBUG1 "ignoring X error: %d - %.1023s", e->error_code, errtxt));
+    LOG(CLOG_DEBUG1 "ignoring X error: %d - %.1023s", e->error_code, errtxt);
 }
 
 void
@@ -1823,7 +1823,7 @@ XWindowsUtil::ErrorLock::saveHandler(Display* display, XErrorEvent* e, void* fla
 {
     char errtxt[1024];
     XGetErrorText(display, e->error_code, errtxt, 1023);
-    LOG((CLOG_DEBUG1 "flagging X error: %d - %.1023s", e->error_code, errtxt));
+    LOG(CLOG_DEBUG1 "flagging X error: %d - %.1023s", e->error_code, errtxt);
     *static_cast<bool*>(flag) = true;
 }
 

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1411,11 +1411,11 @@ bool XWindowsUtil::getWindowProperty(Display* display, Window window, Atom prope
     }
 
     if (okay) {
-        LOG(CLOG_DEBUG2 "read property %ld on window 0x%08lx: bytes=%zd", property, window, (data == nullptr) ? 0 : data->size());
+        LOG_DEBUG2("read property %ld on window 0x%08lx: bytes=%zd", property, window, (data == nullptr) ? 0 : data->size());
         return true;
     }
     else {
-        LOG(CLOG_DEBUG2 "can't read property %ld on window 0x%08lx", property, window);
+        LOG_DEBUG2("can't read property %ld on window 0x%08lx", property, window);
         return false;
     }
 }
@@ -1815,7 +1815,7 @@ XWindowsUtil::ErrorLock::ignoreHandler(Display* display, XErrorEvent* e, void*)
 {
     char errtxt[1024];
     XGetErrorText(display, e->error_code, errtxt, 1023);
-    LOG(CLOG_DEBUG1 "ignoring X error: %d - %.1023s", e->error_code, errtxt);
+    LOG_DEBUG1("ignoring X error: %d - %.1023s", e->error_code, errtxt);
 }
 
 void
@@ -1823,7 +1823,7 @@ XWindowsUtil::ErrorLock::saveHandler(Display* display, XErrorEvent* e, void* fla
 {
     char errtxt[1024];
     XGetErrorText(display, e->error_code, errtxt, 1023);
-    LOG(CLOG_DEBUG1 "flagging X error: %d - %.1023s", e->error_code, errtxt);
+    LOG_DEBUG1("flagging X error: %d - %.1023s", e->error_code, errtxt);
     *static_cast<bool*>(flag) = true;
 }
 

--- a/src/lib/server/ClientConnectionLoggingWrapper.cpp
+++ b/src/lib/server/ClientConnectionLoggingWrapper.cpp
@@ -44,107 +44,107 @@ IStream* ClientConnectionLoggingWrapper::get_stream()
 
 void ClientConnectionLoggingWrapper::send_query_info_1_6()
 {
-    LOG((CLOG_DEBUG1 "querying client \"%s\" info", name_.c_str()));
+    LOG(CLOG_DEBUG1 "querying client \"%s\" info", name_.c_str());
     conn_->send_query_info_1_6();
 }
 
 void ClientConnectionLoggingWrapper::send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs,
                                                     std::uint32_t seq_num, KeyModifierMask mask)
 {
-    LOG((CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
-         seq_num, mask));
+    LOG(CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
+         seq_num, mask);
     conn_->send_enter_1_6(x_abs, y_abs, seq_num, mask);
 }
 
 void ClientConnectionLoggingWrapper::send_leave_1_6()
 {
-    LOG((CLOG_DEBUG1 "send leave to \"%s\"", name_.c_str()));
+    LOG(CLOG_DEBUG1 "send leave to \"%s\"", name_.c_str());
     conn_->send_leave_1_6();
 }
 
 void ClientConnectionLoggingWrapper::send_key_down_1_6(KeyID key, KeyModifierMask mask,
                                                        KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
-         name_.c_str(), key, mask, button));
+    LOG(CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+         name_.c_str(), key, mask, button);
     conn_->send_key_down_1_6(key, mask, button);
 }
 
 void ClientConnectionLoggingWrapper::send_key_up_1_6(KeyID key, KeyModifierMask mask,
                                                      KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
-         name_.c_str(), key, mask, button));
+    LOG(CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+         name_.c_str(), key, mask, button);
     conn_->send_key_up_1_6(key, mask, button);
 }
 
 void ClientConnectionLoggingWrapper::send_key_repeat_1_6(KeyID key, KeyModifierMask mask,
                                                          std::int32_t count, KeyButton button)
 {
-    LOG((CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
-         name_.c_str(), key, mask, count, button));
+    LOG(CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
+         name_.c_str(), key, mask, count, button);
     conn_->send_key_repeat_1_6(key, mask, count, button);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_down_1_6(ButtonID button)
 {
-    LOG((CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", name_.c_str(), button));
+    LOG(CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", name_.c_str(), button);
     conn_->send_mouse_down_1_6(button);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_up_1_6(ButtonID button)
 {
-    LOG((CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", name_.c_str(), button));
+    LOG(CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", name_.c_str(), button);
     conn_->send_mouse_up_1_6(button);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs)
 {
-    LOG((CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs));
+    LOG(CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs);
     conn_->send_mouse_move_1_6(x_abs, y_abs);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_relative_move_1_6(std::int32_t x_rel,
                                                                   std::int32_t y_rel)
 {
-    LOG((CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel));
+    LOG(CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel);
     conn_->send_mouse_relative_move_1_6(x_rel, y_rel);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta)
 {
-    LOG((CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta));
+    LOG(CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta);
     conn_->send_mouse_wheel_1_6(x_delta, y_delta);
 }
 
 void ClientConnectionLoggingWrapper::send_drag_info_1_6(std::uint32_t file_count,
                                                         const std::string& data)
 {
-    LOG((CLOG_DEBUG2 "send drag info to \"%s\" %d, %zd", name_.c_str(), file_count, data.size()));
+    LOG(CLOG_DEBUG2 "send drag info to \"%s\" %d, %zd", name_.c_str(), file_count, data.size());
     conn_->send_drag_info_1_6(file_count, data);
 }
 
 void ClientConnectionLoggingWrapper::send_screensaver_1_6(bool on)
 {
-    LOG((CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0));
+    LOG(CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0);
     conn_->send_screensaver_1_6(on);
 }
 
 void ClientConnectionLoggingWrapper::send_reset_options_1_6()
 {
-    LOG((CLOG_DEBUG1 "send reset options to \"%s\"", name_.c_str()));
+    LOG(CLOG_DEBUG1 "send reset options to \"%s\"", name_.c_str());
     conn_->send_reset_options_1_6();
 }
 
 void ClientConnectionLoggingWrapper::send_set_options_1_6(const OptionsList& options)
 {
-    LOG((CLOG_DEBUG1 "send set options to \"%s\" size=%zd", name_.c_str(), options.size()));
+    LOG(CLOG_DEBUG1 "send set options to \"%s\" size=%zd", name_.c_str(), options.size());
     conn_->send_set_options_1_6(options);
 }
 
 void ClientConnectionLoggingWrapper::send_info_ack_1_6()
 {
-    LOG((CLOG_DEBUG1 "send info ack to \"%s\"", name_.c_str()));
+    LOG(CLOG_DEBUG1 "send info ack to \"%s\"", name_.c_str());
     conn_->send_info_ack_1_6();
 }
 
@@ -155,24 +155,24 @@ void ClientConnectionLoggingWrapper::send_keep_alive_1_6()
 
 void ClientConnectionLoggingWrapper::send_close_1_6(const char* msg)
 {
-    LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str()));
+    LOG(CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str());
     conn_->send_close_1_6(msg);
 }
 
 void ClientConnectionLoggingWrapper::send_clipboard_chunk_1_6(const ClipboardChunk& chunk)
 {
-    LOG((CLOG_DEBUG1 "sending clipboard chunk"));
+    LOG(CLOG_DEBUG1 "sending clipboard chunk");
     switch (chunk.mark_) {
     case kDataStart:
-        LOG((CLOG_DEBUG2 "sending clipboard chunk start: size=%s", chunk.data_.c_str()));
+        LOG(CLOG_DEBUG2 "sending clipboard chunk start: size=%s", chunk.data_.c_str());
         break;
 
     case kDataChunk:
-        LOG((CLOG_DEBUG2 "sending clipboard chunk data: size=%zi", chunk.data_.size()));
+        LOG(CLOG_DEBUG2 "sending clipboard chunk data: size=%zi", chunk.data_.size());
         break;
 
     case kDataEnd:
-        LOG((CLOG_DEBUG2 "sending clipboard finished"));
+        LOG(CLOG_DEBUG2 "sending clipboard finished");
         break;
     default:
         break;
@@ -184,15 +184,15 @@ void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)
 {
     switch (chunk.mark_) {
     case kDataStart:
-        LOG((CLOG_DEBUG2 "sending file chunk start: size=%s", chunk.data_.c_str()));
+        LOG(CLOG_DEBUG2 "sending file chunk start: size=%s", chunk.data_.c_str());
         break;
 
     case kDataChunk:
-        LOG((CLOG_DEBUG2 "sending file chunk: size=%zi", chunk.data_.size()));
+        LOG(CLOG_DEBUG2 "sending file chunk: size=%zi", chunk.data_.size());
         break;
 
     case kDataEnd:
-        LOG((CLOG_DEBUG2 "sending file finished"));
+        LOG(CLOG_DEBUG2 "sending file finished");
         break;
     default:
         break;
@@ -202,7 +202,7 @@ void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)
 
 void ClientConnectionLoggingWrapper::send_grab_clipboard(ClipboardID id)
 {
-    LOG((CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, name_.c_str()));
+    LOG(CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, name_.c_str());
     conn_->send_grab_clipboard(id);
 }
 

--- a/src/lib/server/ClientConnectionLoggingWrapper.cpp
+++ b/src/lib/server/ClientConnectionLoggingWrapper.cpp
@@ -44,28 +44,28 @@ IStream* ClientConnectionLoggingWrapper::get_stream()
 
 void ClientConnectionLoggingWrapper::send_query_info_1_6()
 {
-    LOG(CLOG_DEBUG1 "querying client \"%s\" info", name_.c_str());
+    LOG_DEBUG1("querying client \"%s\" info", name_.c_str());
     conn_->send_query_info_1_6();
 }
 
 void ClientConnectionLoggingWrapper::send_enter_1_6(std::int32_t x_abs, std::int32_t y_abs,
                                                     std::uint32_t seq_num, KeyModifierMask mask)
 {
-    LOG(CLOG_DEBUG1 "send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
+    LOG_DEBUG1("send enter to \"%s\", %d,%d %d %04x", name_.c_str(), x_abs, y_abs,
          seq_num, mask);
     conn_->send_enter_1_6(x_abs, y_abs, seq_num, mask);
 }
 
 void ClientConnectionLoggingWrapper::send_leave_1_6()
 {
-    LOG(CLOG_DEBUG1 "send leave to \"%s\"", name_.c_str());
+    LOG_DEBUG1("send leave to \"%s\"", name_.c_str());
     conn_->send_leave_1_6();
 }
 
 void ClientConnectionLoggingWrapper::send_key_down_1_6(KeyID key, KeyModifierMask mask,
                                                        KeyButton button)
 {
-    LOG(CLOG_DEBUG1 "send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+    LOG_DEBUG1("send key down to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
          name_.c_str(), key, mask, button);
     conn_->send_key_down_1_6(key, mask, button);
 }
@@ -73,7 +73,7 @@ void ClientConnectionLoggingWrapper::send_key_down_1_6(KeyID key, KeyModifierMas
 void ClientConnectionLoggingWrapper::send_key_up_1_6(KeyID key, KeyModifierMask mask,
                                                      KeyButton button)
 {
-    LOG(CLOG_DEBUG1 "send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
+    LOG_DEBUG1("send key up to \"%s\" id=%d, mask=0x%04x, button=0x%04x",
          name_.c_str(), key, mask, button);
     conn_->send_key_up_1_6(key, mask, button);
 }
@@ -81,70 +81,70 @@ void ClientConnectionLoggingWrapper::send_key_up_1_6(KeyID key, KeyModifierMask 
 void ClientConnectionLoggingWrapper::send_key_repeat_1_6(KeyID key, KeyModifierMask mask,
                                                          std::int32_t count, KeyButton button)
 {
-    LOG(CLOG_DEBUG1 "send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
+    LOG_DEBUG1("send key repeat to \"%s\" id=%d, mask=0x%04x, count=%d, button=0x%04x",
          name_.c_str(), key, mask, count, button);
     conn_->send_key_repeat_1_6(key, mask, count, button);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_down_1_6(ButtonID button)
 {
-    LOG(CLOG_DEBUG1 "send mouse down to \"%s\" id=%d", name_.c_str(), button);
+    LOG_DEBUG1("send mouse down to \"%s\" id=%d", name_.c_str(), button);
     conn_->send_mouse_down_1_6(button);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_up_1_6(ButtonID button)
 {
-    LOG(CLOG_DEBUG1 "send mouse up to \"%s\" id=%d", name_.c_str(), button);
+    LOG_DEBUG1("send mouse up to \"%s\" id=%d", name_.c_str(), button);
     conn_->send_mouse_up_1_6(button);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_move_1_6(std::int32_t x_abs, std::int32_t y_abs)
 {
-    LOG(CLOG_DEBUG2 "send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs);
+    LOG_DEBUG2("send mouse move to \"%s\" %d,%d", name_.c_str(), x_abs, y_abs);
     conn_->send_mouse_move_1_6(x_abs, y_abs);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_relative_move_1_6(std::int32_t x_rel,
                                                                   std::int32_t y_rel)
 {
-    LOG(CLOG_DEBUG2 "send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel);
+    LOG_DEBUG2("send mouse relative move to \"%s\" %d,%d", name_.c_str(), x_rel, y_rel);
     conn_->send_mouse_relative_move_1_6(x_rel, y_rel);
 }
 
 void ClientConnectionLoggingWrapper::send_mouse_wheel_1_6(std::int32_t x_delta, std::int32_t y_delta)
 {
-    LOG(CLOG_DEBUG2 "send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta);
+    LOG_DEBUG2("send mouse wheel to \"%s\" %+d,%+d", name_.c_str(), x_delta, y_delta);
     conn_->send_mouse_wheel_1_6(x_delta, y_delta);
 }
 
 void ClientConnectionLoggingWrapper::send_drag_info_1_6(std::uint32_t file_count,
                                                         const std::string& data)
 {
-    LOG(CLOG_DEBUG2 "send drag info to \"%s\" %d, %zd", name_.c_str(), file_count, data.size());
+    LOG_DEBUG2("send drag info to \"%s\" %d, %zd", name_.c_str(), file_count, data.size());
     conn_->send_drag_info_1_6(file_count, data);
 }
 
 void ClientConnectionLoggingWrapper::send_screensaver_1_6(bool on)
 {
-    LOG(CLOG_DEBUG1 "send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0);
+    LOG_DEBUG1("send screen saver to \"%s\" on=%d", name_.c_str(), on ? 1 : 0);
     conn_->send_screensaver_1_6(on);
 }
 
 void ClientConnectionLoggingWrapper::send_reset_options_1_6()
 {
-    LOG(CLOG_DEBUG1 "send reset options to \"%s\"", name_.c_str());
+    LOG_DEBUG1("send reset options to \"%s\"", name_.c_str());
     conn_->send_reset_options_1_6();
 }
 
 void ClientConnectionLoggingWrapper::send_set_options_1_6(const OptionsList& options)
 {
-    LOG(CLOG_DEBUG1 "send set options to \"%s\" size=%zd", name_.c_str(), options.size());
+    LOG_DEBUG1("send set options to \"%s\" size=%zd", name_.c_str(), options.size());
     conn_->send_set_options_1_6(options);
 }
 
 void ClientConnectionLoggingWrapper::send_info_ack_1_6()
 {
-    LOG(CLOG_DEBUG1 "send info ack to \"%s\"", name_.c_str());
+    LOG_DEBUG1("send info ack to \"%s\"", name_.c_str());
     conn_->send_info_ack_1_6();
 }
 
@@ -155,24 +155,24 @@ void ClientConnectionLoggingWrapper::send_keep_alive_1_6()
 
 void ClientConnectionLoggingWrapper::send_close_1_6(const char* msg)
 {
-    LOG(CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, name_.c_str());
+    LOG_DEBUG1("send close \"%s\" to \"%s\"", msg, name_.c_str());
     conn_->send_close_1_6(msg);
 }
 
 void ClientConnectionLoggingWrapper::send_clipboard_chunk_1_6(const ClipboardChunk& chunk)
 {
-    LOG(CLOG_DEBUG1 "sending clipboard chunk");
+    LOG_DEBUG1("sending clipboard chunk");
     switch (chunk.mark_) {
     case kDataStart:
-        LOG(CLOG_DEBUG2 "sending clipboard chunk start: size=%s", chunk.data_.c_str());
+        LOG_DEBUG2("sending clipboard chunk start: size=%s", chunk.data_.c_str());
         break;
 
     case kDataChunk:
-        LOG(CLOG_DEBUG2 "sending clipboard chunk data: size=%zi", chunk.data_.size());
+        LOG_DEBUG2("sending clipboard chunk data: size=%zi", chunk.data_.size());
         break;
 
     case kDataEnd:
-        LOG(CLOG_DEBUG2 "sending clipboard finished");
+        LOG_DEBUG2("sending clipboard finished");
         break;
     default:
         break;
@@ -184,15 +184,15 @@ void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)
 {
     switch (chunk.mark_) {
     case kDataStart:
-        LOG(CLOG_DEBUG2 "sending file chunk start: size=%s", chunk.data_.c_str());
+        LOG_DEBUG2("sending file chunk start: size=%s", chunk.data_.c_str());
         break;
 
     case kDataChunk:
-        LOG(CLOG_DEBUG2 "sending file chunk: size=%zi", chunk.data_.size());
+        LOG_DEBUG2("sending file chunk: size=%zi", chunk.data_.size());
         break;
 
     case kDataEnd:
-        LOG(CLOG_DEBUG2 "sending file finished");
+        LOG_DEBUG2("sending file finished");
         break;
     default:
         break;
@@ -202,7 +202,7 @@ void ClientConnectionLoggingWrapper::send_file_chunk_1_6(const FileChunk& chunk)
 
 void ClientConnectionLoggingWrapper::send_grab_clipboard(ClipboardID id)
 {
-    LOG(CLOG_DEBUG "send grab clipboard %d to \"%s\"", id, name_.c_str());
+    LOG_DEBUG("send grab clipboard %d to \"%s\"", id, name_.c_str());
     conn_->send_grab_clipboard(id);
 }
 

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -48,7 +48,7 @@ ClientListener::ClientListener(const NetworkAddress& address,
                               [this](const auto& e){ handle_client_connecting(); });
 
         // bind listen address
-        LOG((CLOG_DEBUG1 "binding listen socket"));
+        LOG(CLOG_DEBUG1 "binding listen socket");
         listen_->bind(address);
     }
     catch (XSocketAddressInUse&) {
@@ -61,12 +61,12 @@ ClientListener::ClientListener(const NetworkAddress& address,
         socket_factory_.reset();
         throw;
     }
-    LOG((CLOG_DEBUG1 "listening for clients"));
+    LOG(CLOG_DEBUG1 "listening for clients");
 }
 
 ClientListener::~ClientListener()
 {
-    LOG((CLOG_DEBUG1 "stop listening for clients"));
+    LOG(CLOG_DEBUG1 "stop listening for clients");
 
     // discard already connected clients
     for (NewClients::iterator index = m_newClients.begin();
@@ -135,7 +135,7 @@ void ClientListener::handle_client_connecting()
 
 void ClientListener::handle_client_accepted(IDataSocket* socket_ptr)
 {
-    LOG((CLOG_NOTE "accepted client connection"));
+    LOG(CLOG_NOTE "accepted client connection");
     auto socket = client_sockets_.erase(socket_ptr);
     if (!socket) {
         throw std::runtime_error("Got more than one CLIENT_LISTENER_ACCEPTED event");

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -48,7 +48,7 @@ ClientListener::ClientListener(const NetworkAddress& address,
                               [this](const auto& e){ handle_client_connecting(); });
 
         // bind listen address
-        LOG(CLOG_DEBUG1 "binding listen socket");
+        LOG_DEBUG1("binding listen socket");
         listen_->bind(address);
     }
     catch (XSocketAddressInUse&) {
@@ -61,12 +61,12 @@ ClientListener::ClientListener(const NetworkAddress& address,
         socket_factory_.reset();
         throw;
     }
-    LOG(CLOG_DEBUG1 "listening for clients");
+    LOG_DEBUG1("listening for clients");
 }
 
 ClientListener::~ClientListener()
 {
-    LOG(CLOG_DEBUG1 "stop listening for clients");
+    LOG_DEBUG1("stop listening for clients");
 
     // discard already connected clients
     for (NewClients::iterator index = m_newClients.begin();
@@ -135,7 +135,7 @@ void ClientListener::handle_client_connecting()
 
 void ClientListener::handle_client_accepted(IDataSocket* socket_ptr)
 {
-    LOG(CLOG_NOTE "accepted client connection");
+    LOG_NOTE("accepted client connection");
     auto socket = client_sockets_.erase(socket_ptr);
     if (!socket) {
         throw std::runtime_error("Got more than one CLIENT_LISTENER_ACCEPTED event");

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -162,16 +162,16 @@ void ClientProxy1_6::handle_data()
     while (n != 0) {
         // verify we got an entire code
         if (n != 4) {
-            LOG((CLOG_ERR "incomplete message from \"%s\": %d bytes", getName().c_str(), n));
+            LOG(CLOG_ERR "incomplete message from \"%s\": %d bytes", getName().c_str(), n);
             disconnect();
             return;
         }
 
         // parse message
         try {
-            LOG((CLOG_DEBUG2 "msg from \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]));
+            LOG(CLOG_DEBUG2 "msg from \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
             if (!(this->*m_parser)(code)) {
-                LOG((CLOG_ERR "invalid message from client \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]));
+                LOG(CLOG_ERR "invalid message from client \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
                 disconnect();
                 return;
             }
@@ -179,7 +179,7 @@ void ClientProxy1_6::handle_data()
             // TODO: disconnect handling is currently dispersed across both parseMessage() and
             // handleData() functions, we should collect that to a single place
 
-            LOG((CLOG_ERR "protocol error from client: %s", e.what()));
+            LOG(CLOG_ERR "protocol error from client: %s", e.what());
             disconnect();
             return;
         }
@@ -196,7 +196,7 @@ bool ClientProxy1_6::parseHandshakeMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
-        LOG((CLOG_DEBUG2 "no-op from %s", getName().c_str()));
+        LOG(CLOG_DEBUG2 "no-op from %s", getName().c_str());
         return true;
     }
     else if (memcmp(code, kMsgDInfo, 4) == 0) {
@@ -234,7 +234,7 @@ bool ClientProxy1_6::parseMessage(const std::uint8_t* code)
     }
     else if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
-        LOG((CLOG_DEBUG2 "no-op from %s", getName().c_str()));
+        LOG(CLOG_DEBUG2 "no-op from %s", getName().c_str());
         return true;
     }
     else if (memcmp(code, kMsgCClipboard, 4) == 0) {
@@ -248,20 +248,20 @@ bool ClientProxy1_6::parseMessage(const std::uint8_t* code)
 
 void ClientProxy1_6::handle_disconnect()
 {
-    LOG((CLOG_NOTE "client \"%s\" has disconnected", getName().c_str()));
+    LOG(CLOG_NOTE "client \"%s\" has disconnected", getName().c_str());
     disconnect();
 }
 
 void ClientProxy1_6::handle_write_error()
 {
-    LOG((CLOG_WARN "error writing to client \"%s\"", getName().c_str()));
+    LOG(CLOG_WARN "error writing to client \"%s\"", getName().c_str());
     disconnect();
 }
 
 void ClientProxy1_6::handle_flatline()
 {
     // didn't get a heartbeat fast enough.  assume client is dead.
-    LOG((CLOG_NOTE "client \"%s\" is dead", getName().c_str()));
+    LOG(CLOG_NOTE "client \"%s\" is dead", getName().c_str());
     disconnect();
 }
 
@@ -316,7 +316,7 @@ void ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
         std::string data = m_clipboard[id].m_clipboard.marshall();
 
         size_t size = data.size();
-        LOG((CLOG_DEBUG "sending clipboard %d to \"%s\"", id, getName().c_str()));
+        LOG(CLOG_DEBUG "sending clipboard %d to \"%s\"", id, getName().c_str());
 
         StreamChunker::sendClipboard(data, size, id, 0, m_events, this);
     }
@@ -427,7 +427,7 @@ bool ClientProxy1_6::recvInfo()
                             &x, &y, &w, &h, &dummy1, &mx, &my)) {
         return false;
     }
-    LOG((CLOG_DEBUG "received client \"%s\" info shape=%d,%d %dx%d at %d,%d", getName().c_str(), x, y, w, h, mx, my));
+    LOG(CLOG_DEBUG "received client \"%s\" info shape=%d,%d %dx%d at %d,%d", getName().c_str(), x, y, w, h, mx, my);
 
     // validate
     if (w <= 0 || h <= 0) {
@@ -462,10 +462,10 @@ bool ClientProxy1_6::recvClipboard()
 
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
-        LOG((CLOG_DEBUG "receiving clipboard %d size=%zd", id, size));
+        LOG(CLOG_DEBUG "receiving clipboard %d size=%zd", id, size);
     } else if (r == kFinish) {
-        LOG((CLOG_DEBUG "received client \"%s\" clipboard %d seqnum=%d, size=%zd",
-                getName().c_str(), id, seq, dataCached.size()));
+        LOG(CLOG_DEBUG "received client \"%s\" clipboard %d seqnum=%d, size=%zd",
+                getName().c_str(), id, seq, dataCached.size());
         // save clipboard
         m_clipboard[id].m_clipboard.unmarshall(dataCached, 0);
         m_clipboard[id].m_sequenceNumber = seq;
@@ -489,7 +489,7 @@ bool ClientProxy1_6::recvGrabClipboard()
     if (!ProtocolUtil::readf(getStream(), kMsgCClipboard + 4, &id, &seqNum)) {
         return false;
     }
-    LOG((CLOG_DEBUG "received client \"%s\" grabbed clipboard %d seqnum=%d", getName().c_str(), id, seqNum));
+    LOG(CLOG_DEBUG "received client \"%s\" grabbed clipboard %d seqnum=%d", getName().c_str(), id, seqNum);
 
     // validate
     if (id >= kClipboardEnd) {
@@ -522,7 +522,7 @@ void ClientProxy1_6::fileChunkReceived()
     } else if (result == kStart) {
         if (server->getFakeDragFileList().size() > 0) {
             std::string filename = server->getFakeDragFileList().at(0).getFilename();
-            LOG((CLOG_DEBUG "start receiving %s", filename.c_str()));
+            LOG(CLOG_DEBUG "start receiving %s", filename.c_str());
         }
     }
 }

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -162,16 +162,16 @@ void ClientProxy1_6::handle_data()
     while (n != 0) {
         // verify we got an entire code
         if (n != 4) {
-            LOG(CLOG_ERR "incomplete message from \"%s\": %d bytes", getName().c_str(), n);
+            LOG_ERR("incomplete message from \"%s\": %d bytes", getName().c_str(), n);
             disconnect();
             return;
         }
 
         // parse message
         try {
-            LOG(CLOG_DEBUG2 "msg from \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
+            LOG_DEBUG2("msg from \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
             if (!(this->*m_parser)(code)) {
-                LOG(CLOG_ERR "invalid message from client \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
+                LOG_ERR("invalid message from client \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
                 disconnect();
                 return;
             }
@@ -179,7 +179,7 @@ void ClientProxy1_6::handle_data()
             // TODO: disconnect handling is currently dispersed across both parseMessage() and
             // handleData() functions, we should collect that to a single place
 
-            LOG(CLOG_ERR "protocol error from client: %s", e.what());
+            LOG_ERR("protocol error from client: %s", e.what());
             disconnect();
             return;
         }
@@ -196,7 +196,7 @@ bool ClientProxy1_6::parseHandshakeMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
-        LOG(CLOG_DEBUG2 "no-op from %s", getName().c_str());
+        LOG_DEBUG2("no-op from %s", getName().c_str());
         return true;
     }
     else if (memcmp(code, kMsgDInfo, 4) == 0) {
@@ -234,7 +234,7 @@ bool ClientProxy1_6::parseMessage(const std::uint8_t* code)
     }
     else if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
-        LOG(CLOG_DEBUG2 "no-op from %s", getName().c_str());
+        LOG_DEBUG2("no-op from %s", getName().c_str());
         return true;
     }
     else if (memcmp(code, kMsgCClipboard, 4) == 0) {
@@ -248,20 +248,20 @@ bool ClientProxy1_6::parseMessage(const std::uint8_t* code)
 
 void ClientProxy1_6::handle_disconnect()
 {
-    LOG(CLOG_NOTE "client \"%s\" has disconnected", getName().c_str());
+    LOG_NOTE("client \"%s\" has disconnected", getName().c_str());
     disconnect();
 }
 
 void ClientProxy1_6::handle_write_error()
 {
-    LOG(CLOG_WARN "error writing to client \"%s\"", getName().c_str());
+    LOG_WARN("error writing to client \"%s\"", getName().c_str());
     disconnect();
 }
 
 void ClientProxy1_6::handle_flatline()
 {
     // didn't get a heartbeat fast enough.  assume client is dead.
-    LOG(CLOG_NOTE "client \"%s\" is dead", getName().c_str());
+    LOG_NOTE("client \"%s\" is dead", getName().c_str());
     disconnect();
 }
 
@@ -316,7 +316,7 @@ void ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
         std::string data = m_clipboard[id].m_clipboard.marshall();
 
         size_t size = data.size();
-        LOG(CLOG_DEBUG "sending clipboard %d to \"%s\"", id, getName().c_str());
+        LOG_DEBUG("sending clipboard %d to \"%s\"", id, getName().c_str());
 
         StreamChunker::sendClipboard(data, size, id, 0, m_events, this);
     }
@@ -427,7 +427,7 @@ bool ClientProxy1_6::recvInfo()
                             &x, &y, &w, &h, &dummy1, &mx, &my)) {
         return false;
     }
-    LOG(CLOG_DEBUG "received client \"%s\" info shape=%d,%d %dx%d at %d,%d", getName().c_str(), x, y, w, h, mx, my);
+    LOG_DEBUG("received client \"%s\" info shape=%d,%d %dx%d at %d,%d", getName().c_str(), x, y, w, h, mx, my);
 
     // validate
     if (w <= 0 || h <= 0) {
@@ -462,9 +462,9 @@ bool ClientProxy1_6::recvClipboard()
 
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
-        LOG(CLOG_DEBUG "receiving clipboard %d size=%zd", id, size);
+        LOG_DEBUG("receiving clipboard %d size=%zd", id, size);
     } else if (r == kFinish) {
-        LOG(CLOG_DEBUG "received client \"%s\" clipboard %d seqnum=%d, size=%zd",
+        LOG_DEBUG("received client \"%s\" clipboard %d seqnum=%d, size=%zd",
                 getName().c_str(), id, seq, dataCached.size());
         // save clipboard
         m_clipboard[id].m_clipboard.unmarshall(dataCached, 0);
@@ -489,7 +489,7 @@ bool ClientProxy1_6::recvGrabClipboard()
     if (!ProtocolUtil::readf(getStream(), kMsgCClipboard + 4, &id, &seqNum)) {
         return false;
     }
-    LOG(CLOG_DEBUG "received client \"%s\" grabbed clipboard %d seqnum=%d", getName().c_str(), id, seqNum);
+    LOG_DEBUG("received client \"%s\" grabbed clipboard %d seqnum=%d", getName().c_str(), id, seqNum);
 
     // validate
     if (id >= kClipboardEnd) {
@@ -522,7 +522,7 @@ void ClientProxy1_6::fileChunkReceived()
     } else if (result == kStart) {
         if (server->getFakeDragFileList().size() > 0) {
             std::string filename = server->getFakeDragFileList().at(0).getFilename();
-            LOG(CLOG_DEBUG "start receiving %s", filename.c_str());
+            LOG_DEBUG("start receiving %s", filename.c_str());
         }
     }
 }

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -46,7 +46,7 @@ ClientProxyUnknown::ClientProxyUnknown(std::unique_ptr<inputleap::IStream> strea
     m_timer = m_events->newOneShotTimer(timeout, this);
     addStreamHandlers();
 
-    LOG(CLOG_DEBUG1 "saying hello");
+    LOG_DEBUG1("saying hello");
     ProtocolUtil::writef(stream_.get(), kMsgHello, kProtocolMajorVersion, kProtocolMinorVersion);
 }
 
@@ -144,14 +144,14 @@ ClientProxyUnknown::removeTimer()
 
 void ClientProxyUnknown::handle_data()
 {
-    LOG(CLOG_DEBUG1 "parsing hello reply");
+    LOG_DEBUG1("parsing hello reply");
 
     std::string name("<unknown>");
     try {
         // limit the maximum length of the hello
         std::uint32_t n = stream_->getSize();
         if (n > kMaxHelloLength) {
-            LOG(CLOG_DEBUG1 "hello reply too long");
+            LOG_DEBUG1("hello reply too long");
             throw XBadClient();
         }
 
@@ -196,7 +196,7 @@ void ClientProxyUnknown::handle_data()
             throw XIncompatibleClient(major, minor);
         }
 
-        LOG(CLOG_DEBUG1 "created proxy for client \"%s\" version %d.%d", name.c_str(), major, minor);
+        LOG_DEBUG1("created proxy for client \"%s\" version %d.%d", name.c_str(), major, minor);
 
         // wait until the proxy signals that it's ready or has disconnected
         addProxyHandlers();
@@ -204,37 +204,37 @@ void ClientProxyUnknown::handle_data()
     }
     catch (XIncompatibleClient& e) {
         // client is incompatible
-        LOG(CLOG_WARN "client \"%s\" has incompatible version %d.%d)", name.c_str(), e.getMajor(), e.getMinor());
+        LOG_WARN("client \"%s\" has incompatible version %d.%d)", name.c_str(), e.getMajor(), e.getMinor());
         ProtocolUtil::writef(stream_.get(), kMsgEIncompatible,
                              kProtocolMajorVersion, kProtocolMinorVersion);
     }
     catch (XBadClient&) {
         // client not behaving
-        LOG(CLOG_WARN "protocol error from client \"%s\"", name.c_str());
+        LOG_WARN("protocol error from client \"%s\"", name.c_str());
         ProtocolUtil::writef(stream_.get(), kMsgEBad);
     }
     catch (XBase& e) {
         // misc error
-        LOG(CLOG_WARN "error communicating with client \"%s\": %s", name.c_str(), e.what());
+        LOG_WARN("error communicating with client \"%s\": %s", name.c_str(), e.what());
     }
     sendFailure();
 }
 
 void ClientProxyUnknown::handle_write_error()
 {
-    LOG(CLOG_NOTE "error communicating with new client");
+    LOG_NOTE("error communicating with new client");
     sendFailure();
 }
 
 void ClientProxyUnknown::handle_timeout()
 {
-    LOG(CLOG_NOTE "new client is unresponsive");
+    LOG_NOTE("new client is unresponsive");
     sendFailure();
 }
 
 void ClientProxyUnknown::handle_disconnect()
 {
-    LOG(CLOG_NOTE "new client disconnected");
+    LOG_NOTE("new client disconnected");
     sendFailure();
 }
 

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -46,7 +46,7 @@ ClientProxyUnknown::ClientProxyUnknown(std::unique_ptr<inputleap::IStream> strea
     m_timer = m_events->newOneShotTimer(timeout, this);
     addStreamHandlers();
 
-    LOG((CLOG_DEBUG1 "saying hello"));
+    LOG(CLOG_DEBUG1 "saying hello");
     ProtocolUtil::writef(stream_.get(), kMsgHello, kProtocolMajorVersion, kProtocolMinorVersion);
 }
 
@@ -144,14 +144,14 @@ ClientProxyUnknown::removeTimer()
 
 void ClientProxyUnknown::handle_data()
 {
-    LOG((CLOG_DEBUG1 "parsing hello reply"));
+    LOG(CLOG_DEBUG1 "parsing hello reply");
 
     std::string name("<unknown>");
     try {
         // limit the maximum length of the hello
         std::uint32_t n = stream_->getSize();
         if (n > kMaxHelloLength) {
-            LOG((CLOG_DEBUG1 "hello reply too long"));
+            LOG(CLOG_DEBUG1 "hello reply too long");
             throw XBadClient();
         }
 
@@ -196,7 +196,7 @@ void ClientProxyUnknown::handle_data()
             throw XIncompatibleClient(major, minor);
         }
 
-        LOG((CLOG_DEBUG1 "created proxy for client \"%s\" version %d.%d", name.c_str(), major, minor));
+        LOG(CLOG_DEBUG1 "created proxy for client \"%s\" version %d.%d", name.c_str(), major, minor);
 
         // wait until the proxy signals that it's ready or has disconnected
         addProxyHandlers();
@@ -204,37 +204,37 @@ void ClientProxyUnknown::handle_data()
     }
     catch (XIncompatibleClient& e) {
         // client is incompatible
-        LOG((CLOG_WARN "client \"%s\" has incompatible version %d.%d)", name.c_str(), e.getMajor(), e.getMinor()));
+        LOG(CLOG_WARN "client \"%s\" has incompatible version %d.%d)", name.c_str(), e.getMajor(), e.getMinor());
         ProtocolUtil::writef(stream_.get(), kMsgEIncompatible,
                              kProtocolMajorVersion, kProtocolMinorVersion);
     }
     catch (XBadClient&) {
         // client not behaving
-        LOG((CLOG_WARN "protocol error from client \"%s\"", name.c_str()));
+        LOG(CLOG_WARN "protocol error from client \"%s\"", name.c_str());
         ProtocolUtil::writef(stream_.get(), kMsgEBad);
     }
     catch (XBase& e) {
         // misc error
-        LOG((CLOG_WARN "error communicating with client \"%s\": %s", name.c_str(), e.what()));
+        LOG(CLOG_WARN "error communicating with client \"%s\": %s", name.c_str(), e.what());
     }
     sendFailure();
 }
 
 void ClientProxyUnknown::handle_write_error()
 {
-    LOG((CLOG_NOTE "error communicating with new client"));
+    LOG(CLOG_NOTE "error communicating with new client");
     sendFailure();
 }
 
 void ClientProxyUnknown::handle_timeout()
 {
-    LOG((CLOG_NOTE "new client is unresponsive"));
+    LOG(CLOG_NOTE "new client is unresponsive");
     sendFailure();
 }
 
 void ClientProxyUnknown::handle_disconnect()
 {
-    LOG((CLOG_NOTE "new client disconnected"));
+    LOG(CLOG_NOTE "new client disconnected");
     sendFailure();
 }
 

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -759,19 +759,19 @@ InputFilter::Rule::handleEvent(const Event& event)
 
     case kActivate:
         actions = &m_activateActions;
-        LOG((CLOG_DEBUG1 "activate actions"));
+        LOG(CLOG_DEBUG1 "activate actions");
         break;
 
     case kDeactivate:
         actions = &m_deactivateActions;
-        LOG((CLOG_DEBUG1 "deactivate actions"));
+        LOG(CLOG_DEBUG1 "deactivate actions");
         break;
     }
 
     // perform actions
     for (ActionList::const_iterator i = actions->begin();
                                 i != actions->end(); ++i) {
-        LOG((CLOG_DEBUG1 "hotkey: %s", (*i)->format().c_str()));
+        LOG(CLOG_DEBUG1 "hotkey: %s", (*i)->format().c_str());
         (*i)->perform(event);
     }
 

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -759,19 +759,19 @@ InputFilter::Rule::handleEvent(const Event& event)
 
     case kActivate:
         actions = &m_activateActions;
-        LOG(CLOG_DEBUG1 "activate actions");
+        LOG_DEBUG1("activate actions");
         break;
 
     case kDeactivate:
         actions = &m_deactivateActions;
-        LOG(CLOG_DEBUG1 "deactivate actions");
+        LOG_DEBUG1("deactivate actions");
         break;
     }
 
     // perform actions
     for (ActionList::const_iterator i = actions->begin();
                                 i != actions->end(); ++i) {
-        LOG(CLOG_DEBUG1 "hotkey: %s", (*i)->format().c_str());
+        LOG_DEBUG1("hotkey: %s", (*i)->format().c_str());
         (*i)->perform(event);
     }
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -176,7 +176,7 @@ Server::Server(
 
 	// Determine if scroll lock is already set. If so, lock the cursor to the primary screen
 	if (m_primaryClient->getToggleMask() & KeyModifierScrollLock) {
-		LOG(CLOG_NOTE "Scroll Lock is on, locking cursor to screen");
+		LOG_NOTE("Scroll Lock is on, locking cursor to screen");
 		m_lockedToScreen = true;
 	}
 
@@ -276,7 +276,7 @@ Server::adoptClient(BaseClientProxy* client)
 
 	// name must be in our configuration
     if (!m_config->isScreen(client->getName())) {
-		LOG(CLOG_WARN "unrecognised client name \"%s\", check server config", client->getName().c_str());
+		LOG_WARN("unrecognised client name \"%s\", check server config", client->getName().c_str());
 		closeClient(client, kMsgEUnknown);
 		return;
 	}
@@ -284,11 +284,11 @@ Server::adoptClient(BaseClientProxy* client)
 	// add client to client list
 	if (!addClient(client)) {
 		// can only have one screen with a given name at any given time
-		LOG(CLOG_WARN "a client with name \"%s\" is already connected", getName(client).c_str());
+		LOG_WARN("a client with name \"%s\" is already connected", getName(client).c_str());
 		closeClient(client, kMsgEBusy);
 		return;
 	}
-	LOG(CLOG_NOTE "client \"%s\" has connected", getName(client).c_str());
+	LOG_NOTE("client \"%s\" has connected", getName(client).c_str());
 
 	// send configuration options to client
 	sendOptions(client);
@@ -408,7 +408,7 @@ void Server::switchScreen(BaseClientProxy* dst, std::int32_t x, std::int32_t y, 
 #endif
 	assert(m_active != nullptr);
 
-	LOG(CLOG_INFO "switch from \"%s\" to \"%s\" at %d,%d", getName(m_active).c_str(), getName(dst).c_str(), x, y);
+	LOG_INFO("switch from \"%s\" to \"%s\" at %d,%d", getName(m_active).c_str(), getName(dst).c_str(), x, y);
 
 	// stop waiting to switch
 	stopSwitch();
@@ -428,7 +428,7 @@ void Server::switchScreen(BaseClientProxy* dst, std::int32_t x, std::int32_t y, 
 		// leave active screen
 		if (!m_active->leave()) {
 			// cannot leave screen
-			LOG(CLOG_WARN "can't leave screen");
+			LOG_WARN("can't leave screen");
 			return;
 		}
 
@@ -555,7 +555,7 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 	// get source screen name
     std::string srcName = getName(src);
 	assert(!srcName.empty());
-	LOG(CLOG_DEBUG2 "find neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str());
+	LOG_DEBUG2("find neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str());
 
 	// convert position to fraction
 	float t = mapToFraction(src, dir, x, y);
@@ -570,7 +570,7 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 		// progress in this direction.  since we haven't found a
 		// connected neighbor we return nullptr.
 		if (dstName.empty()) {
-			LOG(CLOG_DEBUG2 "no neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str());
+			LOG_DEBUG2("no neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str());
 			return nullptr;
 		}
 
@@ -578,13 +578,13 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 		// ready then we can stop.
 		ClientList::const_iterator index = m_clients.find(dstName);
 		if (index != m_clients.end()) {
-			LOG(CLOG_DEBUG2 "\"%s\" is on %s of \"%s\" at %f", dstName.c_str(), Config::dirName(dir), srcName.c_str(), t);
+			LOG_DEBUG2("\"%s\" is on %s of \"%s\" at %f", dstName.c_str(), Config::dirName(dir), srcName.c_str(), t);
 			mapToPixel(index->second, dir, tTmp, x, y);
 			return index->second;
 		}
 
 		// skip over unconnected screen
-		LOG(CLOG_DEBUG2 "ignored \"%s\" on %s of \"%s\"", dstName.c_str(), Config::dirName(dir), srcName.c_str());
+		LOG_DEBUG2("ignored \"%s\" on %s of \"%s\"", dstName.c_str(), Config::dirName(dir), srcName.c_str());
 		srcName = dstName;
 
 		// use position on skipped screen
@@ -625,7 +625,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (x >= 0) {
 				break;
 			}
-			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
+			LOG_DEBUG2("skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -641,7 +641,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (x < dw) {
 				break;
 			}
-			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
+			LOG_DEBUG2("skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -657,7 +657,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (y >= 0) {
 				break;
 			}
-			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
+			LOG_DEBUG2("skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -673,7 +673,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (y < dh) {
 				break;
 			}
-			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
+			LOG_DEBUG2("skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -752,13 +752,13 @@ void Server::avoidJumpZone(BaseClientProxy* dst, EDirection dir, std::int32_t& x
 bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32_t x,
                           std::int32_t y, std::int32_t xActive, std::int32_t yActive)
 {
-	LOG(CLOG_DEBUG1 "try to leave \"%s\" on %s", getName(m_active).c_str(), Config::dirName(dir));
+	LOG_DEBUG1("try to leave \"%s\" on %s", getName(m_active).c_str(), Config::dirName(dir));
 
 	// is there a neighbor?
 	if (newScreen == nullptr) {
 		// there's no neighbor.  we don't want to switch and we don't
 		// want to try to switch later.
-		LOG(CLOG_DEBUG1 "no neighbor %s", Config::dirName(dir));
+		LOG_DEBUG1("no neighbor %s", Config::dirName(dir));
 		stopSwitch();
 		return false;
 	}
@@ -819,7 +819,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 		// see if we're in a locked corner
 		if ((getCorner(m_active, xActive, yActive, size) & corners) != 0) {
 			// yep, no switching
-			LOG(CLOG_DEBUG1 "locked in corner");
+			LOG_DEBUG1("locked in corner");
 			preventSwitch = true;
 			stopSwitch();
 		}
@@ -827,7 +827,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 
 	// ignore if mouse is locked to screen and don't try to switch later
 	if (!preventSwitch && isLockedToScreen()) {
-		LOG(CLOG_DEBUG1 "locked to screen");
+		LOG_DEBUG1("locked to screen");
 		preventSwitch = true;
 		stopSwitch();
 	}
@@ -840,7 +840,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 			(this->m_switchNeedsControl && ((mods & KeyModifierControl) != KeyModifierControl)) ||
 			(this->m_switchNeedsAlt && ((mods & KeyModifierAlt) != KeyModifierAlt))
 		)) {
-		LOG(CLOG_DEBUG1 "need modifiers to switch");
+		LOG_DEBUG1("need modifiers to switch");
 		preventSwitch = true;
 		stopSwitch();
 	}
@@ -871,7 +871,7 @@ Server::startSwitchTwoTap()
 	m_switchTwoTapEngaged = true;
 	m_switchTwoTapArmed   = false;
 	m_switchTwoTapTimer.reset();
-	LOG(CLOG_DEBUG1 "waiting for second tap");
+	LOG_DEBUG1("waiting for second tap");
 }
 
 void Server::armSwitchTwoTap(std::int32_t x, std::int32_t y)
@@ -949,7 +949,7 @@ Server::startSwitchWait(std::int32_t x, std::int32_t y)
 	m_switchWaitX     = x;
 	m_switchWaitY     = y;
 	m_switchWaitTimer = m_events->newOneShotTimer(m_switchWaitDelay, this);
-	LOG(CLOG_DEBUG1 "waiting to switch");
+	LOG_DEBUG1("waiting to switch");
 }
 
 void
@@ -1036,7 +1036,7 @@ Server::stopRelativeMoves()
 		m_yDelta  = 0;
 		m_xDelta2 = 0;
 		m_yDelta2 = 0;
-		LOG(CLOG_DEBUG2 "synchronize move on %s by %d,%d", getName(m_active).c_str(), m_x, m_y);
+		LOG_DEBUG2("synchronize move on %s by %d,%d", getName(m_active).c_str(), m_x, m_y);
 		m_active->mouseMove(m_x, m_y);
 	}
 }
@@ -1123,13 +1123,13 @@ Server::processOptions()
 			m_enableClipboard = (value != 0);
 
 			if (m_enableClipboard == false) {
-				LOG(CLOG_NOTE "clipboard sharing is disabled");
+				LOG_NOTE("clipboard sharing is disabled");
 			}
 		}
 		else if (id == kOptionClipboardSharingSize) {
 			if (value <= 0) {
 				m_maximumClipboardSize = 0;
-				LOG(CLOG_NOTE "clipboard sharing is disabled because the "
+				LOG_NOTE("clipboard sharing is disabled because the "
 							   "maximum shared clipboard size is set to 0");
 			} else {
 				m_maximumClipboardSize = static_cast<size_t>(value);
@@ -1149,7 +1149,7 @@ void Server::handle_shape_changed(BaseClientProxy* client)
 		return;
 	}
 
-	LOG(CLOG_DEBUG "screen \"%s\" shape changed", getName(client).c_str());
+	LOG_DEBUG("screen \"%s\" shape changed", getName(client).c_str());
 
 	// update jump coordinate
 	std::int32_t x, y;
@@ -1189,13 +1189,13 @@ void Server::handle_clipboard_grabbed(const Event& event, BaseClientProxy* grabb
 	// screen to grab.
     ClipboardInfo& clipboard = m_clipboards[info.m_id];
     if (grabber != m_primaryClient && info.m_sequenceNumber < clipboard.m_clipboardSeqNum) {
-        LOG(CLOG_INFO "ignored screen \"%s\" grab of clipboard %d", getName(grabber).c_str(),
+        LOG_INFO("ignored screen \"%s\" grab of clipboard %d", getName(grabber).c_str(),
              info.m_id);
 		return;
 	}
 
 	// mark screen as owning clipboard
-    LOG(CLOG_INFO "screen \"%s\" grabbed clipboard %d from \"%s\"", getName(grabber).c_str(),
+    LOG_INFO("screen \"%s\" grabbed clipboard %d from \"%s\"", getName(grabber).c_str(),
          info.m_id, clipboard.m_clipboardOwner.c_str());
 	clipboard.m_clipboardOwner  = getName(grabber);
     clipboard.m_clipboardSeqNum = info.m_sequenceNumber;
@@ -1293,7 +1293,7 @@ void Server::handle_switch_wait_event()
 {
 	// ignore if mouse is locked to screen
 	if (isLockedToScreen()) {
-		LOG(CLOG_DEBUG1 "locked to screen");
+		LOG_DEBUG1("locked to screen");
 		stopSwitch();
 		return;
 	}
@@ -1315,7 +1315,7 @@ void Server::handle_client_disconnected(BaseClientProxy* client)
 void Server::handle_client_close_timeout(BaseClientProxy* client)
 {
 	// client took too long to disconnect.  just dump it.
-	LOG(CLOG_NOTE "forced disconnection of client \"%s\"", getName(client).c_str());
+	LOG_NOTE("forced disconnection of client \"%s\"", getName(client).c_str());
 	removeOldClient(client);
 
 	delete client;
@@ -1327,7 +1327,7 @@ void Server::handle_switch_to_screen_event(const Event& event)
 
     ClientList::const_iterator index = m_clients.find(info.m_screen);
 	if (index == m_clients.end()) {
-        LOG(CLOG_DEBUG1 "screen \"%s\" not active", info.m_screen.c_str());
+        LOG_DEBUG1("screen \"%s\" not active", info.m_screen.c_str());
 	}
 	else {
         jumpToScreen(index->second);
@@ -1342,7 +1342,7 @@ Server::handle_toggle_screen_event(const Event& event)
   std::string current = getName(m_active);
   ClientList::const_iterator index = m_clients.find(current);
   if (index == m_clients.end()) {
-    LOG(CLOG_DEBUG1 "screen \"%s\" not active", current.c_str());
+    LOG_DEBUG1("screen \"%s\" not active", current.c_str());
   }
   else {
     ++index;
@@ -1362,7 +1362,7 @@ void Server::handle_switch_in_direction_event(const Event& event)
 	std::int32_t x = m_x, y = m_y;
     BaseClientProxy* newScreen = getNeighbor(m_active, info.m_direction, x, y);
 	if (newScreen == nullptr) {
-        LOG(CLOG_DEBUG1 "no neighbor %s", Config::dirName(info.m_direction));
+        LOG_DEBUG1("no neighbor %s", Config::dirName(info.m_direction));
 	}
 	else {
 		jumpToScreen(newScreen);
@@ -1395,7 +1395,7 @@ void Server::handle_keyboard_broadcast_event(const Event& event)
         info.screens_ != m_keyboardBroadcastingScreens) {
 		m_keyboardBroadcasting        = newState;
         m_keyboardBroadcastingScreens = info.screens_;
-		LOG(CLOG_DEBUG "keyboard broadcasting %s: %s", m_keyboardBroadcasting ? "on" : "off", m_keyboardBroadcastingScreens.c_str());
+		LOG_DEBUG("keyboard broadcasting %s: %s", m_keyboardBroadcasting ? "on" : "off", m_keyboardBroadcastingScreens.c_str());
 	}
 }
 
@@ -1423,7 +1423,7 @@ void Server::handle_lock_cursor_to_screen_event(const Event& event)
 	// enter new state
 	if (newState != m_lockedToScreen) {
 		m_lockedToScreen = newState;
-		LOG(CLOG_NOTE "cursor %s current screen", m_lockedToScreen ? "locked to" : "unlocked from");
+		LOG_NOTE("cursor %s current screen", m_lockedToScreen ? "locked to" : "unlocked from");
 
 		m_primaryClient->reconfigure(getActivePrimarySides());
 		if (!isLockedToScreenServer()) {
@@ -1460,7 +1460,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 
 	// ignore update if sequence number is old
 	if (seqNum < clipboard.m_clipboardSeqNum) {
-		LOG(CLOG_INFO "ignored screen \"%s\" update of clipboard %d (missequenced)", getName(sender).c_str(), id);
+		LOG_INFO("ignored screen \"%s\" update of clipboard %d (missequenced)", getName(sender).c_str(), id);
 		return;
 	}
 
@@ -1469,7 +1469,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 
 	// get data
 	if (!sender->getClipboard(id, &clipboard.m_clipboard)) {
-		LOG(CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (failed to get clipboard)",
+		LOG_DEBUG("ignored screen \"%s\" update of clipboard %d (failed to get clipboard)",
 				clipboard.m_clipboardOwner.c_str(), id);
 		return;
 	}
@@ -1477,17 +1477,17 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 	// ignore if data hasn't changed
     std::string data = clipboard.m_clipboard.marshall();
 	if (data.size() > m_maximumClipboardSize) {
-		LOG(CLOG_NOTE "not updating clipboard because it's over the size limit (%zi KB) configured by the server",
+		LOG_NOTE("not updating clipboard because it's over the size limit (%zi KB) configured by the server",
 			m_maximumClipboardSize);
 		return;
 	}
 	if (data == clipboard.m_clipboardData) {
-		LOG(CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (unchanged)", clipboard.m_clipboardOwner.c_str(), id);
+		LOG_DEBUG("ignored screen \"%s\" update of clipboard %d (unchanged)", clipboard.m_clipboardOwner.c_str(), id);
 		return;
 	}
 
 	// got new data
-	LOG(CLOG_INFO "screen \"%s\" updated clipboard %d", clipboard.m_clipboardOwner.c_str(), id);
+	LOG_INFO("screen \"%s\" updated clipboard %d", clipboard.m_clipboardOwner.c_str(), id);
 	clipboard.m_clipboardData = data;
 
 	// tell all clients except the sender that the clipboard is dirty
@@ -1504,7 +1504,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 void
 Server::onScreensaver(bool activated)
 {
-	LOG(CLOG_DEBUG "onScreenSaver %s", activated ? "activated" : "deactivated");
+	LOG_DEBUG("onScreenSaver %s", activated ? "activated" : "deactivated");
 
 	if (activated) {
 		// save current screen and position
@@ -1560,7 +1560,7 @@ void
 Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button,
 				const char* screens)
 {
-	LOG(CLOG_DEBUG1 "onKeyDown id=%d mask=0x%04x button=0x%04x", id, mask, button);
+	LOG_DEBUG1("onKeyDown id=%d mask=0x%04x button=0x%04x", id, mask, button);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1587,7 +1587,7 @@ void
 Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button,
 				const char* screens)
 {
-	LOG(CLOG_DEBUG1 "onKeyUp id=%d mask=0x%04x button=0x%04x", id, mask, button);
+	LOG_DEBUG1("onKeyUp id=%d mask=0x%04x button=0x%04x", id, mask, button);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1612,7 +1612,7 @@ Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button,
 
 void Server::onKeyRepeat(KeyID id, KeyModifierMask mask, std::int32_t count, KeyButton button)
 {
-	LOG(CLOG_DEBUG1 "onKeyRepeat id=%d mask=0x%04x count=%d button=0x%04x", id, mask, count, button);
+	LOG_DEBUG1("onKeyRepeat id=%d mask=0x%04x count=%d button=0x%04x", id, mask, count, button);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1622,7 +1622,7 @@ void Server::onKeyRepeat(KeyID id, KeyModifierMask mask, std::int32_t count, Key
 void
 Server::onMouseDown(ButtonID id)
 {
-	LOG(CLOG_DEBUG1 "onMouseDown id=%d", id);
+	LOG_DEBUG1("onMouseDown id=%d", id);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1635,7 +1635,7 @@ Server::onMouseDown(ButtonID id)
 void
 Server::onMouseUp(ButtonID id)
 {
-	LOG(CLOG_DEBUG1 "onMouseUp id=%d", id);
+	LOG_DEBUG1("onMouseUp id=%d", id);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1661,7 +1661,7 @@ Server::onMouseUp(ButtonID id)
 
 bool Server::onMouseMovePrimary(std::int32_t x, std::int32_t y)
 {
-	LOG(CLOG_DEBUG4 "onMouseMovePrimary %d,%d", x, y);
+	LOG_DEBUG4("onMouseMovePrimary %d,%d", x, y);
 
 	// mouse move on primary (server's) screen
 	if (m_active != m_primaryClient) {
@@ -1804,16 +1804,16 @@ Server::sendDragInfo(BaseClientProxy* newScreen)
 		info = new char[size];
 		memcpy(info, infoString.c_str(), size);
 
-		LOG(CLOG_DEBUG2 "sending drag information to client");
-		LOG(CLOG_DEBUG3 "dragging file list: %s", info);
-		LOG(CLOG_DEBUG3 "dragging file list string size: %zi", size);
+		LOG_DEBUG2("sending drag information to client");
+		LOG_DEBUG3("dragging file list: %s", info);
+		LOG_DEBUG3("dragging file list string size: %zi", size);
 		newScreen->sendDragInfo(fileCount, info, size);
 	}
 }
 
 void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 {
-	LOG(CLOG_DEBUG2 "onMouseMoveSecondary %+d,%+d", dx, dy);
+	LOG_DEBUG2("onMouseMoveSecondary %+d,%+d", dx, dy);
 
 	// mouse move on secondary (client's) screen
 	assert(m_active != nullptr);
@@ -1829,7 +1829,7 @@ void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 	// program on the secondary screen to warp the mouse on us, so we
 	// have no idea where it really is.
 	if (m_relativeMoves && isLockedToScreenServer()) {
-		LOG(CLOG_DEBUG2 "relative move on %s by %d,%d", getName(m_active).c_str(), dx, dy);
+		LOG_DEBUG2("relative move on %s by %d,%d", getName(m_active).c_str(), dx, dy);
 		m_active->mouseRelativeMove(dx, dy);
 		return;
 	}
@@ -1956,24 +1956,24 @@ void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 		m_y = yOld + dy;
 		if (m_x < ax) {
 			m_x = ax;
-			LOG(CLOG_DEBUG2 "clamp to left of \"%s\"", getName(m_active).c_str());
+			LOG_DEBUG2("clamp to left of \"%s\"", getName(m_active).c_str());
 		}
 		else if (m_x > ax + aw - 1) {
 			m_x = ax + aw - 1;
-			LOG(CLOG_DEBUG2 "clamp to right of \"%s\"", getName(m_active).c_str());
+			LOG_DEBUG2("clamp to right of \"%s\"", getName(m_active).c_str());
 		}
 		if (m_y < ay) {
 			m_y = ay;
-			LOG(CLOG_DEBUG2 "clamp to top of \"%s\"", getName(m_active).c_str());
+			LOG_DEBUG2("clamp to top of \"%s\"", getName(m_active).c_str());
 		}
 		else if (m_y > ay + ah - 1) {
 			m_y = ay + ah - 1;
-			LOG(CLOG_DEBUG2 "clamp to bottom of \"%s\"", getName(m_active).c_str());
+			LOG_DEBUG2("clamp to bottom of \"%s\"", getName(m_active).c_str());
 		}
 
 		// warp cursor if it moved.
 		if (m_x != xOld || m_y != yOld) {
-			LOG(CLOG_DEBUG2 "move on %s to %d,%d", getName(m_active).c_str(), m_x, m_y);
+			LOG_DEBUG2("move on %s to %d,%d", getName(m_active).c_str(), m_x, m_y);
 			m_active->mouseMove(m_x, m_y);
 		}
 	}
@@ -1981,7 +1981,7 @@ void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 
 void Server::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 {
-	LOG(CLOG_DEBUG1 "onMouseWheel %+d,%+d", xDelta, yDelta);
+	LOG_DEBUG1("onMouseWheel %+d,%+d", xDelta, yDelta);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1990,7 +1990,7 @@ void Server::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 
 void Server::on_file_chunk_sending(const FileChunk& chunk)
 {
-	LOG(CLOG_DEBUG1 "sending file chunk");
+	LOG_DEBUG1("sending file chunk");
 	assert(m_active != nullptr);
 
     m_active->file_chunk_sending(chunk);
@@ -2006,7 +2006,7 @@ Server::onFileReceiveCompleted()
 
 void Server::write_to_drop_dir_thread()
 {
-	LOG(CLOG_DEBUG "starting write to drop dir thread");
+	LOG_DEBUG("starting write to drop dir thread");
 
 	while (m_screen->isFakeDraggingStarted()) {
 		inputleap::this_thread_sleep(.1f);
@@ -2082,7 +2082,7 @@ Server::closeClient(BaseClientProxy* client, const char* msg)
 	// note that this method also works on clients that are not in
 	// the m_clients list.  adoptClient() may call us with such a
 	// client.
-	LOG(CLOG_NOTE "disconnecting client \"%s\"", getName(client).c_str());
+	LOG_NOTE("disconnecting client \"%s\"", getName(client).c_str());
 
 	// send message
 	// FIXME -- avoid type cast (kinda hard, though)
@@ -2174,7 +2174,7 @@ Server::forceLeaveClient(BaseClientProxy* client)
 
 		// don't notify active screen since it has probably already
 		// disconnected.
-		LOG(CLOG_INFO "jump from \"%s\" to \"%s\" at %d,%d", getName(active).c_str(), getName(m_primaryClient).c_str(), m_x, m_y);
+		LOG_INFO("jump from \"%s\" to \"%s\" at %d,%d", getName(active).c_str(), getName(m_primaryClient).c_str(), m_x, m_y);
 
 		// cut over
 		m_active = m_primaryClient;
@@ -2235,11 +2235,11 @@ Server::sendFileToClient(const char* filename)
 void Server::send_file_thread(const char* filename)
 {
 	try {
-		LOG(CLOG_DEBUG "sending file to client, filename=%s", filename);
+		LOG_DEBUG("sending file to client, filename=%s", filename);
 		StreamChunker::sendFile(filename, m_events, this);
 	}
 	catch (std::runtime_error &error) {
-		LOG(CLOG_ERR "failed sending file chunks, error: %s", error.what());
+		LOG_ERR("failed sending file chunks, error: %s", error.what());
 	}
 
 	m_sendFileThread = nullptr;
@@ -2248,7 +2248,7 @@ void Server::send_file_thread(const char* filename)
 void Server::dragInfoReceived(std::uint32_t fileNum, std::string content)
 {
 	if (!m_args.m_enableDragDrop) {
-		LOG(CLOG_DEBUG "drag drop not enabled, ignoring drag info.");
+		LOG_DEBUG("drag drop not enabled, ignoring drag info.");
 		return;
 	}
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -176,7 +176,7 @@ Server::Server(
 
 	// Determine if scroll lock is already set. If so, lock the cursor to the primary screen
 	if (m_primaryClient->getToggleMask() & KeyModifierScrollLock) {
-		LOG((CLOG_NOTE "Scroll Lock is on, locking cursor to screen"));
+		LOG(CLOG_NOTE "Scroll Lock is on, locking cursor to screen");
 		m_lockedToScreen = true;
 	}
 
@@ -276,7 +276,7 @@ Server::adoptClient(BaseClientProxy* client)
 
 	// name must be in our configuration
     if (!m_config->isScreen(client->getName())) {
-		LOG((CLOG_WARN "unrecognised client name \"%s\", check server config", client->getName().c_str()));
+		LOG(CLOG_WARN "unrecognised client name \"%s\", check server config", client->getName().c_str());
 		closeClient(client, kMsgEUnknown);
 		return;
 	}
@@ -284,11 +284,11 @@ Server::adoptClient(BaseClientProxy* client)
 	// add client to client list
 	if (!addClient(client)) {
 		// can only have one screen with a given name at any given time
-		LOG((CLOG_WARN "a client with name \"%s\" is already connected", getName(client).c_str()));
+		LOG(CLOG_WARN "a client with name \"%s\" is already connected", getName(client).c_str());
 		closeClient(client, kMsgEBusy);
 		return;
 	}
-	LOG((CLOG_NOTE "client \"%s\" has connected", getName(client).c_str()));
+	LOG(CLOG_NOTE "client \"%s\" has connected", getName(client).c_str());
 
 	// send configuration options to client
 	sendOptions(client);
@@ -408,7 +408,7 @@ void Server::switchScreen(BaseClientProxy* dst, std::int32_t x, std::int32_t y, 
 #endif
 	assert(m_active != nullptr);
 
-	LOG((CLOG_INFO "switch from \"%s\" to \"%s\" at %d,%d", getName(m_active).c_str(), getName(dst).c_str(), x, y));
+	LOG(CLOG_INFO "switch from \"%s\" to \"%s\" at %d,%d", getName(m_active).c_str(), getName(dst).c_str(), x, y);
 
 	// stop waiting to switch
 	stopSwitch();
@@ -428,7 +428,7 @@ void Server::switchScreen(BaseClientProxy* dst, std::int32_t x, std::int32_t y, 
 		// leave active screen
 		if (!m_active->leave()) {
 			// cannot leave screen
-			LOG((CLOG_WARN "can't leave screen"));
+			LOG(CLOG_WARN "can't leave screen");
 			return;
 		}
 
@@ -555,7 +555,7 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 	// get source screen name
     std::string srcName = getName(src);
 	assert(!srcName.empty());
-	LOG((CLOG_DEBUG2 "find neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str()));
+	LOG(CLOG_DEBUG2 "find neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str());
 
 	// convert position to fraction
 	float t = mapToFraction(src, dir, x, y);
@@ -570,7 +570,7 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 		// progress in this direction.  since we haven't found a
 		// connected neighbor we return nullptr.
 		if (dstName.empty()) {
-			LOG((CLOG_DEBUG2 "no neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str()));
+			LOG(CLOG_DEBUG2 "no neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str());
 			return nullptr;
 		}
 
@@ -578,13 +578,13 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 		// ready then we can stop.
 		ClientList::const_iterator index = m_clients.find(dstName);
 		if (index != m_clients.end()) {
-			LOG((CLOG_DEBUG2 "\"%s\" is on %s of \"%s\" at %f", dstName.c_str(), Config::dirName(dir), srcName.c_str(), t));
+			LOG(CLOG_DEBUG2 "\"%s\" is on %s of \"%s\" at %f", dstName.c_str(), Config::dirName(dir), srcName.c_str(), t);
 			mapToPixel(index->second, dir, tTmp, x, y);
 			return index->second;
 		}
 
 		// skip over unconnected screen
-		LOG((CLOG_DEBUG2 "ignored \"%s\" on %s of \"%s\"", dstName.c_str(), Config::dirName(dir), srcName.c_str()));
+		LOG(CLOG_DEBUG2 "ignored \"%s\" on %s of \"%s\"", dstName.c_str(), Config::dirName(dir), srcName.c_str());
 		srcName = dstName;
 
 		// use position on skipped screen
@@ -625,7 +625,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (x >= 0) {
 				break;
 			}
-			LOG((CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str()));
+			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -641,7 +641,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (x < dw) {
 				break;
 			}
-			LOG((CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str()));
+			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -657,7 +657,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (y >= 0) {
 				break;
 			}
-			LOG((CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str()));
+			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -673,7 +673,7 @@ BaseClientProxy* Server::mapToNeighbor(BaseClientProxy* src, EDirection srcSide,
 			if (y < dh) {
 				break;
 			}
-			LOG((CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str()));
+			LOG(CLOG_DEBUG2 "skipping over screen %s", getName(dst).c_str());
 			dst = getNeighbor(lastGoodScreen, srcSide, x, y);
 		}
 		assert(lastGoodScreen != nullptr);
@@ -752,13 +752,13 @@ void Server::avoidJumpZone(BaseClientProxy* dst, EDirection dir, std::int32_t& x
 bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32_t x,
                           std::int32_t y, std::int32_t xActive, std::int32_t yActive)
 {
-	LOG((CLOG_DEBUG1 "try to leave \"%s\" on %s", getName(m_active).c_str(), Config::dirName(dir)));
+	LOG(CLOG_DEBUG1 "try to leave \"%s\" on %s", getName(m_active).c_str(), Config::dirName(dir));
 
 	// is there a neighbor?
 	if (newScreen == nullptr) {
 		// there's no neighbor.  we don't want to switch and we don't
 		// want to try to switch later.
-		LOG((CLOG_DEBUG1 "no neighbor %s", Config::dirName(dir)));
+		LOG(CLOG_DEBUG1 "no neighbor %s", Config::dirName(dir));
 		stopSwitch();
 		return false;
 	}
@@ -819,7 +819,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 		// see if we're in a locked corner
 		if ((getCorner(m_active, xActive, yActive, size) & corners) != 0) {
 			// yep, no switching
-			LOG((CLOG_DEBUG1 "locked in corner"));
+			LOG(CLOG_DEBUG1 "locked in corner");
 			preventSwitch = true;
 			stopSwitch();
 		}
@@ -827,7 +827,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 
 	// ignore if mouse is locked to screen and don't try to switch later
 	if (!preventSwitch && isLockedToScreen()) {
-		LOG((CLOG_DEBUG1 "locked to screen"));
+		LOG(CLOG_DEBUG1 "locked to screen");
 		preventSwitch = true;
 		stopSwitch();
 	}
@@ -840,7 +840,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 			(this->m_switchNeedsControl && ((mods & KeyModifierControl) != KeyModifierControl)) ||
 			(this->m_switchNeedsAlt && ((mods & KeyModifierAlt) != KeyModifierAlt))
 		)) {
-		LOG((CLOG_DEBUG1 "need modifiers to switch"));
+		LOG(CLOG_DEBUG1 "need modifiers to switch");
 		preventSwitch = true;
 		stopSwitch();
 	}
@@ -871,7 +871,7 @@ Server::startSwitchTwoTap()
 	m_switchTwoTapEngaged = true;
 	m_switchTwoTapArmed   = false;
 	m_switchTwoTapTimer.reset();
-	LOG((CLOG_DEBUG1 "waiting for second tap"));
+	LOG(CLOG_DEBUG1 "waiting for second tap");
 }
 
 void Server::armSwitchTwoTap(std::int32_t x, std::int32_t y)
@@ -949,7 +949,7 @@ Server::startSwitchWait(std::int32_t x, std::int32_t y)
 	m_switchWaitX     = x;
 	m_switchWaitY     = y;
 	m_switchWaitTimer = m_events->newOneShotTimer(m_switchWaitDelay, this);
-	LOG((CLOG_DEBUG1 "waiting to switch"));
+	LOG(CLOG_DEBUG1 "waiting to switch");
 }
 
 void
@@ -1036,7 +1036,7 @@ Server::stopRelativeMoves()
 		m_yDelta  = 0;
 		m_xDelta2 = 0;
 		m_yDelta2 = 0;
-		LOG((CLOG_DEBUG2 "synchronize move on %s by %d,%d", getName(m_active).c_str(), m_x, m_y));
+		LOG(CLOG_DEBUG2 "synchronize move on %s by %d,%d", getName(m_active).c_str(), m_x, m_y);
 		m_active->mouseMove(m_x, m_y);
 	}
 }
@@ -1123,14 +1123,14 @@ Server::processOptions()
 			m_enableClipboard = (value != 0);
 
 			if (m_enableClipboard == false) {
-				LOG((CLOG_NOTE "clipboard sharing is disabled"));
+				LOG(CLOG_NOTE "clipboard sharing is disabled");
 			}
 		}
 		else if (id == kOptionClipboardSharingSize) {
 			if (value <= 0) {
 				m_maximumClipboardSize = 0;
-				LOG((CLOG_NOTE "clipboard sharing is disabled because the "
-							   "maximum shared clipboard size is set to 0"));
+				LOG(CLOG_NOTE "clipboard sharing is disabled because the "
+							   "maximum shared clipboard size is set to 0");
 			} else {
 				m_maximumClipboardSize = static_cast<size_t>(value);
 			}
@@ -1149,7 +1149,7 @@ void Server::handle_shape_changed(BaseClientProxy* client)
 		return;
 	}
 
-	LOG((CLOG_DEBUG "screen \"%s\" shape changed", getName(client).c_str()));
+	LOG(CLOG_DEBUG "screen \"%s\" shape changed", getName(client).c_str());
 
 	// update jump coordinate
 	std::int32_t x, y;
@@ -1189,14 +1189,14 @@ void Server::handle_clipboard_grabbed(const Event& event, BaseClientProxy* grabb
 	// screen to grab.
     ClipboardInfo& clipboard = m_clipboards[info.m_id];
     if (grabber != m_primaryClient && info.m_sequenceNumber < clipboard.m_clipboardSeqNum) {
-        LOG((CLOG_INFO "ignored screen \"%s\" grab of clipboard %d", getName(grabber).c_str(),
-             info.m_id));
+        LOG(CLOG_INFO "ignored screen \"%s\" grab of clipboard %d", getName(grabber).c_str(),
+             info.m_id);
 		return;
 	}
 
 	// mark screen as owning clipboard
-    LOG((CLOG_INFO "screen \"%s\" grabbed clipboard %d from \"%s\"", getName(grabber).c_str(),
-         info.m_id, clipboard.m_clipboardOwner.c_str()));
+    LOG(CLOG_INFO "screen \"%s\" grabbed clipboard %d from \"%s\"", getName(grabber).c_str(),
+         info.m_id, clipboard.m_clipboardOwner.c_str());
 	clipboard.m_clipboardOwner  = getName(grabber);
     clipboard.m_clipboardSeqNum = info.m_sequenceNumber;
 
@@ -1293,7 +1293,7 @@ void Server::handle_switch_wait_event()
 {
 	// ignore if mouse is locked to screen
 	if (isLockedToScreen()) {
-		LOG((CLOG_DEBUG1 "locked to screen"));
+		LOG(CLOG_DEBUG1 "locked to screen");
 		stopSwitch();
 		return;
 	}
@@ -1315,7 +1315,7 @@ void Server::handle_client_disconnected(BaseClientProxy* client)
 void Server::handle_client_close_timeout(BaseClientProxy* client)
 {
 	// client took too long to disconnect.  just dump it.
-	LOG((CLOG_NOTE "forced disconnection of client \"%s\"", getName(client).c_str()));
+	LOG(CLOG_NOTE "forced disconnection of client \"%s\"", getName(client).c_str());
 	removeOldClient(client);
 
 	delete client;
@@ -1327,7 +1327,7 @@ void Server::handle_switch_to_screen_event(const Event& event)
 
     ClientList::const_iterator index = m_clients.find(info.m_screen);
 	if (index == m_clients.end()) {
-        LOG((CLOG_DEBUG1 "screen \"%s\" not active", info.m_screen.c_str()));
+        LOG(CLOG_DEBUG1 "screen \"%s\" not active", info.m_screen.c_str());
 	}
 	else {
         jumpToScreen(index->second);
@@ -1342,7 +1342,7 @@ Server::handle_toggle_screen_event(const Event& event)
   std::string current = getName(m_active);
   ClientList::const_iterator index = m_clients.find(current);
   if (index == m_clients.end()) {
-    LOG((CLOG_DEBUG1 "screen \"%s\" not active", current.c_str()));
+    LOG(CLOG_DEBUG1 "screen \"%s\" not active", current.c_str());
   }
   else {
     ++index;
@@ -1362,7 +1362,7 @@ void Server::handle_switch_in_direction_event(const Event& event)
 	std::int32_t x = m_x, y = m_y;
     BaseClientProxy* newScreen = getNeighbor(m_active, info.m_direction, x, y);
 	if (newScreen == nullptr) {
-        LOG((CLOG_DEBUG1 "no neighbor %s", Config::dirName(info.m_direction)));
+        LOG(CLOG_DEBUG1 "no neighbor %s", Config::dirName(info.m_direction));
 	}
 	else {
 		jumpToScreen(newScreen);
@@ -1395,7 +1395,7 @@ void Server::handle_keyboard_broadcast_event(const Event& event)
         info.screens_ != m_keyboardBroadcastingScreens) {
 		m_keyboardBroadcasting        = newState;
         m_keyboardBroadcastingScreens = info.screens_;
-		LOG((CLOG_DEBUG "keyboard broadcasting %s: %s", m_keyboardBroadcasting ? "on" : "off", m_keyboardBroadcastingScreens.c_str()));
+		LOG(CLOG_DEBUG "keyboard broadcasting %s: %s", m_keyboardBroadcasting ? "on" : "off", m_keyboardBroadcastingScreens.c_str());
 	}
 }
 
@@ -1423,7 +1423,7 @@ void Server::handle_lock_cursor_to_screen_event(const Event& event)
 	// enter new state
 	if (newState != m_lockedToScreen) {
 		m_lockedToScreen = newState;
-		LOG((CLOG_NOTE "cursor %s current screen", m_lockedToScreen ? "locked to" : "unlocked from"));
+		LOG(CLOG_NOTE "cursor %s current screen", m_lockedToScreen ? "locked to" : "unlocked from");
 
 		m_primaryClient->reconfigure(getActivePrimarySides());
 		if (!isLockedToScreenServer()) {
@@ -1460,7 +1460,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 
 	// ignore update if sequence number is old
 	if (seqNum < clipboard.m_clipboardSeqNum) {
-		LOG((CLOG_INFO "ignored screen \"%s\" update of clipboard %d (missequenced)", getName(sender).c_str(), id));
+		LOG(CLOG_INFO "ignored screen \"%s\" update of clipboard %d (missequenced)", getName(sender).c_str(), id);
 		return;
 	}
 
@@ -1469,25 +1469,25 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 
 	// get data
 	if (!sender->getClipboard(id, &clipboard.m_clipboard)) {
-		LOG((CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (failed to get clipboard)",
-				clipboard.m_clipboardOwner.c_str(), id));
+		LOG(CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (failed to get clipboard)",
+				clipboard.m_clipboardOwner.c_str(), id);
 		return;
 	}
 
 	// ignore if data hasn't changed
     std::string data = clipboard.m_clipboard.marshall();
 	if (data.size() > m_maximumClipboardSize) {
-		LOG((CLOG_NOTE "not updating clipboard because it's over the size limit (%zi KB) configured by the server",
-			m_maximumClipboardSize));
+		LOG(CLOG_NOTE "not updating clipboard because it's over the size limit (%zi KB) configured by the server",
+			m_maximumClipboardSize);
 		return;
 	}
 	if (data == clipboard.m_clipboardData) {
-		LOG((CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (unchanged)", clipboard.m_clipboardOwner.c_str(), id));
+		LOG(CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (unchanged)", clipboard.m_clipboardOwner.c_str(), id);
 		return;
 	}
 
 	// got new data
-	LOG((CLOG_INFO "screen \"%s\" updated clipboard %d", clipboard.m_clipboardOwner.c_str(), id));
+	LOG(CLOG_INFO "screen \"%s\" updated clipboard %d", clipboard.m_clipboardOwner.c_str(), id);
 	clipboard.m_clipboardData = data;
 
 	// tell all clients except the sender that the clipboard is dirty
@@ -1504,7 +1504,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 void
 Server::onScreensaver(bool activated)
 {
-	LOG((CLOG_DEBUG "onScreenSaver %s", activated ? "activated" : "deactivated"));
+	LOG(CLOG_DEBUG "onScreenSaver %s", activated ? "activated" : "deactivated");
 
 	if (activated) {
 		// save current screen and position
@@ -1560,7 +1560,7 @@ void
 Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button,
 				const char* screens)
 {
-	LOG((CLOG_DEBUG1 "onKeyDown id=%d mask=0x%04x button=0x%04x", id, mask, button));
+	LOG(CLOG_DEBUG1 "onKeyDown id=%d mask=0x%04x button=0x%04x", id, mask, button);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1587,7 +1587,7 @@ void
 Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button,
 				const char* screens)
 {
-	LOG((CLOG_DEBUG1 "onKeyUp id=%d mask=0x%04x button=0x%04x", id, mask, button));
+	LOG(CLOG_DEBUG1 "onKeyUp id=%d mask=0x%04x button=0x%04x", id, mask, button);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1612,7 +1612,7 @@ Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button,
 
 void Server::onKeyRepeat(KeyID id, KeyModifierMask mask, std::int32_t count, KeyButton button)
 {
-	LOG((CLOG_DEBUG1 "onKeyRepeat id=%d mask=0x%04x count=%d button=0x%04x", id, mask, count, button));
+	LOG(CLOG_DEBUG1 "onKeyRepeat id=%d mask=0x%04x count=%d button=0x%04x", id, mask, count, button);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1622,7 +1622,7 @@ void Server::onKeyRepeat(KeyID id, KeyModifierMask mask, std::int32_t count, Key
 void
 Server::onMouseDown(ButtonID id)
 {
-	LOG((CLOG_DEBUG1 "onMouseDown id=%d", id));
+	LOG(CLOG_DEBUG1 "onMouseDown id=%d", id);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1635,7 +1635,7 @@ Server::onMouseDown(ButtonID id)
 void
 Server::onMouseUp(ButtonID id)
 {
-	LOG((CLOG_DEBUG1 "onMouseUp id=%d", id));
+	LOG(CLOG_DEBUG1 "onMouseUp id=%d", id);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1661,7 +1661,7 @@ Server::onMouseUp(ButtonID id)
 
 bool Server::onMouseMovePrimary(std::int32_t x, std::int32_t y)
 {
-	LOG((CLOG_DEBUG4 "onMouseMovePrimary %d,%d", x, y));
+	LOG(CLOG_DEBUG4 "onMouseMovePrimary %d,%d", x, y);
 
 	// mouse move on primary (server's) screen
 	if (m_active != m_primaryClient) {
@@ -1804,16 +1804,16 @@ Server::sendDragInfo(BaseClientProxy* newScreen)
 		info = new char[size];
 		memcpy(info, infoString.c_str(), size);
 
-		LOG((CLOG_DEBUG2 "sending drag information to client"));
-		LOG((CLOG_DEBUG3 "dragging file list: %s", info));
-		LOG((CLOG_DEBUG3 "dragging file list string size: %zi", size));
+		LOG(CLOG_DEBUG2 "sending drag information to client");
+		LOG(CLOG_DEBUG3 "dragging file list: %s", info);
+		LOG(CLOG_DEBUG3 "dragging file list string size: %zi", size);
 		newScreen->sendDragInfo(fileCount, info, size);
 	}
 }
 
 void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 {
-	LOG((CLOG_DEBUG2 "onMouseMoveSecondary %+d,%+d", dx, dy));
+	LOG(CLOG_DEBUG2 "onMouseMoveSecondary %+d,%+d", dx, dy);
 
 	// mouse move on secondary (client's) screen
 	assert(m_active != nullptr);
@@ -1829,7 +1829,7 @@ void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 	// program on the secondary screen to warp the mouse on us, so we
 	// have no idea where it really is.
 	if (m_relativeMoves && isLockedToScreenServer()) {
-		LOG((CLOG_DEBUG2 "relative move on %s by %d,%d", getName(m_active).c_str(), dx, dy));
+		LOG(CLOG_DEBUG2 "relative move on %s by %d,%d", getName(m_active).c_str(), dx, dy);
 		m_active->mouseRelativeMove(dx, dy);
 		return;
 	}
@@ -1956,24 +1956,24 @@ void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 		m_y = yOld + dy;
 		if (m_x < ax) {
 			m_x = ax;
-			LOG((CLOG_DEBUG2 "clamp to left of \"%s\"", getName(m_active).c_str()));
+			LOG(CLOG_DEBUG2 "clamp to left of \"%s\"", getName(m_active).c_str());
 		}
 		else if (m_x > ax + aw - 1) {
 			m_x = ax + aw - 1;
-			LOG((CLOG_DEBUG2 "clamp to right of \"%s\"", getName(m_active).c_str()));
+			LOG(CLOG_DEBUG2 "clamp to right of \"%s\"", getName(m_active).c_str());
 		}
 		if (m_y < ay) {
 			m_y = ay;
-			LOG((CLOG_DEBUG2 "clamp to top of \"%s\"", getName(m_active).c_str()));
+			LOG(CLOG_DEBUG2 "clamp to top of \"%s\"", getName(m_active).c_str());
 		}
 		else if (m_y > ay + ah - 1) {
 			m_y = ay + ah - 1;
-			LOG((CLOG_DEBUG2 "clamp to bottom of \"%s\"", getName(m_active).c_str()));
+			LOG(CLOG_DEBUG2 "clamp to bottom of \"%s\"", getName(m_active).c_str());
 		}
 
 		// warp cursor if it moved.
 		if (m_x != xOld || m_y != yOld) {
-			LOG((CLOG_DEBUG2 "move on %s to %d,%d", getName(m_active).c_str(), m_x, m_y));
+			LOG(CLOG_DEBUG2 "move on %s to %d,%d", getName(m_active).c_str(), m_x, m_y);
 			m_active->mouseMove(m_x, m_y);
 		}
 	}
@@ -1981,7 +1981,7 @@ void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)
 
 void Server::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 {
-	LOG((CLOG_DEBUG1 "onMouseWheel %+d,%+d", xDelta, yDelta));
+	LOG(CLOG_DEBUG1 "onMouseWheel %+d,%+d", xDelta, yDelta);
 	assert(m_active != nullptr);
 
 	// relay
@@ -1990,7 +1990,7 @@ void Server::onMouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 
 void Server::on_file_chunk_sending(const FileChunk& chunk)
 {
-	LOG((CLOG_DEBUG1 "sending file chunk"));
+	LOG(CLOG_DEBUG1 "sending file chunk");
 	assert(m_active != nullptr);
 
     m_active->file_chunk_sending(chunk);
@@ -2006,7 +2006,7 @@ Server::onFileReceiveCompleted()
 
 void Server::write_to_drop_dir_thread()
 {
-	LOG((CLOG_DEBUG "starting write to drop dir thread"));
+	LOG(CLOG_DEBUG "starting write to drop dir thread");
 
 	while (m_screen->isFakeDraggingStarted()) {
 		inputleap::this_thread_sleep(.1f);
@@ -2082,7 +2082,7 @@ Server::closeClient(BaseClientProxy* client, const char* msg)
 	// note that this method also works on clients that are not in
 	// the m_clients list.  adoptClient() may call us with such a
 	// client.
-	LOG((CLOG_NOTE "disconnecting client \"%s\"", getName(client).c_str()));
+	LOG(CLOG_NOTE "disconnecting client \"%s\"", getName(client).c_str());
 
 	// send message
 	// FIXME -- avoid type cast (kinda hard, though)
@@ -2174,7 +2174,7 @@ Server::forceLeaveClient(BaseClientProxy* client)
 
 		// don't notify active screen since it has probably already
 		// disconnected.
-		LOG((CLOG_INFO "jump from \"%s\" to \"%s\" at %d,%d", getName(active).c_str(), getName(m_primaryClient).c_str(), m_x, m_y));
+		LOG(CLOG_INFO "jump from \"%s\" to \"%s\" at %d,%d", getName(active).c_str(), getName(m_primaryClient).c_str(), m_x, m_y);
 
 		// cut over
 		m_active = m_primaryClient;
@@ -2235,11 +2235,11 @@ Server::sendFileToClient(const char* filename)
 void Server::send_file_thread(const char* filename)
 {
 	try {
-		LOG((CLOG_DEBUG "sending file to client, filename=%s", filename));
+		LOG(CLOG_DEBUG "sending file to client, filename=%s", filename);
 		StreamChunker::sendFile(filename, m_events, this);
 	}
 	catch (std::runtime_error &error) {
-		LOG((CLOG_ERR "failed sending file chunks, error: %s", error.what()));
+		LOG(CLOG_ERR "failed sending file chunks, error: %s", error.what());
 	}
 
 	m_sendFileThread = nullptr;
@@ -2248,7 +2248,7 @@ void Server::send_file_thread(const char* filename)
 void Server::dragInfoReceived(std::uint32_t fileNum, std::string content)
 {
 	if (!m_args.m_enableDragDrop) {
-		LOG((CLOG_DEBUG "drag drop not enabled, ignoring drag info."));
+		LOG(CLOG_DEBUG "drag drop not enabled, ignoring drag info.");
 		return;
 	}
 

--- a/src/test/integtests/ipc/IpcTests.cpp
+++ b/src/test/integtests/ipc/IpcTests.cpp
@@ -174,13 +174,13 @@ void IpcTests::sendMessageToServer_serverHandleMessageReceived(const Event& e)
 {
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcHello) {
-        LOG(CLOG_DEBUG "client said hello, sending test to server");
+        LOG_DEBUG("client said hello, sending test to server");
         IpcCommandMessage cm("test", true);
         m_sendMessageToServer_client->send(cm);
     }
     else if (m.type() == kIpcCommand) {
         const auto& cm = static_cast<const IpcCommandMessage&>(m);
-        LOG(CLOG_DEBUG "got ipc command message, %s", cm.command().c_str());
+        LOG_DEBUG("got ipc command message, %s", cm.command().c_str());
         m_sendMessageToServer_receivedString = cm.command();
         m_events.raiseQuitEvent();
     }
@@ -190,7 +190,7 @@ void IpcTests::sendMessageToClient_server_handle_client_connected(const Event& e
 {
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcHello) {
-        LOG(CLOG_DEBUG "client said hello, sending test to client");
+        LOG_DEBUG("client said hello, sending test to client");
         IpcLogLineMessage msg("test");
         m_sendMessageToClient_server->send(msg, kIpcClientNode);
     }
@@ -201,7 +201,7 @@ void IpcTests::sendMessageToClient_client_handle_message_received(const Event& e
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcLogLine) {
         const auto& llm = static_cast<const IpcLogLineMessage&>(m);
-        LOG(CLOG_DEBUG "got ipc log message, %s", llm.logLine().c_str());
+        LOG_DEBUG("got ipc log message, %s", llm.logLine().c_str());
         m_sendMessageToClient_receivedString = llm.logLine();
         m_events.raiseQuitEvent();
     }

--- a/src/test/integtests/ipc/IpcTests.cpp
+++ b/src/test/integtests/ipc/IpcTests.cpp
@@ -174,13 +174,13 @@ void IpcTests::sendMessageToServer_serverHandleMessageReceived(const Event& e)
 {
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcHello) {
-        LOG((CLOG_DEBUG "client said hello, sending test to server"));
+        LOG(CLOG_DEBUG "client said hello, sending test to server");
         IpcCommandMessage cm("test", true);
         m_sendMessageToServer_client->send(cm);
     }
     else if (m.type() == kIpcCommand) {
         const auto& cm = static_cast<const IpcCommandMessage&>(m);
-        LOG((CLOG_DEBUG "got ipc command message, %s", cm.command().c_str()));
+        LOG(CLOG_DEBUG "got ipc command message, %s", cm.command().c_str());
         m_sendMessageToServer_receivedString = cm.command();
         m_events.raiseQuitEvent();
     }
@@ -190,7 +190,7 @@ void IpcTests::sendMessageToClient_server_handle_client_connected(const Event& e
 {
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcHello) {
-        LOG((CLOG_DEBUG "client said hello, sending test to client"));
+        LOG(CLOG_DEBUG "client said hello, sending test to client");
         IpcLogLineMessage msg("test");
         m_sendMessageToClient_server->send(msg, kIpcClientNode);
     }
@@ -201,7 +201,7 @@ void IpcTests::sendMessageToClient_client_handle_message_received(const Event& e
     const auto& m = e.get_data_as<IpcMessage>();
     if (m.type() == kIpcLogLine) {
         const auto& llm = static_cast<const IpcLogLineMessage&>(m);
-        LOG((CLOG_DEBUG "got ipc log message, %s", llm.logLine().c_str()));
+        LOG(CLOG_DEBUG "got ipc log message, %s", llm.logLine().c_str());
         m_sendMessageToClient_receivedString = llm.logLine();
         m_events.raiseQuitEvent();
     }

--- a/src/test/integtests/platform/OSXKeyStateTests.cpp
+++ b/src/test/integtests/platform/OSXKeyStateTests.cpp
@@ -110,7 +110,7 @@ OSXKeyStateTests::isKeyPressed(const OSXKeyState& keyState, KeyButton button)
 
     IKeyState::KeyButtonSet::const_iterator it;
     for (it = pressed.begin(); it != pressed.end(); ++it) {
-        LOG((CLOG_DEBUG "checking key %d", *it));
+        LOG(CLOG_DEBUG "checking key %d", *it);
         if (*it == button) {
             return true;
         }

--- a/src/test/integtests/platform/OSXKeyStateTests.cpp
+++ b/src/test/integtests/platform/OSXKeyStateTests.cpp
@@ -110,7 +110,7 @@ OSXKeyStateTests::isKeyPressed(const OSXKeyState& keyState, KeyButton button)
 
     IKeyState::KeyButtonSet::const_iterator it;
     for (it = pressed.begin(); it != pressed.end(); ++it) {
-        LOG(CLOG_DEBUG "checking key %d", *it);
+        LOG_DEBUG("checking key %d", *it);
         if (*it == button) {
             return true;
         }

--- a/src/test/integtests/platform/XWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/XWindowsKeyStateTests.cpp
@@ -48,7 +48,7 @@ protected:
     ~XWindowsKeyStateTests() override
     {
         if (m_display != nullptr) {
-            LOG((CLOG_DEBUG "closing display"));
+            LOG(CLOG_DEBUG "closing display");
             XCloseDisplay(m_display);
         }
     }
@@ -58,7 +58,7 @@ protected:
     {
         // open the display only once for the entire test suite
         if (this->m_display == nullptr) {
-            LOG((CLOG_DEBUG "opening display"));
+            LOG(CLOG_DEBUG "opening display");
             this->m_display = XOpenDisplay(nullptr);
 
             // failed to open the display and DISPLAY is null? probably

--- a/src/test/integtests/platform/XWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/XWindowsKeyStateTests.cpp
@@ -48,7 +48,7 @@ protected:
     ~XWindowsKeyStateTests() override
     {
         if (m_display != nullptr) {
-            LOG(CLOG_DEBUG "closing display");
+            LOG_DEBUG("closing display");
             XCloseDisplay(m_display);
         }
     }
@@ -58,7 +58,7 @@ protected:
     {
         // open the display only once for the entire test suite
         if (this->m_display == nullptr) {
-            LOG(CLOG_DEBUG "opening display");
+            LOG_DEBUG("opening display");
             this->m_display = XOpenDisplay(nullptr);
 
             // failed to open the display and DISPLAY is null? probably


### PR DESCRIPTION
On top of #1858, mostly filing this to check if the CI passes :)

`__VA_ARGS__` has been a thing in macros for quite a while now so the old justification for the current log macros no longer applies, we can improve them. This patch changes

```
  LOG((CLOG_WARN "some error: %d", foo));
```
to a much more natural
```
  LOG_WARN("some error: %d", foo);
```