### PR TITLE
fix: show window and file menu on mac os

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -273,8 +273,14 @@ void MainWindow::createTrayIcon()
 
 void MainWindow::retranslateMenuBar()
 {
+#ifndef Q_OS_DARWIN
     main_menu_->setTitle(tr("&InputLeap"));
     m_pMenuHelp->setTitle(tr("&Help"));
+#else
+    m_pMenuHelp->setTitle(tr("&File"));
+    main_menu_->setTitle(tr("&Window"));
+#endif
+
 }
 
 void MainWindow::createMenuBar()
@@ -284,17 +290,29 @@ void MainWindow::createMenuBar()
     m_pMenuHelp = new QMenu("", m_pMenuBar);
     retranslateMenuBar();
 
+#ifndef Q_OS_DARWIN
     m_pMenuBar->addAction(main_menu_->menuAction());
     m_pMenuBar->addAction(m_pMenuHelp->menuAction());
+#else
+    m_pMenuBar->addAction(m_pMenuHelp->menuAction());
+    m_pMenuBar->addAction(main_menu_->menuAction());
+#endif
 
     main_menu_->addAction(ui_->m_pActionShowLog);
     main_menu_->addAction(ui_->m_pActionSettings);
     main_menu_->addAction(ui_->m_pActionMinimize);
     main_menu_->addSeparator();
+
+#ifndef Q_OS_DARWIN
     main_menu_->addAction(ui_->m_pActionSave);
+#endif
     main_menu_->addSeparator();
     main_menu_->addAction(ui_->m_pActionQuit);
     m_pMenuHelp->addAction(ui_->m_pActionAbout);
+
+#ifdef Q_OS_DARWIN
+    m_pMenuHelp->addAction(ui_->m_pActionSave);
+#endif
 
     setMenuBar(m_pMenuBar);
 }


### PR DESCRIPTION
## Contributor Checklist:

* [X] This is a user-visible change and I have NOT created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This is not a user-visible change

Mac os by default has a menu for APPNAME (with some items auto moved here by the os) so making our menus on mac os  a little differently
Before: 
<img width="268" alt="Screenshot 2024-09-18 at 8 13 27 PM" src="https://github.com/user-attachments/assets/63b8f62b-c686-4672-9768-a62be990840d">
<img width="336" alt="Screenshot 2024-09-18 at 8 23 31 PM" src="https://github.com/user-attachments/assets/84ed5bc3-300e-4475-bdba-f1715afc19e4">

After: 
<img width="235" alt="Screenshot 2024-09-18 at 8 20 21 PM" src="https://github.com/user-attachments/assets/ddcd1f49-2d67-46be-b07d-19614a447861">
<img width="341" alt="Screenshot 2024-09-18 at 8 21 44 PM" src="https://github.com/user-attachments/assets/c3d2c6e6-603b-42db-91ed-63e4b246e395">
<img width="309" alt="Screenshot 2024-09-18 at 8 22 13 PM" src="https://github.com/user-attachments/assets/244b7c80-7895-4c25-ab17-8920ebe1cbb5">
