### PR TITLE
github: Remove opensuse/tumbleweed from the build set

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -190,13 +190,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora:40", "opensuse/tumbleweed"]
+        os: ["fedora:40"]
         include:
           - installer: dnf install -y
             rpm_tag: fedora
-          - os: opensuse/tumbleweed
-            installer: zypper install -y
-            rpm_tag: suse_version
 
     steps:
       - name: Install extra build dependencies


### PR DESCRIPTION
Tumbleweed has problems installing dependencies lately (most likely due to glibc upgrade and rebuild). The Docker repository does not provide any specific tags, only latest. As a result, Tumbleweed cannot be depended on for CI builds.

This commit should be reverted as soon as OpenSuse Leap 16 is released or tumbleweed is fixed.

