### PR TITLE
gui: Fix screen name entry in screen settings dialog

### DIFF
--- a/doc/newsfragments/screen-name-entry.bugfix
+++ b/doc/newsfragments/screen-name-entry.bugfix
@@ -1,0 +1,1 @@
+Fixed broken screen name entry in screen settings dialog.

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -25,7 +25,7 @@
 #include <QtGui>
 #include <QMessageBox>
 
-static const QRegularExpression ValidScreenName("[a-z0-9\\._-]{,255}",
+static const QRegularExpression ValidScreenName("[a-z0-9\\._-]{0,255}",
                                                 QRegularExpression::CaseInsensitiveOption);
 
 static QString check_name_param(QString name)


### PR DESCRIPTION
Current code was limiting the screen name to single character.

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
