### PR TITLE
libei: Fixed small mouse movements

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -695,10 +695,18 @@ void EiScreen::on_motion_event(ei_event* event)
          }
 #endif
     } else {
-        LOG_DEBUG("on_motion_event on secondary at (dx,dy)=(%.2f,%.2f)", dx, dy);
-        send_event(EventType::PRIMARY_SCREEN_MOTION_ON_SECONDARY,
-                   create_event_data<MotionInfo>(MotionInfo{static_cast<std::int32_t>(dx),
-                                                            static_cast<std::int32_t>(dy)}));
+        buffer_dx += dx;
+        buffer_dy += dy;
+        auto pixel_dx = static_cast<std::int32_t>(buffer_dx);
+        auto pixel_dy = static_cast<std::int32_t>(buffer_dy);
+        LOG_DEBUG2("on_motion_event(buffer) on secondary at (dx,dy)=(%0.2f,%0.2f)", buffer_dx, buffer_dy);
+        if (pixel_dx || pixel_dy) {
+            LOG_DEBUG("on_motion_event on secondary at (dx,dy)=(%d,%d)", pixel_dx, pixel_dy);
+            send_event(EventType::PRIMARY_SCREEN_MOTION_ON_SECONDARY,
+                       create_event_data<MotionInfo>(MotionInfo{pixel_dx, pixel_dy}));
+            buffer_dx -= pixel_dx;
+            buffer_dy -= pixel_dy;
+        }
     }
 }
 

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -158,6 +158,9 @@ private:
     std::int32_t cursor_x_ = 0;
     std::int32_t cursor_y_ = 0;
 
+    double buffer_dx = 0;
+    double buffer_dy = 0;
+
     mutable std::mutex mutex_;
 
     PortalRemoteDesktop* portal_remote_desktop_ = nullptr;


### PR DESCRIPTION
When moving sub low pixels of delta on libei, we should buffer the output so that these small movements are accumulated.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change
