### PR TITLE
github-ci: update to use Fedora 39

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora:36", "opensuse/tumbleweed"]
+        os: ["fedora:39", "opensuse/tumbleweed"]
         include:
           - installer: dnf install -y
             rpm_tag: fedora


### PR DESCRIPTION
F36 is well past it's EOL

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
