### PR TITLE
ei: start with an initial screen size of 1x1

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -45,6 +45,8 @@ namespace inputleap {
 EiScreen::EiScreen(bool is_primary, IEventQueue* events, bool use_portal) :
     is_primary_(is_primary),
     events_(events),
+    w_(1),
+    h_(1),
     is_on_screen_(is_primary)
 {
     init_ei();


### PR DESCRIPTION
getShape() is called as soon as we connect to the server but at this point we do not have a shape yet, we're still waiting for the user to confirm the portal request. If we return all zeroes here the server disconnects us (ClientProxy1_6::recvInfo()), resulting in a continuous connect/disconnect loop until the user finally says yes.

Send an intial screen shape instead, that shape will get updated later when we get the devices through libei.

Fixes #1718

cc @Shuna322, can you give this a try please?


## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
