### PR TITLE
ei: ifdef out support for remote desktop session restore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,14 +184,15 @@ if (UNIX)
             include_directories(${LIBEI_INCLUDE_DIRS} ${LIBXKBCOMMON_INCLUDE_DIRS} ${GLIB2_INCLUDE_DIRS} ${LIBPORTAL_INCLUDE_DIRS} ${LIBM_INCLUDE_DIRS})
             list(APPEND libs ${LIBEI_LINK_LIBRARIES} ${LIBXKBCOMMON_LINK_LIBRARIES} ${GLIB2_LINK_LIBRARIES} ${LIBPORTAL_LINK_LIBRARIES} ${LIBM_LIBRARIES})
 
-            # no libportal release has xdp_session_connect_to_eis, so let's check for that
-            # and enable the hackaround in the code
+            # libportal 0.7 has xdp_session_connect_to_eis but it doesn't have remote desktop session restore or
+            # the inputcapture code, so let's check for explicit functions that bits depending on what we have
             include(CMakePushCheckState)
             include(CheckCXXSourceCompiles)
             cmake_push_check_state(RESET)
             set(CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES};${LIBPORTAL_INCLUDE_DIRS};${GLIB2_INCLUDE_DIRS}")
             set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES};${LIBPORTAL_LINK_LIBRARIES};${GLIB2_LINK_LIBRARIES}")
             check_symbol_exists(xdp_session_connect_to_eis "libportal/portal.h" HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS)
+            check_symbol_exists(xdp_portal_create_remote_desktop_session_full "libportal/portal.h" HAVE_LIBPORTAL_CREATE_REMOTE_DESKTOP_SESSION_FULL)
             check_symbol_exists(xdp_input_capture_session_connect_to_eis "libportal/inputcapture.h" HAVE_LIBPORTAL_INPUTCAPTURE)
             # check_symbol_exists can’t check for enum values
             check_cxx_source_compiles("#include <libportal/portal.h>

--- a/res/config.h.in
+++ b/res/config.h.in
@@ -31,6 +31,9 @@
 /* Define if libportal has xdp_session_connect_to_eis */
 #cmakedefine HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS ${HAVE_LIBPORTAL_SESSION_CONNECT_TO_EIS}
 
+/* Define if libportal has xdp_portal_create_remote_desktop_session_full */
+#cmakedefine HAVE_LIBPORTAL_CREATE_REMOTE_DESKTOP_SESSION_FULL ${HAVE_LIBPORTAL_CREATE_REMOTE_DESKTOP_SESSION_FULL}
+
 /* Define if libportal has inputcapture support */
 #cmakedefine HAVE_LIBPORTAL_INPUTCAPTURE ${HAVE_LIBPORTAL_INPUTCAPTURE}
 

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -158,6 +158,26 @@ void PortalRemoteDesktop::cb_init_remote_desktop_session(GObject* object, GAsync
                       this);
 }
 
+#if !defined(HAVE_LIBPORTAL_CREATE_REMOTE_DESKTOP_SESSION_FULL)
+static inline void
+xdp_portal_create_remote_desktop_session_full(XdpPortal              *portal,
+                                              XdpDeviceType           devices,
+                                              XdpOutputType           outputs,
+                                              XdpRemoteDesktopFlags   flags,
+                                              XdpCursorMode           cursor_mode,
+                                              XdpPersistMode          _unused1,
+                                              const char             *_unused2,
+                                              GCancellable           *cancellable,
+                                              GAsyncReadyCallback     callback,
+                                              gpointer                data)
+{
+    xdp_portal_create_remote_desktop_session(portal, devices, outputs,
+                                             flags, cursor_mode, cancellable,
+                                             callback, data);
+}
+#endif
+
+
 gboolean PortalRemoteDesktop::init_remote_desktop_session()
 {
     LOG_DEBUG("Setting up the RemoteDesktop session with restore token %s", session_restore_token_);


### PR DESCRIPTION
This was added after the 0.7 release which means we have users that have xdp_session_connect_to_eis but not xdp_portal_create_remote_desktop_session_full, causing build errors.

Let's ifdef this out and create a thin wrapper around the older xdp_portal_create_remote_desktop_session which doesn't handle the restore token. This way we get back to the behavior before b3308fc505d3 ("ei: Try to restore RemoteDesktop sessions when we lose them")

Closes #1912

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change


---

Warning: compile-tested only, sorry, I'm seriously ETIME today