### PR TITLE
ci: use libei 1.3.0

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -103,15 +103,15 @@ jobs:
           submodules: recursive
           set-safe-directory: ${{ github.workspace }}
 
-      - name: Get libei v1.2.1 from freedesktop
-        # Manual checkout of libinput/libei ref 1.2.1 from https://gitlab.freedesktop.org
+      - name: Get libei v1.3.0 from freedesktop
+        # Manual checkout of libinput/libei ref 1.3.0 from https://gitlab.freedesktop.org
         # because actions/checkout does not support gitlab
         if: matrix.wayland
         run: |
           git clone --depth=1 --branch="$ref" --recurse-submodules -- \
             "https://gitlab.freedesktop.org/libinput/libei" libei
         env:
-          ref: 1.2.1
+          ref: 1.3.0
 
       - name: Get libportal from upstream
         uses: actions/checkout@v4

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora:39", "opensuse/tumbleweed"]
+        os: ["fedora:40", "opensuse/tumbleweed"]
         include:
           - installer: dnf install -y
             rpm_tag: fedora


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [X] This is not a user-visible change
 - CI: to use libEi 1.3.0 (ubuntu) 
 - CI: Use fedora 40 