### PR TITLE
ei: implement server-side hotkey handling

### DIFF
--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -106,6 +106,7 @@ private:
     void on_pointer_scroll_discrete_event(ei_event* event);
     void on_motion_event(ei_event *event);
     void on_abs_motion_event(ei_event *event);
+    bool on_hotkey(KeyID key, bool is_press, KeyModifierMask mask);
 
 private:
     // true if screen is being used as a primary screen, false otherwise
@@ -141,6 +142,33 @@ private:
 #if HAVE_LIBPORTAL_INPUTCAPTURE
     PortalInputCapture* portal_input_capture_;
 #endif
+
+    struct HotKeyItem {
+    public:
+        HotKeyItem(std::uint32_t mask, std::uint32_t id);
+        bool operator<(const HotKeyItem& other) const { return mask_ < other.mask_; };
+
+    public:
+        std::uint32_t mask_ = 0;
+        std::uint32_t id_ = 0;  // for registering the hotkey
+    };
+
+    class HotKeySet {
+    public:
+        HotKeySet(KeyID keyid);
+        KeyID keyid() const { return id_; };
+        bool remove_by_id(std::uint32_t id);
+        void add_item(HotKeyItem item);
+        std::uint32_t find_by_mask(std::uint32_t mask) const;
+
+    private:
+        KeyID id_ = 0;
+        std::vector<HotKeyItem> set_;
+    };
+
+    using HotKeyMap = std::map<KeyID, HotKeySet>;
+
+    HotKeyMap hotkeys_;
 };
 
 } // namespace inputleap


### PR DESCRIPTION
Add a map that contains the key id and a vector of modifier masks + the assigned hotkey id, then register and lookup those hotkeys as we get the events. This is a bit minimum effort but should get us 80% of the way there, further inspiration can be taken from the X implementation of the same thing.

Note that due to how the InputCapture portal works, this code is not triggered unless we're currently capturing input - and that only happens when we're logically on the remote.

No solution currently exists in the ei backend to capture the key on the server side.

Fixes #1711 (partially)

---

A note here: this is the MVP to get Ctrl+Backspace working and it works in my tests here. The X windows implementation is a lot more complex but I'm running out of time so a mostly-working solution is better than none :)

And as mentioned above, this only works to lock the screen on the remote client, not the local server. Maybe the `GlobalShortcuts` portal is an eventual solution for that but for now this will have to do.

---

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
