### PR TITLE
Fix x86_64 mac builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -174,7 +174,7 @@ jobs:
       matrix:
        include:
          - name: macOS-x86_64
-           os: macos-11
+           os: macos-12
            qt-version: 5.15
            min-macOS-version: 10.9
            arch: 'x86_64'


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change

Github no longer has macos-11 runners so we must build x86-64 mac using macos-12