### PR TITLE
build: remove unused curl dependency

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -58,7 +58,6 @@ jobs:
                   clang \
                   git \
                   libavahi-compat-libdnssd-dev \
-                  libcurl4-openssl-dev \
                   libice-dev \
                   libsm-dev \
                   libssl-dev \
@@ -429,7 +428,6 @@ jobs:
               pkgconf \
               git \
               avahi-libdns \
-              curl \
               libsm \
               libxinerama \
               libxrandr \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,16 +109,6 @@ if (UNIX)
     find_package (Threads REQUIRED)
     list (APPEND libs Threads::Threads)
 
-    # curl is used on both Linux and Mac
-    find_package (CURL)
-    if (CURL_FOUND)
-        include_directories(${CURL_INCLUDE_DIRS})
-        list (APPEND libs ${CURL_LIBRARIES})
-
-    else()
-        message (FATAL_ERROR "Missing library: curl")
-    endif()
-
     if (APPLE)
         set (CMAKE_CXX_FLAGS "--sysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
 

--- a/dist/rpm/input-leap.spec.in
+++ b/dist/rpm/input-leap.spec.in
@@ -24,7 +24,6 @@ BuildRequires: gulrak-filesystem-devel
 BuildRequires: libX11-devel
 BuildRequires: libXtst-devel libXinerama-devel libXrandr-devel
 BuildRequires: libICE-devel libSM-devel
-BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 BuildRequires: qt6-qtbase-devel
 BuildRequires: qt6-qttools-devel
@@ -41,7 +40,6 @@ BuildRequires: gtest
 BuildRequires: libX11-devel
 BuildRequires: libXtst-devel libXinerama-devel libXrandr-devel
 BuildRequires: libICE-devel libSM-devel
-BuildRequires: libcurl-devel
 BuildRequires: libopenssl-devel
 BuildRequires: qt6-base-devel
 BuildRequires: qt6-linguist-devel


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [X] This change does not affect end users

Clean up unneeded dependencies

 - Remove unneeded `curl`