### PR TITLE
x11: log a warning if we're running against Xwayland

### DIFF
--- a/doc/newsfragments/warn-on-xwayland.feature
+++ b/doc/newsfragments/warn-on-xwayland.feature
@@ -1,0 +1,1 @@
+InputLeap now warns when connecting to Xwayland.

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -118,6 +118,8 @@ XWindowsScreen::XWindowsScreen(
                                              m_keyMap);
 		LOG_DEBUG("screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_xinerama ? "(xinerama)" : "");
 		LOG_DEBUG("window is 0x%08lx", m_window);
+        if (detectXwayland())
+            LOG_WARN("Running against Xwayland. InputLeap will not work as expected");
 	}
 	catch (...) {
         if (m_display != nullptr) {
@@ -2023,6 +2025,14 @@ XWindowsScreen::detectXI2()
 	int event, error;
     return m_impl->XQueryExtension(m_display,
 			"XInputExtension", &xi_opcode, &event, &error);
+}
+
+bool
+XWindowsScreen::detectXwayland()
+{
+    int opcode, event, error;
+    return m_impl->XQueryExtension(m_display, "XWAYLAND",
+                                   &opcode, &event, &error);
 }
 
 void

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -143,6 +143,7 @@ private:
     int y_accumulateMouseScroll(std::int32_t yDelta) const;
 
     bool detectXI2();
+    bool detectXwayland();
     void selectXIRawMotion();
     void selectEvents(Window) const;
     void doSelectEvents(Window) const;


### PR DESCRIPTION
Check if the XWAYLAND extension is available and if so, print a warning. This extension is available in xwayland 23.1.0 and later.

Two comments on the patch:
- the indentation in this file is all over the place with a 50/50 split between tabs and spaces, I stuck with spaces (because `.editorconfig` says so)
- there are heuristics for checking for xwayland (output names, xinput device names) but the extension is the only guaranteed reliable one. It's relatively new but the majority of systems that switch to wayland will also have a relatively new xwayland so I think it's easier to just stick with the simpler call.



## Contributor Checklist:

* [x] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This is not a user-visible change
