### PR TITLE
fix: stuck keys on client

### DIFF
--- a/src/lib/inputleap/IPlatformScreen.h
+++ b/src/lib/inputleap/IPlatformScreen.h
@@ -64,12 +64,19 @@ public:
 
     //! Leave screen
     /*!
-    Called when the user navigates off the screen.  Returns true on
-    success, false on failure.  A typical reason for failure is being
+    Called when the user navigates off the screen.  Returns true if
+    the leave can proceed.  A typical reason for failure is being
     unable to install the keyboard and mouse snoopers on a primary
     screen.  Secondary screens should not fail.
     */
-    virtual bool leave() = 0;
+    virtual bool canLeave() = 0;
+
+    //! Leave screen
+    /*!
+    Called when the user navigates off the screen.  Should be gated
+    by canLeave().
+    */
+    virtual void leave() = 0;
 
     //! Set clipboard
     /*!

--- a/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
+++ b/src/lib/inputleap/PlatformScreenLoggingWrapper.cpp
@@ -41,11 +41,16 @@ void PlatformScreenLoggingWrapper::enter()
     screen_->enter();
 }
 
-bool PlatformScreenLoggingWrapper::leave()
+bool PlatformScreenLoggingWrapper::canLeave()
 {
-    auto result = screen_->leave();
-    LOG_DEBUG1("PlatformScreen::leave() => %d", result);
+    auto result = screen_->canLeave();
+    LOG_DEBUG1("PlatformScreen::canLeave() => %d", result);
     return result;
+}
+
+void PlatformScreenLoggingWrapper::leave()
+{
+    LOG_DEBUG1("PlatformScreen::leave()");
 }
 
 bool PlatformScreenLoggingWrapper::setClipboard(ClipboardID id, const IClipboard* clipboard)

--- a/src/lib/inputleap/PlatformScreenLoggingWrapper.h
+++ b/src/lib/inputleap/PlatformScreenLoggingWrapper.h
@@ -30,7 +30,8 @@ public:
     void enable() override;
     void disable() override;
     void enter() override;
-    bool leave() override;
+    bool canLeave() override;
+    void leave() override;
     bool setClipboard(ClipboardID id, const IClipboard* clipboard) override;
     void checkClipboards() override;
     void openScreensaver(bool notify) override;

--- a/src/lib/inputleap/Screen.cpp
+++ b/src/lib/inputleap/Screen.cpp
@@ -122,9 +122,10 @@ Screen::leave()
     assert(m_entered == true);
     LOG_INFO("leaving screen");
 
-    if (!m_screen->leave()) {
+    if (!m_screen->canLeave()) {
         return false;
     }
+
     if (m_isPrimary) {
         leavePrimary();
     }
@@ -132,6 +133,7 @@ Screen::leave()
         leaveSecondary();
     }
 
+    m_screen->leave();
     // make sure our idea of clipboard ownership is correct
     m_screen->checkClipboards();
 

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -353,7 +353,11 @@ void EiScreen::enter()
 #endif
 }
 
-bool EiScreen::leave()
+bool EiScreen::canLeave() {
+    return true;
+}
+
+void EiScreen::leave()
 {
     if (!is_primary_) {
         if (ei_pointer_) {
@@ -368,7 +372,6 @@ bool EiScreen::leave()
     }
 
     is_on_screen_ = false;
-    return true;
 }
 
 bool EiScreen::setClipboard(ClipboardID id, const IClipboard* clipboard)

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -76,7 +76,8 @@ public:
     void enable() override;
     void disable() override;
     void enter() override;
-    bool leave() override;
+    bool canLeave() override;
+    void leave() override;
     bool setClipboard(ClipboardID, const IClipboard*) override;
     void checkClipboards() override;
     void openScreensaver(bool notify) override;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -301,8 +301,19 @@ MSWindowsScreen::enter()
     forceShowCursor();
 }
 
-bool
-MSWindowsScreen::leave()
+bool MSWindowsScreen::canLeave() {
+  POINT pos;
+  if (!GetCursorPos(&pos)) {
+    LOG_DEBUG ("unable to leave screen as windows security has disabled critical functions");
+    // unable to get position this means inputleap will break if the cursor
+    // leaves the screen
+    return false;
+  }
+
+  return true;
+}
+
+void MSWindowsScreen::leave()
 {
     // get keyboard layout of foreground window.  we'll use this
     // keyboard layout for translating keys sent to clients.
@@ -350,8 +361,6 @@ MSWindowsScreen::leave()
     if (isDraggingStarted() && !m_isPrimary) {
         m_sendDragThread = new Thread([this](){ send_drag_thread(); });
     }
-
-    return true;
 }
 
 void MSWindowsScreen::send_drag_thread()

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -108,7 +108,8 @@ public:
     virtual void enable();
     virtual void disable();
     virtual void enter();
-    virtual bool leave();
+    virtual bool canLeave();
+    virtual void leave();
     virtual bool setClipboard(ClipboardID, const IClipboard*);
     virtual void checkClipboards();
     virtual void openScreensaver(bool notify);

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -85,7 +85,8 @@ public:
     virtual void enable();
     virtual void disable();
     virtual void enter();
-    virtual bool leave();
+    virtual bool canLeave();
+    virtual void leave();
     virtual bool setClipboard(ClipboardID, const IClipboard*);
     virtual void checkClipboards();
     virtual void openScreensaver(bool notify);

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -823,6 +823,12 @@ OSXScreen::enter()
 }
 
 bool
+OSXScreen::canLeave()
+{
+    return true;
+}
+
+void
 OSXScreen::leave()
 {
     hideCursor();
@@ -859,8 +865,6 @@ OSXScreen::leave()
 
 	// now off screen
 	m_isOnScreen = false;
-
-	return true;
 }
 
 bool

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -289,8 +289,15 @@ XWindowsScreen::enter()
 	m_isOnScreen = true;
 }
 
-bool
-XWindowsScreen::leave()
+bool XWindowsScreen::canLeave()
+{
+    // raise and show the window, required to grab mouse and keyboard
+    m_impl->XMapRaised(m_display, m_window);
+    // see if grabbing the mouse and keyboard, if primary, is possible
+    return !(m_isPrimary && !grabMouseAndKeyboard());
+}
+
+void XWindowsScreen::leave()
 {
 	if (!m_isPrimary) {
 		// restore the previous keyboard auto-repeat state.  if the user
@@ -312,7 +319,6 @@ XWindowsScreen::leave()
 	// grab the mouse and keyboard, if primary and possible
 	if (m_isPrimary && !grabMouseAndKeyboard()) {
         m_impl->XUnmapWindow(m_display, m_window);
-		return false;
 	}
 
 	// save current focus
@@ -342,8 +348,6 @@ XWindowsScreen::leave()
 
 	// now off screen
 	m_isOnScreen = false;
-
-	return true;
 }
 
 bool

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -75,7 +75,8 @@ public:
     void enable() override;
     void disable() override;
     void enter() override;
-    bool leave() override;
+    bool canLeave() override;
+    void leave() override;
     bool setClipboard(ClipboardID, const IClipboard*) override;
     void checkClipboards() override;
     void openScreensaver(bool notify) override;


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [X] This is not a user-visible change

Fixes: #1690
Fixes: #1897

This fixes keys being stuck when entering the client 
based on https://github.com/deskflow/deskflow/pull/7520 by @enzious 

This checks to see if we can leave a screen before trying todo so 

Tested ON
 * [x] Wayland Server
 * [X] X11 Server
 * [ ] Windows Server
 * [X] Mac os Server
