### PR TITLE
Make Qt6 the default

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Configure the build
         run: |
           cmake -DCMAKE_BUILD_TYPE="${B_BUILD_TYPE}" -S input-leap -B build \
+                -DQT_DEFAULT_MAJOR_VERSION=5 \
                 -DCMAKE_CXX_FLAGS:STRING="-Wall -Wextra -Wno-unused-parameter" \
                 -DCMAKE_CXX_FLAGS_DEBUG:STRING="-g -Werror" \
                 -DINPUTLEAP_BUILD_LIBEI:BOOL=${{ matrix.wayland }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 if(NOT QT_DEFAULT_MAJOR_VERSION)
-    set(QT_DEFAULT_MAJOR_VERSION 5)
+    set(QT_DEFAULT_MAJOR_VERSION 6)
 endif()
 
 include (cmake/Version.cmake)

--- a/dist/flatpak/com.github.input-leap.input-leaps.yml
+++ b/dist/flatpak/com.github.input-leap.input-leaps.yml
@@ -94,6 +94,7 @@ modules:
     - name: input-leap
       buildsystem: cmake
       config-opts:
+          - -DQT_DEFAULT_MAJOR_VERSION=5
           - -DINPUTLEAP_BUILD_GUI=OFF
           - -DINPUTLEAP_BUILD_TESTS=OFF
           - -DINPUTLEAP_BUILD_INSTALLER=OFF

--- a/dist/rpm/input-leap.spec.in
+++ b/dist/rpm/input-leap.spec.in
@@ -26,8 +26,9 @@ BuildRequires: libXtst-devel libXinerama-devel libXrandr-devel
 BuildRequires: libICE-devel libSM-devel
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
-BuildRequires: qt5-qtbase-devel
-BuildRequires: qt5-linguist
+BuildRequires: qt6-qtbase-devel
+BuildRequires: qt6-qttools-devel
+BuildRequires: qt6-qt5compat-devel
 BuildRequires: make
 %endif
 
@@ -43,13 +44,14 @@ BuildRequires: libXtst-devel libXinerama-devel libXrandr-devel
 BuildRequires: libICE-devel libSM-devel
 BuildRequires: libcurl-devel
 BuildRequires: libopenssl-devel
-BuildRequires: libqt5-qtbase-devel
-BuildRequires: libqt5-linguist libqt5-linguist-devel
+BuildRequires: qt6-base-devel
+BuildRequires: qt6-qt5compat-devel
+BuildRequires: qt6-linguist-devel
 BuildRequires: make
 
 Requires: libc libstdc++ libgcc_s1
 Requires: libdns_sd
-Requires: libQt5Core5 libQt5Gui5 libQt5Network5 libQt5Widgets5
+Requires: libQt5Core6 libQt5Gui6 libQt5Network6 libQt5Widgets6 libQt6Core5Compat6
 Requires: libopenssl3
 Requires: libX11-6 libXext6 libXinerama1 libXrandr2 libXtst6
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,7 @@ parts:
     source-type: git
     plugin: cmake
     configflags:
+      - "-DQT_DEFAULT_MAJOR_VERSION=5"
       - "-DCMAKE_INSTALL_PREFIX=/usr"
       - "-DCMAKE_BUILD_TYPE=Release"
     build-packages:


### PR DESCRIPTION
## Contributor Checklist
 * [ ] This is a user-visible change and I have created a file in the doc/newsfragments directory (and made sure to read the README.md in that directory)
* [x] This is not a user-visible change

- Build with Qt6 by default
- Does not change snap or flatpak formulas
