### PR TITLE
`README.md`: Added a note on how to obtain test builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ and how the issue gets resolved.
 
 ### Usage
 
+> [!WARNING]
+> Currently, there are no stable builds (binary releases) for Input Leap yet.
+> 
+> However, **test** builds _(also called debug build artifacts)_ are available
+> via [GitHub Actions](https://github.com/input-leap/input-leap/actions?query=branch%3Amaster),
+> as described in [this discussions post](https://github.com/input-leap/input-leap/discussions/1793#discussioncomment-8577620).
+
 1. Install and run Input Leap on each machine that will be sharing.
 2. On the machine with the keyboard and mouse, make it the server.
 3. Click the "Configure server" button and drag a new screen onto the grid for

--- a/doc/newsfragments/1911-builds_note_in_readme.doc
+++ b/doc/newsfragments/1911-builds_note_in_readme.doc
@@ -1,0 +1,1 @@
+Added a note in README.md on how to obtain test builds.


### PR DESCRIPTION
Added a note in `README.md` on how to obtain test builds.

## Contributor Checklist:

* [x] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This is not a user-visible change
