### PR TITLE
Deployment on Linux: Avoid deploying Flatpak file unless in a Flatpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ option(INPUTLEAP_BUILD_TESTS "Build the tests" ON)
 option(INPUTLEAP_USE_EXTERNAL_GTEST "Use external installation of Google Test framework" OFF)
 option(INPUTLEAP_BUILD_X11 "Build with XWindows support" ON)
 option(INPUTLEAP_BUILD_LIBEI "Build with libei support" OFF)
-
+option(INPUTLEAP_DEPLOY_FLATPAK_SCRIPT "Deploy Flatpak script [Expermental]" OFF)
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CXX_EXTENSIONS OFF)
@@ -199,10 +199,13 @@ if (UNIX)
             " HAVE_LIBPORTAL_OUTPUT_NONE)
             cmake_pop_check_state()
 
-            # Flatpak bits
-            install(FILES "dist/flatpak/input-leap-flatpak"
-                    DESTINATION bin
-                    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+            if(INPUTLEAP_DEPLOY_FLATPAK_SCRIPT)
+                # Flatpak bits
+                install(FILES "dist/flatpak/input-leap-flatpak"
+                        DESTINATION bin
+                        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+                )
+            endif()
         endif()
 
         check_include_files ("dns_sd.h" HAVE_DNSSD)


### PR DESCRIPTION
Split from #1846 

 - Add Configuration option `INPUTLEAP_DEPLOY_FLATPAK_SCRIPT` (default: OFF) to control if the `dist/flatpak/input-leap-flatpak` is installed.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change