### PR TITLE
Don't use a hidden file for the config on linux

### DIFF
--- a/doc/input-leaps.1
+++ b/doc/input-leaps.1
@@ -71,7 +71,7 @@ interfaces using port number 24800.
 If no configuration file pathname is provided then the first of the
 following to load successfully sets the configuration:
 .IP
-.I $HOME/.local/share/input-leap/.input-leap.conf
+.I $HOME/.config/InputLeap/input-leap.conf
 .br
 .I /etc/input-leap.conf
 .SH COPYRIGHT

--- a/src/lib/common/unix/DataDirectories.cpp
+++ b/src/lib/common/unix/DataDirectories.cpp
@@ -65,10 +65,10 @@ static fs::path profile_basedir()
 #if defined(WINAPI_XWINDOWS) || defined(WINAPI_LIBEI)
     // linux/bsd adheres to freedesktop standards
     // https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-    const char* dir = std::getenv("XDG_DATA_HOME");
+    const char* dir = std::getenv("XDG_CONFIG_HOME");
     if (dir != nullptr)
         return fs::u8path(dir);
-    return unix_home() / ".local/share";
+    return unix_home() / ".config/";
 #else
     // macos has its own standards
     // https://developer.apple.com/library/content/documentation/General/Conceptual/MOSXAppProgrammingGuide/AppRuntime/AppRuntime.html

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -118,9 +118,9 @@ ServerApp::help()
         profile_path = inputleap::DataDirectories::profile();
     }
 
-    auto usr_config_path = (profile_path / inputleap::fs::u8path(USR_CONFIG_NAME)).u8string();
+    auto usr_config_path = (profile_path / inputleap::fs::u8path(CONFIG_NAME)).u8string();
     auto sys_config_path = (inputleap::DataDirectories::systemconfig() /
-                            inputleap::fs::u8path(SYS_CONFIG_NAME)).u8string();
+                            inputleap::fs::u8path(CONFIG_NAME)).u8string();
 
     std::ostringstream buffer;
     buffer << "Start the InputLeap server component. The server shares the keyboard &\n"
@@ -208,7 +208,7 @@ ServerApp::loadConfig()
         auto path = inputleap::DataDirectories::profile();
         if (!path.empty()) {
             // complete path
-            path /= inputleap::fs::u8path(USR_CONFIG_NAME);
+            path /= inputleap::fs::u8path(CONFIG_NAME);
 
             // now try loading the user's configuration
             if (loadConfig(path.u8string())) {
@@ -220,7 +220,7 @@ ServerApp::loadConfig()
             // try the system-wide config file
             path = inputleap::DataDirectories::systemconfig();
             if (!path.empty()) {
-                path /= inputleap::fs::u8path(SYS_CONFIG_NAME);
+                path /= inputleap::fs::u8path(CONFIG_NAME);
                 if (loadConfig(path.u8string())) {
                     loaded            = true;
                     args().m_configFile = path.u8string();

--- a/src/lib/inputleap/ServerApp.h
+++ b/src/lib/inputleap/ServerApp.h
@@ -118,11 +118,9 @@ private:
 
 // configuration file name
 #if SYSAPI_WIN32
-#define USR_CONFIG_NAME "input-leap.sgc"
-#define SYS_CONFIG_NAME "input-leap.sgc"
+#define CONFIG_NAME "input-leap.sgc"
 #elif SYSAPI_UNIX
-#define USR_CONFIG_NAME ".input-leap.conf"
-#define SYS_CONFIG_NAME "input-leap.conf"
+#define CONFIG_NAME "input-leap.conf"
 #endif
 
 } // namespace inputleap


### PR DESCRIPTION
Unify `USR_CONFIG_NAME` and `SYS_CONFIG_NAME` into one new `CONFIG_NAME`. This moves the USER based config from `$HOME/.local/share/input-leap/.input-leap.conf` -> `$HOME/.config/Inputleap/input-leap.conf`

Fixes #1851  by correcting the path in the manual.
