### PR TITLE
lib: drop raw protocol write/read messages to DEBUG5

### DIFF
--- a/src/lib/inputleap/ProtocolUtil.cpp
+++ b/src/lib/inputleap/ProtocolUtil.cpp
@@ -33,7 +33,7 @@ ProtocolUtil::writef(inputleap::IStream* stream, const char* fmt, ...)
 {
     assert(stream != nullptr);
     assert(fmt != nullptr);
-    LOG_DEBUG2("writef(%s)", fmt);
+    LOG_DEBUG5("writef(%s)", fmt);
 
     va_list args;
     va_start(args, fmt);
@@ -49,7 +49,7 @@ ProtocolUtil::readf(inputleap::IStream* stream, const char* fmt, ...)
 {
     assert(stream != nullptr);
     assert(fmt != nullptr);
-    LOG_DEBUG2("readf(%s)", fmt);
+    LOG_DEBUG5("readf(%s)", fmt);
 
     bool result;
     va_list args;
@@ -83,7 +83,7 @@ void ProtocolUtil::vwritef(inputleap::IStream* stream, const char* fmt, std::uin
     try {
         // write buffer
         stream->write(buffer, size);
-        LOG_DEBUG2("wrote %d bytes", size);
+        LOG_DEBUG5("wrote %d bytes", size);
 
         delete[] buffer;
     }
@@ -120,7 +120,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                 case 1:
                     // 1 byte integer
                     *static_cast<std::uint8_t*>(v) = buffer[0];
-                    LOG_DEBUG2("readf: read %d byte integer: %d (0x%x)", len,
+                    LOG_DEBUG5("readf: read %d byte integer: %d (0x%x)", len,
                          *static_cast<std::uint8_t*>(v), *static_cast<std::uint8_t*>(v));
                     break;
 
@@ -130,7 +130,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         static_cast<std::uint16_t>(
                         (static_cast<std::uint16_t>(buffer[0]) << 8) |
                          static_cast<std::uint16_t>(buffer[1]));
-                    LOG_DEBUG2("readf: read %d byte integer: %d (0x%x)", len,
+                    LOG_DEBUG5("readf: read %d byte integer: %d (0x%x)", len,
                          *static_cast<std::uint16_t*>(v), *static_cast<std::uint16_t*>(v));
                     break;
 
@@ -141,7 +141,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         (static_cast<std::uint32_t>(buffer[1]) << 16) |
                         (static_cast<std::uint32_t>(buffer[2]) <<  8) |
                          static_cast<std::uint32_t>(buffer[3]);
-                    LOG_DEBUG2("readf: read %d byte integer: %d (0x%x)", len,
+                    LOG_DEBUG5("readf: read %d byte integer: %d (0x%x)", len,
                          *static_cast<std::uint32_t*>(v), *static_cast<std::uint32_t*>(v));
                     break;
                 default:
@@ -175,7 +175,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                         read(stream, buffer, 1);
                         static_cast<std::vector<std::uint8_t>*>(v)->push_back(
                             buffer[0]);
-                        LOG_DEBUG2("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG_DEBUG5("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint8_t>*>(v)->back(),
                              static_cast<std::vector<std::uint8_t>*>(v)->back());
                     }
@@ -189,7 +189,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                             static_cast<std::uint16_t>(
                             (static_cast<std::uint16_t>(buffer[0]) << 8) |
                              static_cast<std::uint16_t>(buffer[1])));
-                        LOG_DEBUG2("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG_DEBUG5("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint16_t>*>(v)->back(),
                              static_cast<std::vector<std::uint16_t>*>(v)->back());
                     }
@@ -204,7 +204,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                             (static_cast<std::uint32_t>(buffer[1]) << 16) |
                             (static_cast<std::uint32_t>(buffer[2]) <<  8) |
                              static_cast<std::uint32_t>(buffer[3]));
-                        LOG_DEBUG2("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
+                        LOG_DEBUG5("readf: read %d byte integer[%d]: %d (0x%x)", len, i,
                              static_cast<std::vector<std::uint32_t>*>(v)->back(),
                              static_cast<std::vector<std::uint32_t>*>(v)->back());
                     }
@@ -250,7 +250,7 @@ ProtocolUtil::vreadf(inputleap::IStream* stream, const char* fmt, va_list args)
                     throw;
                 }
 
-                LOG_DEBUG2("readf: read %d byte string", str_len);
+                LOG_DEBUG5("readf: read %d byte string", str_len);
 
                 // save the data
                 std::string* dst = va_arg(args, std::string*);


### PR DESCRIPTION
These are quite noisy and by the time we have errors in the actual protocol mapping we should have ruled out anything above already.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change
