### PR TITLE
feat: Add support for an 'uninstall' target to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,21 @@ else()
     message (STATUS "NOT configuring the installer")
 endif()
 
+#
+# Uninstall target
+#
+
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
 enable_testing()
 
 add_subdirectory (src)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" -E remove "$ENV{DESTDIR}${file}"
+      RESULT_VARIABLE rm_retval
+      OUTPUT_VARIABLE rm_out
+    )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/doc/newsfragments/1913-uninstall-target.feature
+++ b/doc/newsfragments/1913-uninstall-target.feature
@@ -1,0 +1,4 @@
+Create an `uninstall` target for Makefiles
+
+This allows for developers (or users who are testing) to remove Input Leap from
+their system, based on `$PREFIX`.


### PR DESCRIPTION
This works with Make and Ninja.

## Contributor Checklist:

* [x] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This is not a user-visible change
