### PR TITLE
Replace signals with Q_SIGNALS

### DIFF
--- a/src/gui/src/CommandProcess.h
+++ b/src/gui/src/CommandProcess.h
@@ -27,7 +27,7 @@ class CommandProcess : public QObject
 public:
     CommandProcess(QString cmd, QStringList arguments, QString input = "");
 
-signals:
+Q_SIGNALS:
     void finished();
 
 public slots:

--- a/src/gui/src/DataDownloader.h
+++ b/src/gui/src/DataDownloader.h
@@ -36,7 +36,7 @@ public:
     void download(QUrl url);
     bool isFinished() const { return m_IsFinished; }
 
-signals:
+Q_SIGNALS:
     void isComplete();
 
 private slots:

--- a/src/gui/src/IpcClient.h
+++ b/src/gui/src/IpcClient.h
@@ -50,7 +50,7 @@ private slots:
     void error(QAbstractSocket::SocketError error);
     void handleReadLogLine(const QString& text);
 
-signals:
+Q_SIGNALS:
     void readLogLine(const QString& text);
     void infoMessage(const QString& text);
     void errorMessage(const QString& text);

--- a/src/gui/src/IpcReader.h
+++ b/src/gui/src/IpcReader.h
@@ -33,7 +33,7 @@ public:
     void start();
     void stop();
 
-signals:
+Q_SIGNALS:
     void readLogLine(const QString& text);
 
 private:

--- a/src/gui/src/KeySequenceWidget.h
+++ b/src/gui/src/KeySequenceWidget.h
@@ -29,7 +29,7 @@ class KeySequenceWidget : public QPushButton
     public:
         KeySequenceWidget(QWidget* parent, const KeySequence& seq = KeySequence());
 
-    signals:
+    Q_SIGNALS:
         void keySequenceChanged();
 
     public:

--- a/src/gui/src/SslCertificate.h
+++ b/src/gui/src/SslCertificate.h
@@ -31,7 +31,7 @@ public:
 public slots:
     void generateCertificate();
 
-signals:
+Q_SIGNALS:
     void error(QString e);
     void info(QString i);
     void generateFinished();

--- a/src/gui/src/ZeroconfBrowser.h
+++ b/src/gui/src/ZeroconfBrowser.h
@@ -39,7 +39,7 @@ public:
     inline QList<ZeroconfRecord> currentRecords() const { return m_Records; }
     inline QString serviceType() const { return m_BrowsingType; }
 
-signals:
+Q_SIGNALS:
     void currentRecordsChanged(const QList<ZeroconfRecord>& list);
     void error(DNSServiceErrorType err);
 

--- a/src/gui/src/ZeroconfRegister.h
+++ b/src/gui/src/ZeroconfRegister.h
@@ -43,7 +43,7 @@ public:
     void registerService(const ZeroconfRecord& record, quint16 servicePort);
     inline ZeroconfRecord registeredRecord() const { return finalRecord; }
 
-signals:
+Q_SIGNALS:
     void error(DNSServiceErrorType error);
     void serviceRegistered(const ZeroconfRecord& record);
 

--- a/src/gui/src/ZeroconfThread.h
+++ b/src/gui/src/ZeroconfThread.h
@@ -29,7 +29,7 @@ public:
 
     void run() override;
 
-signals:
+Q_SIGNALS:
     void error(QTcpSocket::SocketError socketError);
 
 private:


### PR DESCRIPTION
* [X] This is not a user-visible change
Replace all the `signals` with `Q_SIGNALS` in our Qt using headers