### PR TITLE
Update `doc/input-leap.conf.example-advanced` to match top comment

### DIFF
--- a/doc/input-leap.conf.example-advanced
+++ b/doc/input-leap.conf.example-advanced
@@ -27,23 +27,17 @@ section: screens
 end
 
 section: links
-	# larry is to the right of moe and curly is above moe
-	moe:
-		right = larry
-		up    = curly
+	desktop1:
+		top = desktop2 (0, 50)
+		right = desktop2 (50, 100)
+		left = laptop
 
-	# moe is to the left of larry and curly is above larry.
-	# note that curly is above both moe and larry and moe
-	# and larry have a symmetric connection (they're in
-	# opposite directions of each other).
-	larry:
-		left  = moe
-		up    = curly
+	desktop2:
+		bottom (0, 50) = desktop1
+		left (50, 100) = desktop1
 
-	# larry is below curly.  if you move up from moe and then
-	# down, you'll end up on larry.
-	curly:
-		down  = larry
+	laptop:
+		right = desktop1
 end
 
 # The aliases section is to map the full names of the computers to their logical names used in the screens section
@@ -51,5 +45,5 @@ end
 section: aliases
 	# Laptop is actually known as John-Smiths-MacBook-3.local
 	John-Smiths-MacBook-3.local:
-		desktop2
+		laptop
 end

--- a/doc/newsfragments/fix-advanced-example.doc
+++ b/doc/newsfragments/fix-advanced-example.doc
@@ -1,0 +1,1 @@
+Fixed `input-leap.conf.example-advanced` to accurately include the advanced configuration described in/intended by the comment within it.


### PR DESCRIPTION
This looks like it was a WIP that got committed a long time ago but never finished, so I've filled out the configuration matching the top comment's setup description to the best of my knowledge.

(See also https://github.com/input-leap/input-leap/discussions/1899)

## Contributor Checklist:

* [x] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This is not a user-visible change
