### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -56,6 +56,8 @@
 #include <Windows.h>
 #endif
 
+#include <signal.h>
+
 namespace {
 
 static const QString allFilesFilter(QObject::tr("All files (*.*)"));


### PR DESCRIPTION
This fixes GUI build error on FreeBSD/X11:

`src/gui/src/MainWindow.cpp:843:9: error: use of undeclared identifier 'kill'`

I'm not very satisfied with this fix, but I was unable to find any meaningful difference in the build command line for this file on Linux vs. FreeBSD. I don't know how signal.h gets included in the Linux build. Shouldn't be any harm doing it explicitly, anyway.