### PR TITLE
ci: use ubuntu 22.04 version of cmake

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -65,17 +65,6 @@ jobs:
           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' \
             > /etc/apt/sources.list.d/kitware.list
 
-      - if: matrix.os == 'ubuntu:22.04'
-        name: Add repositories with newer git and cmake
-        run: |
-          # InputLeap requires at least CMake 3.21.
-          # This mirrors instructions at https://apt.kitware.com
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-            | gpg --dearmor - \
-            > /usr/share/keyrings/kitware-archive-keyring.gpg
-          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
-            > /etc/apt/sources.list.d/kitware.list
-
       - name: Update image and install pre-reqs
         run: |
           apt-get update -y


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [X] This change does not affect end users


while waiting for #1804  to land ubuntu updated its cmake version for 22.04 to cmake 3.22. This uses the ubuntu build of cmake instead of the one from the kitware ppa
