### PR TITLE
Remove packages for Ubuntu 20.04

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,11 +30,6 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - name: ubuntu-20-04
-           os: "ubuntu:20.04"
-           cc: "gcc"
-           cxx: "g++"
-           wayland: false
          - name: ubuntu-22-04-clang
            os: "ubuntu:22.04"
            cc: "clang"
@@ -58,17 +53,6 @@ jobs:
           apt-get update -y
           # software-properties-common is needed for add-apt-repository
           apt-get install -y software-properties-common gpg wget
-
-      - if: matrix.os == 'ubuntu:20.04'
-        name: Add repositories with newer git and cmake
-        run: |
-          # InputLeap requires at least CMake 3.21.
-          # This mirrors instructions at https://apt.kitware.com
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-            | gpg --dearmor - \
-            > /usr/share/keyrings/kitware-archive-keyring.gpg
-          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' \
-            > /etc/apt/sources.list.d/kitware.list
 
       - name: Update and install packages
         run: |
@@ -101,15 +85,6 @@ jobs:
                   debhelper \
                   devscripts \
                   xvfb
-
-      - if: matrix.os != 'ubuntu:20.04'
-        name: Install Qt6 packages
-        run: |
-          apt-get install -y \
-                  qt6-base-dev \
-                  qt6-l10n-tools \
-                  qt6-tools-dev-tools \
-                  qt6-tools-dev
 
       - if: matrix.wayland
         name: Install libei and libportal pre-reqs
@@ -210,9 +185,6 @@ jobs:
         run: |
           cd input-leap
           cp -r dist/debian debian
-          if [ "${{ matrix.name }}" = "ubuntu-20-04" ]; then
-            sed -i -e 's/QT_DEFAULT_MAJOR_VERSION=6/QT_DEFAULT_MAJOR_VERSION=5/g' debian/rules
-          fi
           debuild -us -uc
 
       - name: Upload Artifacts

--- a/dist/scripts/download_release.py
+++ b/dist/scripts/download_release.py
@@ -50,10 +50,6 @@ def main():
             "input-leap_.*_amd64.deb",
             f"InputLeap_{version}_debian12_amd64.deb",
         ),
-        "input-leap-deb-ubuntu-20-04": (
-            "input-leap_.*_amd64.deb",
-            f"InputLeap_{version}_ubuntu_20-04_amd64.deb",
-        ),
         "input-leap-deb-ubuntu-22-04": (
             "input-leap_.*_amd64.deb",
             f"InputLeap_{version}_ubuntu_22-04_amd64.deb",

--- a/doc/newsfragments/ubuntu-20-02-build.removal
+++ b/doc/newsfragments/ubuntu-20-02-build.removal
@@ -1,0 +1,1 @@
+Packages for Ubuntu 20.04 are no longer distributed.


### PR DESCRIPTION
Extracted from https://github.com/input-leap/input-leap/pull/1988, co-authored by @sithlord48

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
