### PR TITLE
flatpak: Update manifest

### DIFF
--- a/dist/flatpak/com.github.input-leap.input-leaps.yml
+++ b/dist/flatpak/com.github.input-leap.input-leaps.yml
@@ -10,9 +10,9 @@
 # https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1013
 
 app-id: com.github.inputleap.InputLeap
-runtime: org.gnome.Platform
-runtime-version: '42'
-sdk: org.gnome.Sdk
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
 command: input-leap-flatpak
 
 finish-args:
@@ -28,12 +28,15 @@ finish-args:
     - --nosocket=wayland
 
 modules:
+    - python3-attrs.json
+    - python3-jinja2.json
+
     - name: libei
       buildsystem: meson
       config-opts:
-          - -Ddocumentation=false
-          - -Dtests=false
-          - -Dportal=false  # wrong portal for our use
+          - -Ddocumentation=[]
+          - -Dliboeffis=disabled
+          - -Dtests=disabled
       sources:
           - type: git
             url: https://gitlab.freedesktop.org/libinput/libei
@@ -85,7 +88,6 @@ modules:
           - -Dtests=false
           - -Dportal-tests=false
           - -Dvapi=false
-          - -Dbackends=gtk4
       sources:
           - type: git
             url: https://github.com/whot/libportal
@@ -94,15 +96,16 @@ modules:
     - name: input-leap
       buildsystem: cmake
       config-opts:
-          - -DQT_DEFAULT_MAJOR_VERSION=5
+          - -DQT_DEFAULT_MAJOR_VERSION=6
           - -DINPUTLEAP_BUILD_GUI=OFF
           - -DINPUTLEAP_BUILD_TESTS=OFF
           - -DINPUTLEAP_BUILD_INSTALLER=OFF
+          - -DINPUTLEAP_DEPLOY_FLATPAK_SCRIPT=TRUE
           - -DINPUTLEAP_BUILD_X11=ON  # FIXME: undefined reference to `XWindowsUtil::mapKeySymToKeyID otherwise
           - -DINPUTLEAP_BUILD_LIBEI=ON
       sources:
           - type: git
-            url: https://github.com/whot/input-leap
-            branch: wip/libei
+            url: https://github.com/input-leap/input-leap
+            branch: master
 
 #

--- a/dist/flatpak/python3-attrs.json
+++ b/dist/flatpak/python3-attrs.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-attrs",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"attrs\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl",
+            "sha256": "81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"
+        }
+    ]
+}

--- a/dist/flatpak/python3-jinja2.json
+++ b/dist/flatpak/python3-jinja2.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-jinja2",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"jinja2\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz",
+            "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl",
+            "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+        }
+    ]
+}


### PR DESCRIPTION
Update the input-leap flatpak manifest so that current input-leap and dependencies (including libei) can build.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change

/cc @whot 