### PR TITLE
README: Update post 3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@ you're controlling at any given moment. Input Leap does this in software, allowi
 you to tell it which machine to control by moving your mouse to the edge of the
 screen, or by using a keypress to switch focus to a different system.
 
-Input Leap was [forked](https://github.com/input-leap/input-leap/issues/1414)
-from Barrier in November 2021. At this time, Input Leap is in heavy
-development, and not ready for production use. We hope to release our first
-post-fork release (v3.0.0) very soon.
-
-But for now, we advise sticking with Barrier v2.4.0/v2.3.4, and avoid building
-from Git - unless you're aware that building from Git may result in unexpected
-behaviour. Of course, testing is welcome.
-
 At the moment, Input Leap is not compatible with Synergy.
 
 Input Leap needs to be installed on all machines that will share keyboard and
@@ -56,13 +47,6 @@ add additional information. You will also be able to see when progress is made
 and how the issue gets resolved.
 
 ### Usage
-
-> [!WARNING]
-> Currently, there are no stable builds (binary releases) for Input Leap yet.
-> 
-> However, **test** builds _(also called debug build artifacts)_ are available
-> via [GitHub Actions](https://github.com/input-leap/input-leap/actions?query=branch%3Amaster),
-> as described in [this discussions post](https://github.com/input-leap/input-leap/discussions/1793#discussioncomment-8577620).
 
 1. Install and run Input Leap on each machine that will be sharing.
 2. On the machine with the keyboard and mouse, make it the server.
@@ -130,42 +114,21 @@ specific packages.
 
 **Q: What OSes are supported?**
 
-Currently, Input Leap is in heavy development, and we hope to make our first
-post-fork release very soon. However, we wish to make clear that building from
-Git is prone to breaking changes and other bugs/issues. Our advice is to stick
-with Barrier v2.4.0/v2.3.4 for the time-being.
-
-<!-- TODO: Update upon v3.0.0 release.
 > A: The [most recent release](https://github.com/input-leap/input-leap/releases/latest) of Input Leap is known to work on:
->  - Windows 7, 8, 8.1, 10, and 11
+>  - Windows 10, and 11
 >  - macOS *(previously known as OS X or Mac OS X)*
->    - _The current GUI does **not** work on OS versions prior to macOS 10.12 Sierra (but see the related answer below)_
+>    - 10.12 and newer
 >  - Linux
 >  - FreeBSD
 >  - OpenBSD
--->
 
-<!-- TODO: Update upon v3.0.0 release.
 **Q: Are 32-bit versions of Windows supported?**
 
-> A: Not officially.
--->
+> A: No
 
-<!-- TODO: Update upon v3.0.0 release.
 __Q: Is it possible to use Input Leap on Mac OS X / OS X versions prior to 10.12?__
 
-> A: Not officially.
->   - For OS X 10.10 Yosemite and later:
->     - [Input Leap v2.1.0](https://github.com/input-leap/input-leap/releases/tag/v2.1.0) or earlier _may_ work.
->   - For Mac OS X 10.9 Mavericks _(and perhaps earlier)_:
->     1. the command-line portions of the [current release](https://github.com/input-leap/input-leap/releases/latest) _should_ run fine.
->     2. The GUI will _not_ run, as that OS version does not include Apple's *Metal* framework.
->         - _(For a GUI workaround for Mac OS X 10.9, see the [discussion at issue #544](https://github.com/input-leap/input-leap/issues/544))_
-
-> Note: Only versions [v2.3.4](https://github.com/input-leap/input-leap/releases/tag/v2.3.4) and [later](https://github.com/input-leap/input-leap/releases/latest) of Input Leap can be supported by this project.
->  - Anyone using an earlier version is advised to upgrade due to recently-addressed security vulnerabilities *(and other bug fixes)*.
->    - This is especially important for computers accessible from the public Internet *(or from other shared/untrusted networks, such as when using shared WiFi)*.
--->
+> A: No
 
 **Q: How do I load my configuration on startup?**
 
@@ -188,9 +151,5 @@ __Q: Is it possible to use Input Leap on Mac OS X / OS X versions prior to 10.12
 > A: Currently:
 >    - Input Leap currently has limited UTF-8 support; issues have been reported with processing various languages.
 >      - *(see [#860](https://github.com/input-leap/input-leap/issues/860))*
->
->    - There is interest in future support for the Wayland compositor/display server protocol *([official site](https://wayland.freedesktop.org/) | [Wikipedia article](https://en.wikipedia.org/wiki/Wayland_(display_server_protocol)))* on Linux.
->      - As of mid-2022, there is no expected completion date for *Wayland* support.
->      - *(see [#109](https://github.com/input-leap/input-leap/issues/109) and [#1251](https://github.com/input-leap/input-leap/issues/1251) for status or to volunteer your talents)*
 >
 > The complete list of open issues can be found in the ['Issues' tab on GitHub](https://github.com/input-leap/input-leap/issues?q=is%3Aissue+is%3Aopen). Help is always appreciated.


### PR DESCRIPTION
A lot of parts in README no longer apply after 3.0 release.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
