### PR TITLE
github: Build Debian tests with Wayland support always enabled

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -34,22 +34,18 @@ jobs:
            os: "ubuntu:22.04"
            cc: "clang"
            cxx: "clang++"
-           wayland: true
          - name: ubuntu-22-04
            os: "ubuntu:22.04"
            cc: "gcc"
            cxx: "g++"
-           wayland: true
          - name: ubuntu-24-04
            os: "ubuntu:24.04"
            cc: "gcc"
            cxx: "g++"
-           wayland: true
          - name: debian-12
            os: "debian:bookworm"
            cc: "gcc"
            cxx: "g++"
-           wayland: true
     steps:
 
       # Preparation steps
@@ -91,8 +87,7 @@ jobs:
                   devscripts \
                   xvfb
 
-      - if: matrix.wayland
-        name: Install libei and libportal pre-reqs
+      - name: Install libei and libportal pre-reqs
         run: |
           apt-get install -y \
                   ca-certificates \
@@ -126,7 +121,6 @@ jobs:
       - name: Get libei v1.3.0 from freedesktop
         # Manual checkout of libinput/libei ref 1.3.0 from https://gitlab.freedesktop.org
         # because actions/checkout does not support gitlab
-        if: matrix.wayland
         run: |
           git clone --depth=1 --branch="$ref" --recurse-submodules -- \
             "https://gitlab.freedesktop.org/libinput/libei" libei
@@ -135,20 +129,17 @@ jobs:
 
       - name: Get libportal from upstream
         uses: actions/checkout@v4
-        if: matrix.wayland
         with:
           repository: flatpak/libportal
           ref: main
           path: libportal
 
-      - if: matrix.wayland
-        name: build libei from git tag
+      - name: build libei from git tag
         run: |
             meson setup -Dprefix=/usr -Dtests=disabled -Dliboeffis=disabled -Ddocumentation=[] libei _libei_builddir
             ninja -C _libei_builddir install
 
-      - if: matrix.wayland
-        name: build libportal
+      - name: build libportal
         run: |
             meson setup --prefix=/usr -Dbackend-gtk3=enabled -Ddocs=false libportal _libportal_builddir
             ninja -C _libportal_builddir install
@@ -160,7 +151,7 @@ jobs:
                 -DQT_DEFAULT_MAJOR_VERSION=5 \
                 -DCMAKE_CXX_FLAGS:STRING="-Wall -Wextra -Wno-unused-parameter" \
                 -DCMAKE_CXX_FLAGS_DEBUG:STRING="-g -Werror" \
-                -DINPUTLEAP_BUILD_LIBEI:BOOL=${{ matrix.wayland }} \
+                -DINPUTLEAP_BUILD_LIBEI:BOOL=1 \
                 -DCMAKE_INSTALL_PREFIX=input-leap-${{ matrix.name }}
           cmake --build build --parallel --target install
         env:


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
