### PR TITLE
Revert "github: Remove opensuse/tumbleweed from the build set"

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -190,10 +190,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora:40"]
+        os: ["fedora:40", "opensuse/tumbleweed"]
         include:
           - installer: dnf install -y
             rpm_tag: fedora
+          - os: opensuse/tumbleweed
+            installer: zypper install -y
+            rpm_tag: suse_version
 
     steps:
       - name: Install extra build dependencies


### PR DESCRIPTION
Reverts input-leap/input-leap#2000

Merge this once Opensuse build no longer fails.