### PR TITLE
github: Remove Qt6 from Windows workflow name

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -379,7 +379,7 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - name: Windows Qt6
+         - name: Windows
            os: windows-2022
            qt-version: 6.6
 

--- a/dist/scripts/download_release.py
+++ b/dist/scripts/download_release.py
@@ -82,7 +82,7 @@ def main():
             "InputLeapSetup-.*-release.exe",
             f"InputLeap_{version}_windows_qt5.exe",
         ),
-        "windows-installer-Windows Qt6": (
+        "windows-installer-Windows": (
             "InputLeapSetup-.*-release.exe",
             f"InputLeap_{version}_windows_qt6.exe",
         ),


### PR DESCRIPTION
This affects the name of the artifacts. There's a single Windows build, so it's doesn't make sense to include Qt version there.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
