### PR TITLE
lib: Rename IClipboard::empty() to IClipboard::clear()

### DIFF
--- a/src/lib/inputleap/Clipboard.cpp
+++ b/src/lib/inputleap/Clipboard.cpp
@@ -26,7 +26,7 @@ Clipboard::Clipboard() :
     m_owner(false)
 {
     open(0);
-    empty();
+    clear();
     close();
 }
 
@@ -36,7 +36,7 @@ Clipboard::~Clipboard()
 }
 
 bool
-Clipboard::empty()
+Clipboard::clear()
 {
     assert(m_open);
 

--- a/src/lib/inputleap/Clipboard.h
+++ b/src/lib/inputleap/Clipboard.h
@@ -55,7 +55,7 @@ public:
     //@}
 
     // IClipboard overrides
-    bool empty() override;
+    bool clear() override;
     void add(EFormat, const std::string& data) override;
     bool open(Time) const override;
     void close() const override;

--- a/src/lib/inputleap/IClipboard.cpp
+++ b/src/lib/inputleap/IClipboard.cpp
@@ -30,7 +30,7 @@ void IClipboard::unmarshall(IClipboard* clipboard, const std::string& data, Time
 
     if (clipboard->open(time)) {
         // clear existing data
-        clipboard->empty();
+        clipboard->clear();
 
         // read the number of formats
         const std::uint32_t numFormats = readUInt32(index);
@@ -127,7 +127,7 @@ IClipboard::copy(IClipboard* dst, const IClipboard* src, Time time)
     bool success = false;
     if (src->open(time)) {
         if (dst->open(time)) {
-            if (dst->empty()) {
+            if (dst->clear()) {
                 for (std::int32_t format = 0;
                                 format != IClipboard::kNumFormats; ++format) {
                     IClipboard::EFormat eFormat = static_cast<IClipboard::EFormat>(format);

--- a/src/lib/inputleap/IClipboard.h
+++ b/src/lib/inputleap/IClipboard.h
@@ -79,7 +79,7 @@ public:
     Return false if the clipboard ownership could not be taken;
     the clipboard should not be emptied in this case.
     */
-    virtual bool empty() = 0;
+    virtual bool clear() = 0;
 
     //! Add data
     /*!

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -78,7 +78,7 @@ MSWindowsClipboard::emptyUnowned()
 }
 
 bool
-MSWindowsClipboard::empty()
+MSWindowsClipboard::clear()
 {
     if (!emptyUnowned()) {
         return false;

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -57,7 +57,7 @@ public:
     static bool is_owned_by_us();
 
     // IClipboard overrides
-    virtual bool empty();
+    virtual bool clear();
     virtual void add(EFormat, const std::string& data);
     virtual bool open(Time) const;
     virtual void close() const;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -394,7 +394,7 @@ MSWindowsScreen::setClipboard(ClipboardID, const IClipboard* src)
         if (!dst.open(0)) {
             return false;
         }
-        dst.empty();
+        dst.clear();
         dst.close();
         return true;
     }

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -60,7 +60,7 @@ OSXClipboard::~OSXClipboard()
 }
 
     bool
-OSXClipboard::empty()
+OSXClipboard::clear()
 {
     LOG_DEBUG("emptying clipboard");
     if (m_pboard == nullptr)

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -35,7 +35,7 @@ public:
     virtual ~OSXClipboard();
 
     // IClipboard overrides
-    virtual bool empty();
+    virtual bool clear();
     virtual void add(EFormat, const std::string& data);
     virtual bool open(Time) const;
     virtual void close() const;

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -283,7 +283,7 @@ XWindowsClipboard::getSelection() const
 }
 
 bool
-XWindowsClipboard::empty()
+XWindowsClipboard::clear()
 {
     assert(m_open);
 

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -88,7 +88,7 @@ public:
     Atom getSelection() const;
 
     // IClipboard overrides
-    bool empty() override;
+    bool clear() override;
     void add(EFormat, const std::string& data) override;
     bool open(Time) const override;
     void close() const override;

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -371,7 +371,7 @@ XWindowsScreen::setClipboard(ClipboardID id, const IClipboard* clipboard)
 		if (!m_clipboard[id]->open(timestamp)) {
 			return false;
 		}
-		m_clipboard[id]->empty();
+        m_clipboard[id]->clear();
 		m_clipboard[id]->close();
 		return true;
 	}

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -109,7 +109,7 @@ Server::Server(
 		clipboard.m_clipboardOwner  = primaryName;
 		clipboard.m_clipboardSeqNum = m_seqNum;
 		if (clipboard.m_clipboard.open(0)) {
-			clipboard.m_clipboard.empty();
+			clipboard.m_clipboard.clear();
 			clipboard.m_clipboard.close();
 		}
 		clipboard.m_clipboardData   = clipboard.m_clipboard.marshall();
@@ -1203,7 +1203,7 @@ void Server::handle_clipboard_grabbed(const Event& event, BaseClientProxy* grabb
 
 	// clear the clipboard data (since it's not known at this point)
 	if (clipboard.m_clipboard.open(0)) {
-		clipboard.m_clipboard.empty();
+		clipboard.m_clipboard.clear();
 		clipboard.m_clipboard.close();
 	}
 	clipboard.m_clipboardData = clipboard.m_clipboard.marshall();

--- a/src/test/integtests/platform/MSWindowsClipboardTests.cpp
+++ b/src/test/integtests/platform/MSWindowsClipboardTests.cpp
@@ -42,7 +42,7 @@ private:
     {
         MSWindowsClipboard clipboard(nullptr);
         clipboard.open(0);
-        clipboard.empty();
+        clipboard.clear();
     }
 };
 
@@ -67,7 +67,7 @@ TEST_F(MSWindowsClipboardTests, empty_openCalled_returnsTrue)
     MSWindowsClipboard clipboard(nullptr);
     clipboard.open(0);
 
-    bool actual = clipboard.empty();
+    bool actual = clipboard.clear();
 
     EXPECT_EQ(true, actual);
 }
@@ -78,7 +78,7 @@ TEST_F(MSWindowsClipboardTests, empty_singleFormat_hasReturnsFalse)
     clipboard.open(0);
     clipboard.add(MSWindowsClipboard::kText, "test string!");
 
-    clipboard.empty();
+    clipboard.clear();
 
     bool actual = clipboard.has(MSWindowsClipboard::kText);
     EXPECT_EQ(false, actual);
@@ -178,7 +178,7 @@ TEST_F(MSWindowsClipboardTests, has_withFormatAdded_returnsTrue)
 {
     MSWindowsClipboard clipboard(nullptr);
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
     clipboard.add(IClipboard::kText, "test string!");
 
     bool actual = clipboard.has(IClipboard::kText);
@@ -190,7 +190,7 @@ TEST_F(MSWindowsClipboardTests, has_withNoFormats_returnsFalse)
 {
     MSWindowsClipboard clipboard(nullptr);
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
 
     bool actual = clipboard.has(IClipboard::kText);
 
@@ -201,7 +201,7 @@ TEST_F(MSWindowsClipboardTests, get_withNoFormats_returnsEmpty)
 {
     MSWindowsClipboard clipboard(nullptr);
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
 
     std::string actual = clipboard.get(IClipboard::kText);
 
@@ -212,7 +212,7 @@ TEST_F(MSWindowsClipboardTests, get_withFormatAdded_returnsExpected)
 {
     MSWindowsClipboard clipboard(nullptr);
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
     clipboard.add(IClipboard::kText, "test string!");
 
     std::string actual = clipboard.get(IClipboard::kText);

--- a/src/test/integtests/platform/OSXClipboardTests.cpp
+++ b/src/test/integtests/platform/OSXClipboardTests.cpp
@@ -28,7 +28,7 @@ TEST(OSXClipboardTests, empty_openCalled_returnsTrue)
     OSXClipboard clipboard;
     clipboard.open(0);
 
-    bool actual = clipboard.empty();
+    bool actual = clipboard.clear();
 
     EXPECT_EQ(true, actual);
 }
@@ -39,7 +39,7 @@ TEST(OSXClipboardTests, empty_singleFormat_hasReturnsFalse)
     clipboard.open(0);
     clipboard.add(OSXClipboard::kText, "test string!");
 
-    clipboard.empty();
+    clipboard.clear();
 
     bool actual = clipboard.has(OSXClipboard::kText);
     EXPECT_EQ(false, actual);
@@ -112,7 +112,7 @@ TEST(OSXClipboardTests, getTime_openAndEmpty_returnsOne)
 {
     OSXClipboard clipboard;
     clipboard.open(1);
-    clipboard.empty();
+    clipboard.clear();
 
     OSXClipboard::Time actual = clipboard.getTime();
 
@@ -123,7 +123,7 @@ TEST(OSXClipboardTests, has_withFormatAdded_returnsTrue)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
     clipboard.add(IClipboard::kText, "test string!");
 
     bool actual = clipboard.has(IClipboard::kText);
@@ -135,7 +135,7 @@ TEST(OSXClipboardTests, has_withNoFormats_returnsFalse)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
 
     bool actual = clipboard.has(IClipboard::kText);
 
@@ -146,7 +146,7 @@ TEST(OSXClipboardTests, get_withNoFormats_returnsEmpty)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
 
     std::string actual = clipboard.get(IClipboard::kText);
 
@@ -157,7 +157,7 @@ TEST(OSXClipboardTests, get_withFormatAdded_returnsExpected)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    clipboard.empty();
+    clipboard.clear();
     clipboard.add(IClipboard::kText, "test string!");
 
     std::string actual = clipboard.get(IClipboard::kText);

--- a/src/test/unittests/inputleap/ClipboardTests.cpp
+++ b/src/test/unittests/inputleap/ClipboardTests.cpp
@@ -27,7 +27,7 @@ TEST(ClipboardTests, empty_openCalled_returnsTrue)
     Clipboard clipboard;
     clipboard.open(0);
 
-    bool actual = clipboard.empty();
+    bool actual = clipboard.clear();
 
     EXPECT_EQ(true, actual);
 }
@@ -38,7 +38,7 @@ TEST(ClipboardTests, empty_singleFormat_hasReturnsFalse)
     clipboard.open(0);
     clipboard.add(Clipboard::kText, "test string!");
 
-    clipboard.empty();
+    clipboard.clear();
 
     bool actual = clipboard.has(Clipboard::kText);
     EXPECT_FALSE(actual);
@@ -109,7 +109,7 @@ TEST(ClipboardTests, getTime_openAndEmpty_returnsOne)
 {
     Clipboard clipboard;
     clipboard.open(1);
-    clipboard.empty();
+    clipboard.clear();
 
     Clipboard::Time actual = clipboard.getTime();
 


### PR DESCRIPTION
The new name is the accepted standard for what the code does. empty() is usually non-modifying operation, so previous name was confusing.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
