### PR TITLE
dist/scripts: Remove no longer existing artifact

### DIFF
--- a/dist/scripts/download_release.py
+++ b/dist/scripts/download_release.py
@@ -78,10 +78,6 @@ def main():
             "InputLeap-.*-release.dmg",
             f"InputLeap_{version}_macos_x86_64.dmg",
         ),
-        "windows-installer-Windows Qt5": (
-            "InputLeapSetup-.*-release.exe",
-            f"InputLeap_{version}_windows_qt5.exe",
-        ),
         "windows-installer-Windows": (
             "InputLeapSetup-.*-release.exe",
             f"InputLeap_{version}_windows_qt6.exe",


### PR DESCRIPTION
Windows Qt5 artifact should have been removed in the Qt5 removal commits.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
