### PR TITLE
Add build for Ubuntu 24.04

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,6 +45,11 @@ jobs:
            cc: "gcc"
            cxx: "g++"
            wayland: true
+         - name: ubuntu-24-04
+           os: "ubuntu:24.04"
+           cc: "gcc"
+           cxx: "g++"
+           wayland: true
          - name: debian-12
            os: "debian:bookworm"
            cc: "gcc"

--- a/dist/scripts/download_release.py
+++ b/dist/scripts/download_release.py
@@ -58,6 +58,10 @@ def main():
             "input-leap_.*_amd64.deb",
             f"InputLeap_{version}_ubuntu_22-04_amd64.deb",
         ),
+        "input-leap-deb-ubuntu-24-04": (
+            "input-leap_.*_amd64.deb",
+            f"InputLeap_{version}_ubuntu_24-04_amd64.deb",
+        ),
         "input-leap-rpms-fedora": (
             "x86_64/input-leap-.*.fc40.x86_64.rpm",
             f"InputLeap_{version}_fedora_fc40_x86_64.rpm",

--- a/doc/newsfragments/ubuntu-24-04-build.feature
+++ b/doc/newsfragments/ubuntu-24-04-build.feature
@@ -1,0 +1,1 @@
+Added a Debian package for Ubuntu 24.04 to the set of released packages.


### PR DESCRIPTION
Extracted from https://github.com/input-leap/input-leap/pull/1988, co-authored by @sithlord48 

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
