### PR TITLE
fix(macOS): Add check for `macos_environment.sh` in build script

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -17,7 +17,7 @@ B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"
 
 if [ "$(uname)" = "Darwin" ]; then
     # macOS needs a little help, so we source this environment script to fix paths.
-    . ./macos_environment.sh
+    [ -e ./macos_environment.sh ] && . ./macos_environment.sh
     B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
 fi
 


### PR DESCRIPTION
`macos_environment.sh` reference in `clean_build.sh` caused a build error.

This fix allows for `macos_environment.sh` to be sourced, if it exists. If not, it doesn't error out.

Related: #1846.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change
