### PR TITLE
build: Remove unneed Qt5Compat dependency

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -183,13 +183,11 @@ jobs:
            os: macos-12
            qt-version: 6.6
            min-macOS-version: 11
-           qt-modules: qt5compat
            arch: 'arm64;x86_64'
          - name: macOS-Apple_Silicon
            os: macos-14
            qt-version: 6.6
            min-macOS-version: 14
-           qt-modules: qt5compat
            arch: 'arm64'
 
     env:
@@ -289,7 +287,6 @@ jobs:
            os: windows-2022
            qt-version: 6.6
            qt-major: 6
-           qt-modules: qt5compat
 
     steps:
       - uses: actions/checkout@v4

--- a/dist/rpm/input-leap.spec.in
+++ b/dist/rpm/input-leap.spec.in
@@ -28,7 +28,6 @@ BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 BuildRequires: qt6-qtbase-devel
 BuildRequires: qt6-qttools-devel
-BuildRequires: qt6-qt5compat-devel
 BuildRequires: make
 %endif
 
@@ -45,13 +44,12 @@ BuildRequires: libICE-devel libSM-devel
 BuildRequires: libcurl-devel
 BuildRequires: libopenssl-devel
 BuildRequires: qt6-base-devel
-BuildRequires: qt6-qt5compat-devel
 BuildRequires: qt6-linguist-devel
 BuildRequires: make
 
 Requires: libc libstdc++ libgcc_s1
 Requires: libdns_sd
-Requires: libQt5Core6 libQt5Gui6 libQt5Network6 libQt5Widgets6 libQt6Core5Compat6
+Requires: libQt5Core6 libQt5Gui6 libQt5Network6 libQt5Widgets6
 Requires: libopenssl3
 Requires: libX11-6 libXext6 libXinerama1 libXrandr2 libXtst6
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,10 +1,6 @@
 
 find_package (Qt${QT_DEFAULT_MAJOR_VERSION} ${REQUIRED_QT_VERSION} COMPONENTS Core Widgets Network LinguistTools REQUIRED)
 
-if (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
-    find_package (Qt6 REQUIRED COMPONENTS Core5Compat)
-endif()
-
 message(STATUS "Using Qt ${QT_DEFAULT_MAJOR_VERSION}")
 
 set (CMAKE_AUTOMOC ON)
@@ -204,9 +200,6 @@ target_link_libraries(input-leap
     Qt${QT_DEFAULT_MAJOR_VERSION}::Network
 )
 
-if (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
-    target_link_libraries(input-leap Qt::Core5Compat)
-endif()
 target_link_libraries(input-leap OpenSSL::SSL OpenSSL::Crypto)
 
 target_compile_definitions (input-leap PRIVATE -DINPUTLEAP_VERSION_STAGE="${INPUTLEAP_VERSION_STAGE}")
@@ -274,7 +267,4 @@ if(INPUTLEAP_BUILD_TESTS)
 
     target_include_directories(guiunittests PUBLIC ../../ext)
     target_link_libraries(guiunittests gtest gmock Qt${QT_DEFAULT_MAJOR_VERSION}::Core Qt${QT_DEFAULT_MAJOR_VERSION}::Widgets Qt${QT_DEFAULT_MAJOR_VERSION}::Network ${libs})
-    if (QT_DEFAULT_MAJOR_VERSION EQUAL 6)
-        target_link_libraries(guiunittests Qt::Core5Compat)
-    endif()
 endif()


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [X] This is not a user-visible change

Turns out we are not really using anything from the `Qt5Compat` module so it is no longer a dependency.