### PR TITLE
ei: disconnect SESSION_CLOSED from the right session object

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -67,11 +67,12 @@ PortalInputCapture::~PortalInputCapture()
     }
 
     if (session_) {
-        for (auto sigid: signals_) {
-            if (sigid != 0) {
-                g_signal_handler_disconnect(session_, sigid);
-            }
-        }
+        XdpSession *parent_session = xdp_input_capture_session_get_session(session_);
+        g_signal_handler_disconnect(G_OBJECT(parent_session), signals_[SESSION_CLOSED]);
+        g_signal_handler_disconnect(session_, signals_[DISABLED]);
+        g_signal_handler_disconnect(session_, signals_[ACTIVATED]);
+        g_signal_handler_disconnect(session_, signals_[DEACTIVATED]);
+        g_signal_handler_disconnect(session_, signals_[ZONES_CHANGED]);
         g_object_unref(session_);
     }
 


### PR DESCRIPTION
The SESSION_CLOSED signal is on the parent session so we need to disconnect it there too.

   ../gobject/gsignal.c:2777: instance '0x7fd130001c90' has no handler with id '12'

Fixes f2d7d9f57af218a4ff3762342f361e61021a949d

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
