### PR TITLE
ei: drop debug priority for ei debug messages

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -99,7 +99,7 @@ void EiScreen::handle_ei_log_event(ei* ei,
 {
     switch (priority) {
         case EI_LOG_PRIORITY_DEBUG:
-            LOG_DEBUG("ei: %s", message);
+            LOG_DEBUG3("ei: %s", message);
             break;
         case EI_LOG_PRIORITY_INFO:
             LOG_INFO("ei: %s", message);


### PR DESCRIPTION
While this is useful for debugging libei, it's almost never useful for anything else so let's drop the log priority a bit.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change