### PR TITLE
Add automatic user config migration from old code path on Linux

### DIFF
--- a/doc/newsfragments/config-location-linux.bugfix
+++ b/doc/newsfragments/config-location-linux.bugfix
@@ -1,0 +1,1 @@
+Added automatic user config migration from old config location on Linux.

--- a/doc/release_notes/index.md
+++ b/doc/release_notes/index.md
@@ -78,6 +78,7 @@ Changes
 -------
 
 - Changed server configuration dialog initial tab to "Screens".
+- Changed user configuration location on Linux from ~/.local/share to ~/.config.
 
 Deprecations and Removals
 -------------------------

--- a/src/lib/common/DataDirectoriesCommon.cpp
+++ b/src/lib/common/DataDirectoriesCommon.cpp
@@ -18,21 +18,45 @@
 
 namespace inputleap {
 
-void DataDirectories::maybe_copy_old_profile(const fs::path& old_profile_path,
-                                             const fs::path& curr_profile_path)
+void maybe_copy_old_profile_cert(const fs::path& old_profile_path,
+                                 const fs::path& curr_profile_path)
 {
-    if (fs::exists(curr_profile_path)) {
-        return;
-    }
-    if (!fs::is_directory(old_profile_path)) {
-        return;
-    }
-    fs::copy(old_profile_path, curr_profile_path, fs::copy_options::recursive);
     auto old_cert_path = curr_profile_path / "SSL" / "Barrier.pem";
     auto new_cert_path = curr_profile_path / "SSL" / "InputLeap.pem";
     if (fs::is_regular_file(old_cert_path) && !fs::exists(new_cert_path)) {
         fs::rename(old_cert_path, new_cert_path);
     }
+}
+
+void maybe_copy_old_profile_ssl(const fs::path& old_profile_path,
+                                const fs::path& curr_profile_path)
+{
+    if (fs::exists(curr_profile_path / "SSL")) {
+        return;
+    }
+    if (!fs::exists(old_profile_path / "SSL")) {
+        return;
+    }
+    if (!fs::is_directory(old_profile_path / "SSL")) {
+        return;
+    }
+    fs::copy(old_profile_path / "SSL", curr_profile_path / "SSL", fs::copy_options::recursive);
+    maybe_copy_old_profile_cert(old_profile_path, curr_profile_path);
+}
+
+void DataDirectories::maybe_copy_old_profile(const fs::path& old_profile_path,
+                                             const fs::path& curr_profile_path)
+{
+    if (fs::exists(curr_profile_path)) {
+        maybe_copy_old_profile_ssl(old_profile_path, curr_profile_path);
+        return;
+    }
+
+    if (!fs::is_directory(old_profile_path)) {
+        return;
+    }
+    fs::copy(old_profile_path, curr_profile_path, fs::copy_options::recursive);
+    maybe_copy_old_profile_cert(old_profile_path, curr_profile_path);
 }
 
 } // namespace inputleap

--- a/src/lib/common/unix/DataDirectories.cpp
+++ b/src/lib/common/unix/DataDirectories.cpp
@@ -76,11 +76,25 @@ static fs::path profile_basedir()
 #endif
 }
 
+#if defined(WINAPI_XWINDOWS) || defined(WINAPI_LIBEI)
+static fs::path old_profile_basedir()
+{
+    // The following was used before 3.0.0
+    const char* dir = std::getenv("XDG_DATA_HOME");
+    if (dir != nullptr)
+        return fs::u8path(dir);
+    return unix_home() / ".local/share";
+}
+#endif
+
 const fs::path& DataDirectories::profile()
 {
     if (_profile.empty()) {
         _profile = profile_basedir() / "InputLeap";
         maybe_copy_old_profile(profile_basedir() / "barrier", _profile);
+#if defined(WINAPI_XWINDOWS) || defined(WINAPI_LIBEI)
+        maybe_copy_old_profile(old_profile_basedir() / "InputLeap", _profile);
+#endif
     }
     return _profile;
 }

--- a/src/lib/common/unix/DataDirectories.cpp
+++ b/src/lib/common/unix/DataDirectories.cpp
@@ -68,7 +68,7 @@ static fs::path profile_basedir()
     const char* dir = std::getenv("XDG_CONFIG_HOME");
     if (dir != nullptr)
         return fs::u8path(dir);
-    return unix_home() / ".config/";
+    return unix_home() / ".config";
 #else
     // macos has its own standards
     // https://developer.apple.com/library/content/documentation/General/Conceptual/MOSXAppProgrammingGuide/AppRuntime/AppRuntime.html


### PR DESCRIPTION
Fixes https://github.com/input-leap/input-leap/pull/1892.

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
