### PR TITLE
github: Clarify criteria for inclusion of newsfragment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 ## Contributor Checklist:
 
-* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
-* [ ] This is not a user-visible change
+* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
+* [ ] This change does not affect end users


### PR DESCRIPTION
User-visible is not entirely clear because it may be interpreted literally (i.e. must change something that user sees). The intended criteria for newsfragment is that any changes affecting end users should have a release note.

Changes that don't affect end users, such as refactors or build system changes do not need release notes.

## Contributor Checklist:

* [ ] This is a user-visible change and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This is not a user-visible change
