### PR TITLE
Update clean_build.sh to use xcrun rather than xcode-select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ CMakeLists.txt.user
 # Transient in-project-directory dependencies
 /deps/
 /out/build/x64-Debug
+bundle
+compile_commands.json

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -18,7 +18,7 @@ B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"
 if [ "$(uname)" = "Darwin" ]; then
     # macOS needs a little help, so we source this environment script to fix paths.
     [ -e ./macos_environment.sh ] && . ./macos_environment.sh
-    B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
+    B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
 fi
 
 # Prefer ninja if available


### PR DESCRIPTION
On Sonoma 14.4.1 I was not able to build without making this change because the SDK path was wrong. xcrun is provided by xcode and gives an exact path to the SDK. This should prevent similar issues in the future.

I also updated the gitignore because I noticed a couple files being generated that don't seem like they should be checked in to git.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change

