### PR TITLE
fix(macOS): qt6 build requires macOS 10.15+

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -18,7 +18,7 @@ B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"
 if [ "$(uname)" = "Darwin" ]; then
     # macOS needs a little help, so we source this environment script to fix paths.
     [ -e ./macos_environment.sh ] && . ./macos_environment.sh
-    B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
+    B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15"
 fi
 
 # Prefer ninja if available


### PR DESCRIPTION

this is a breaking change as it implies dropping support for all platforms older than Catalina, however, Open Core Legacy Patcher should be useful for anyone still needing to run old hardware that needs macOS 10.15+

As noted by @FightingSu

-  Fixes #1950 

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change
