### PR TITLE
ei: Fix stuck modifiers

### DIFF
--- a/doc/newsfragments/handle-super-modifier-on-wayland.bugfix
+++ b/doc/newsfragments/handle-super-modifier-on-wayland.bugfix
@@ -1,0 +1,1 @@
+Handle the super modifier on a wayland client

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -169,8 +169,6 @@ void EiKeyState::assign_generated_modifiers(std::uint32_t keycode, inputleap::Ke
 
 void EiKeyState::getKeyMap(inputleap::KeyMap& keyMap)
 {
-    inputleap::KeyMap::KeyItem item;
-
     auto min_keycode = xkb_keymap_min_keycode(xkb_keymap_);
     auto max_keycode = xkb_keymap_max_keycode(xkb_keymap_);
 
@@ -182,8 +180,6 @@ void EiKeyState::getKeyMap(inputleap::KeyMap& keyMap)
             continue;
 
         for (auto group = 0U; group < xkb_keymap_num_layouts(xkb_keymap_); group++) {
-            item.m_group = group;
-
             for (auto level = 0U;
                  level < xkb_keymap_num_levels_for_key(xkb_keymap_, keycode, group);
                  level++) {
@@ -199,12 +195,12 @@ void EiKeyState::getKeyMap(inputleap::KeyMap& keyMap)
                 if (nsyms > 1)
                     LOG_WARN(" Multiple keysyms per keycode are not supported, keycode %d", keycode);
 
+                inputleap::KeyMap::KeyItem item{};
                 xkb_keysym_t keysym = syms[0];
                 KeySym sym = static_cast<KeyID>(keysym);
                 item.m_id = XWindowsUtil::mapKeySymToKeyID(sym);
                 item.m_button   = static_cast<KeyButton>(keycode) - 8; // X keycode offset
-                item.m_client   = 0;
-                item.m_sensitive = 0;
+                item.m_group = group;
 
                 // For debugging only
                 char keysym_name[128] = {0};

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -137,6 +137,8 @@ std::uint32_t EiKeyState::convert_mod_mask(std::uint32_t xkb_mask) const
             barrier_mask |= (1 << kKeyModifierBitControl);
         else if (strcmp(XKB_MOD_NAME_ALT, name) == 0)
             barrier_mask |= (1 << kKeyModifierBitAlt);
+        else if (strcmp(XKB_MOD_NAME_LOGO, name) == 0)
+            barrier_mask |= (1 << kKeyModifierBitSuper);
     }
 
     return barrier_mask;

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -162,12 +162,6 @@ void EiKeyState::assign_generated_modifiers(std::uint32_t keycode, inputleap::Ke
         }
     }
     xkb_state_update_key(state, keycode, XKB_KEY_UP);
-
-    // If we locked a modifier, press again to hopefully unlock
-    if (changed & (XKB_STATE_MODS_LOCKED|XKB_STATE_MODS_LATCHED)) {
-        xkb_state_update_key(state, keycode, XKB_KEY_DOWN);
-        xkb_state_update_key(state, keycode, XKB_KEY_UP);
-    }
     xkb_state_unref(state);
 
     item.m_generates = convert_mod_mask(mods_generates);

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -299,7 +299,8 @@ void EiScreen::fakeMouseWheel(int32_t xDelta, int32_t yDelta) const
 
 void EiScreen::fakeKey(uint32_t keycode, bool is_down) const
 {
-    key_state_->update_xkb_state(keycode, is_down);
+    auto xkb_keycode = keycode + 8;
+    key_state_->update_xkb_state(xkb_keycode, is_down);
     ei_device_keyboard_key(ei_keyboard_, keycode, is_down);
     ei_device_frame(ei_keyboard_, ei_now(ei_));
 }


### PR DESCRIPTION
This struct was statically allocated but not initialized and the code
never set item.m_lock unless it was an actual locking modifier.

So our modifiers were randomly locking, or definitely locking if they
sorted after alocking modifier.

Fix this by both localizing and initializing the variable.


Fixes #1816, #1725

Reapplies #1811 

## Contributor Checklist:

* [x] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This is not a user-visible change

Note: there was already a newsfragment for the super modifier so I just left that in there.
AFAICT we haven't had a release yet with libei support so adding newsfragments for "fixed a bug in a new feature before you got to see it" seems a bit superfluous :)
