### PR TITLE
Check for deprecated Qt5 stuff when using Qt6

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -315,6 +315,7 @@ void MainWindow::loadSettings()
 void MainWindow::initConnections()
 {
     connect(ui_->m_pActionMinimize, &QAction::triggered, this, &MainWindow::hide);
+    connect(ui_->m_pComboServerList, &QComboBox::currentTextChanged, this, &MainWindow::comboServerList_currentIndexChanged);
     connect(ui_->m_pActionRestore, &QAction::triggered, this, &MainWindow::showNormal);
     connect(ui_->m_pActionStartCmdApp, &QAction::triggered, this, &MainWindow::start_cmd_app);
     connect(ui_->m_pActionStopCmdApp, &QAction::triggered, this, &MainWindow::stop_cmd_app);
@@ -1380,7 +1381,7 @@ void MainWindow::promptAutoConfig()
     m_AppConfig->setAutoConfigPrompted(true);
 }
 
-void MainWindow::on_m_pComboServerList_currentIndexChanged(QString )
+void MainWindow::comboServerList_currentIndexChanged(QString )
 {
     if (ui_->m_pComboServerList->count() != 0) {
         restart_cmd_app();

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -198,7 +198,7 @@ public slots:
 
 private slots:
     void on_m_pCheckBoxAutoConfig_toggled(bool checked);
-    void on_m_pComboServerList_currentIndexChanged(QString );
+    void comboServerList_currentIndexChanged(QString );
     void on_m_pButtonReload_clicked();
     void installBonjour();
 

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -163,9 +163,13 @@ QDataStream& operator>>(QDataStream& inStream, Screen& screen)
         ;
 
     screen.m_Modifiers.clear();
-    for (auto mod : qAsConst(modifiers)) {
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+    auto const mods = std::as_const(modifiers);
+#else
+    auto const mods = qAsConst(modifiers);
+#endif
+    for (auto mod : mods) {
         screen.m_Modifiers.push_back(static_cast<Screen::Modifier>(mod));
     }
-
     return inStream;
 }

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -171,9 +171,13 @@ void ScreenSetupView::dragMoveEvent(QDragMoveEvent* event)
         }
         else
         {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            int col = columnAt(event->position().x());
+            int row = rowAt(event->position().y());
+#else
             int col = columnAt(event->pos().x());
             int row = rowAt(event->pos().y());
-
+#endif
             // a drop from outside is not allowed if there's a screen already there.
             if (!model()->screen(col, row).isNull())
                 event->ignore();


### PR DESCRIPTION
## Contributor Checklist
 * [ ] This is a user-visible change and I have created a file in the doc/newsfragments directory (and made sure to read the README.md in that directory)
* [x] This is not a user-visible change

Guard deprecated Qt methods in Qt6 
 - Guard deprecated `QEvent::pos`for Qt6 builds
 - Use std::as_const
 - fix broken autoconnected method in mainwindow 
