### PR TITLE
github: Build Opensuse Leap instead of Tumbleweed

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -190,11 +190,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora:40", "opensuse/tumbleweed"]
+        os: ["fedora:40", "opensuse/leap:15.6"]
         include:
           - installer: dnf install -y
             rpm_tag: fedora
-          - os: opensuse/tumbleweed
+          - os: opensuse/leap
             installer: zypper install -y
             rpm_tag: suse_version
 


### PR DESCRIPTION
Tumbleweed has problems installing dependencies lately (most likely due to glibc upgrade and rebuild). The Docker repository does not provide any specific tags, only latest. As a result, Tumbleweed cannot be depended on for CI builds.

Accordingly, CI is switched to a specific version of OpenSuse Leap distribution.
