### PR TITLE
Use auto for complicated types more

### DIFF
--- a/src/client/MSWindowsClientTaskBarReceiver.cpp
+++ b/src/client/MSWindowsClientTaskBarReceiver.cpp
@@ -226,8 +226,7 @@ MSWindowsClientTaskBarReceiver::copyLog() const
     if (m_logBuffer != nullptr) {
         // collect log buffer
         std::string data;
-        for (BufferedLogOutputter::const_iterator index = m_logBuffer->begin();
-                                index != m_logBuffer->end(); ++index) {
+        for (auto index = m_logBuffer->begin(); index != m_logBuffer->end(); ++index) {
             data += *index;
             data += "\n";
         }

--- a/src/gui/src/AppLocale.cpp
+++ b/src/gui/src/AppLocale.cpp
@@ -59,8 +59,7 @@ void AppLocale::addLanguage(const QString& ietfCode, const QString& name)
 void AppLocale::fillLanguageComboBox(QComboBox* comboBox)
 {
     comboBox->blockSignals(true);
-    QVector<AppLocale::Language>::iterator it;
-    for (it = m_Languages.begin(); it != m_Languages.end(); ++it)
+    for (auto it = m_Languages.begin(); it != m_Languages.end(); ++it)
     {
         comboBox->addItem((*it).m_Name, (*it).m_IetfCode);
     }

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -452,8 +452,7 @@ ArchThreadImpl*
 ArchMultithreadPosix::findNoRef(pthread_t thread)
 {
     // linear search
-    for (ThreadList::const_iterator index  = m_threadList.begin();
-                                     index != m_threadList.end(); ++index) {
+    for (auto index  = m_threadList.begin(); index != m_threadList.end(); ++index) {
         if ((*index)->m_thread == thread) {
             return *index;
         }

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -346,8 +346,7 @@ ArchMiscWindows::removeDialog(HWND hwnd)
 bool
 ArchMiscWindows::processDialog(MSG* msg)
 {
-    for (Dialogs::const_iterator index = s_dialogs->begin();
-                            index != s_dialogs->end(); ++index) {
+    for (auto index = s_dialogs->begin(); index != s_dialogs->end(); ++index) {
         if (IsDialogMessage(*index, msg)) {
             return true;
         }

--- a/src/lib/arch/win32/ArchMultithreadWindows.cpp
+++ b/src/lib/arch/win32/ArchMultithreadWindows.cpp
@@ -102,8 +102,7 @@ ArchMultithreadWindows::~ArchMultithreadWindows()
     s_instance = nullptr;
 
     // clean up thread list
-    for (ThreadList::iterator index  = m_threadList.begin();
-                               index != m_threadList.end(); ++index) {
+    for (auto index  = m_threadList.begin(); index != m_threadList.end(); ++index) {
         delete *index;
     }
 }
@@ -421,8 +420,7 @@ ArchThreadImpl*
 ArchMultithreadWindows::findNoRefOrCreate(DWORD id)
 {
     // linear search
-    for (ThreadList::const_iterator index  = m_threadList.begin();
-                                     index != m_threadList.end(); ++index) {
+    for (auto index  = m_threadList.begin(); index != m_threadList.end(); ++index) {
         if ((*index)->m_id == id) {
             return *index;
         }
@@ -445,8 +443,7 @@ ArchMultithreadWindows::insert(ArchThreadImpl* thread)
 void
 ArchMultithreadWindows::erase(ArchThreadImpl* thread)
 {
-    for (ThreadList::iterator index  = m_threadList.begin();
-                               index != m_threadList.end(); ++index) {
+    for (auto index = m_threadList.begin(); index != m_threadList.end(); ++index) {
         if (*index == thread) {
             m_threadList.erase(index);
             break;

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -112,8 +112,7 @@ ArchNetworkWinsock::~ArchNetworkWinsock()
         s_networkModule = nullptr;
     }
 
-    EventList::iterator it;
-    for (it = m_unblockEvents.begin(); it != m_unblockEvents.end(); it++) {
+    for (auto it = m_unblockEvents.begin(); it != m_unblockEvents.end(); it++) {
         delete *it;
     }
 }

--- a/src/lib/arch/win32/ArchTaskBarWindows.cpp
+++ b/src/lib/arch/win32/ArchTaskBarWindows.cpp
@@ -104,7 +104,7 @@ ArchTaskBarWindows::addReceiver(IArchTaskBarReceiver* receiver)
     }
 
     // add receiver if necessary
-    ReceiverToInfoMap::iterator index = m_receivers.find(receiver);
+    auto index = m_receivers.find(receiver);
     if (index == m_receivers.end()) {
         // add it, creating a new message ID for it
         ReceiverInfo info;
@@ -123,7 +123,7 @@ void
 ArchTaskBarWindows::removeReceiver(IArchTaskBarReceiver* receiver)
 {
     // find receiver
-    ReceiverToInfoMap::iterator index = m_receivers.find(receiver);
+    auto index = m_receivers.find(receiver);
     if (index == m_receivers.end()) {
         return;
     }
@@ -143,7 +143,7 @@ void
 ArchTaskBarWindows::updateReceiver(IArchTaskBarReceiver* receiver)
 {
     // find receiver
-    ReceiverToInfoMap::const_iterator index = m_receivers.find(receiver);
+    auto index = m_receivers.find(receiver);
     if (index == m_receivers.end()) {
         return;
     }
@@ -173,7 +173,7 @@ void
 ArchTaskBarWindows::addIcon(UINT id)
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    CIDToReceiverMap::const_iterator index = m_idTable.find(id);
+    auto index = m_idTable.find(id);
     if (index != m_idTable.end()) {
         modifyIconNoLock(index->second, NIM_ADD);
     }
@@ -190,7 +190,7 @@ void
 ArchTaskBarWindows::updateIcon(UINT id)
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    CIDToReceiverMap::const_iterator index = m_idTable.find(id);
+    auto index = m_idTable.find(id);
     if (index != m_idTable.end()) {
         modifyIconNoLock(index->second, NIM_MODIFY);
     }
@@ -200,8 +200,7 @@ void
 ArchTaskBarWindows::addAllIcons()
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    for (ReceiverToInfoMap::const_iterator index = m_receivers.begin();
-                                    index != m_receivers.end(); ++index) {
+    for (auto index = m_receivers.begin(); index != m_receivers.end(); ++index) {
         modifyIconNoLock(index, NIM_ADD);
     }
 }
@@ -210,8 +209,7 @@ void
 ArchTaskBarWindows::removeAllIcons()
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    for (ReceiverToInfoMap::const_iterator index = m_receivers.begin();
-                                    index != m_receivers.end(); ++index) {
+    for (auto index = m_receivers.begin(); index != m_receivers.end(); ++index) {
         removeIconNoLock(index->second.m_id);
     }
 }
@@ -319,7 +317,7 @@ ArchTaskBarWindows::wndProc(HWND hwnd,
     switch (msg) {
     case kNotifyReceiver: {
         // lookup receiver
-        CIDToReceiverMap::const_iterator index = m_idTable.find((UINT)wParam);
+        auto index = m_idTable.find((UINT)wParam);
         if (index != m_idTable.end()) {
             IArchTaskBarReceiver* receiver = index->second->first;
             handleIconMessage(receiver, lParam);

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -94,7 +94,7 @@ void EventQueue::set_buffer(std::unique_ptr<IEventQueueBuffer> buffer)
 
     // discard old buffer and old events
     buffer_.reset();
-    for (EventTable::iterator i = m_events.begin(); i != m_events.end(); ++i) {
+    for (auto i = m_events.begin(); i != m_events.end(); ++i) {
         Event::deleteData(i->second);
     }
     m_events.clear();
@@ -265,14 +265,13 @@ EventQueue::deleteTimer(EventQueueTimer* timer)
 {
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        for (TimerQueue::iterator index = m_timerQueue.begin();
-                                index != m_timerQueue.end(); ++index) {
+        for (auto index = m_timerQueue.begin(); index != m_timerQueue.end(); ++index) {
             if (index->getTimer() == timer) {
                 m_timerQueue.erase(index);
                 break;
             }
         }
-        Timers::iterator index = m_timers.find(timer);
+        auto index = m_timers.find(timer);
         if (index != m_timers.end()) {
             m_timers.erase(index);
         }
@@ -299,10 +298,10 @@ void EventQueue::remove_handler(EventType type, const EventTarget* target)
     }
 
     std::lock_guard<std::mutex> lock(mutex_);
-    HandlerTable::iterator index = m_handlers.find(target);
+    auto index = m_handlers.find(target);
     if (index != m_handlers.end()) {
         TypeHandlerTable& typeHandlers = index->second;
-        TypeHandlerTable::iterator index2 = typeHandlers.find(type);
+        auto index2 = typeHandlers.find(type);
         if (index2 != typeHandlers.end()) {
             typeHandlers.erase(index2);
         }
@@ -324,7 +323,7 @@ void EventQueue::remove_handlers(const EventTarget* target)
         throw std::invalid_argument("EventTarget sent to wrong EventQueue");
     }
 
-    HandlerTable::iterator index = m_handlers.find(target);
+    auto index = m_handlers.find(target);
     if (index != m_handlers.end()) {
         m_handlers.erase(index);
     }
@@ -335,10 +334,10 @@ std::shared_ptr<EventQueue::EventHandler>
     EventQueue::get_handler(EventType type, const EventTarget* target) const
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    HandlerTable::const_iterator index = m_handlers.find(target);
+    auto index = m_handlers.find(target);
     if (index != m_handlers.end()) {
         const TypeHandlerTable& typeHandlers = index->second;
-        TypeHandlerTable::const_iterator index2 = typeHandlers.find(type);
+        auto index2 = typeHandlers.find(type);
         if (index2 != typeHandlers.end()) {
             return index2->second;
         }
@@ -368,7 +367,7 @@ std::uint32_t EventQueue::save_event(Event&& event)
 Event EventQueue::removeEvent(std::uint32_t eventID)
 {
     // look up id
-    EventTable::iterator index = m_events.find(eventID);
+    auto index = m_events.find(eventID);
     if (index == m_events.end()) {
         return Event();
     }
@@ -398,8 +397,7 @@ EventQueue::hasTimerExpired(Event& event)
     m_time.reset();
 
     // countdown elapsed time
-    for (TimerQueue::iterator index = m_timerQueue.begin();
-                            index != m_timerQueue.end(); ++index) {
+    for (auto index = m_timerQueue.begin(); index != m_timerQueue.end(); ++index) {
         (*index) -= time;
     }
 

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -80,12 +80,10 @@ Log::Log(Log* src)
 Log::~Log()
 {
     // clean up
-    for (OutputterList::iterator index    = m_outputters.begin();
-                                    index != m_outputters.end(); ++index) {
+    for (auto index= m_outputters.begin(); index != m_outputters.end(); ++index) {
         delete *index;
     }
-    for (OutputterList::iterator index    = m_alwaysOutputters.begin();
-                                    index != m_alwaysOutputters.end(); ++index) {
+    for (auto index = m_alwaysOutputters.begin(); index != m_alwaysOutputters.end(); ++index) {
         delete *index;
     }
 }

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -338,8 +338,7 @@ Client::resetOptions()
 void
 Client::setOptions(const OptionsList& options)
 {
-    for (OptionsList::const_iterator index = options.begin();
-         index != options.end(); ++index) {
+    for (auto index = options.begin(); index != options.end(); ++index) {
         const OptionID id       = *index;
         if (id == kOptionClipboardSharing) {
             index++;

--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -552,7 +552,7 @@ std::string ArgParser::assembleCommand(std::vector<std::string>& argsArray,
 {
     std::string result;
 
-    for (std::vector<std::string>::iterator it = argsArray.begin(); it != argsArray.end(); ++it) {
+    for (auto it = argsArray.begin(); it != argsArray.end(); ++it) {
         if (it->compare(ignoreArg) == 0) {
             it = it + parametersRequired;
             continue;

--- a/src/lib/inputleap/KeyMap.cpp
+++ b/src/lib/inputleap/KeyMap.cpp
@@ -158,7 +158,7 @@ bool KeyMap::addKeyCombinationEntry(KeyID id, std::int32_t group, const KeyID* k
     // convert to buttons
     KeyItemList items;
     for (std::uint32_t i = 0; i < numKeys; ++i) {
-        KeyIDMap::const_iterator gtIndex = m_keyIDMap.find(keys[i]);
+        auto gtIndex = m_keyIDMap.find(keys[i]);
         if (gtIndex == m_keyIDMap.end()) {
             return false;
         }
@@ -224,8 +224,7 @@ KeyMap::finish()
     m_numGroups = findNumGroups();
 
     // make sure every key has the same number of groups
-    for (KeyIDMap::iterator i = m_keyIDMap.begin();
-                                i != m_keyIDMap.end(); ++i) {
+    for (auto i = m_keyIDMap.begin(); i != m_keyIDMap.end(); ++i) {
         i->second.resize(m_numGroups);
     }
 
@@ -236,8 +235,7 @@ KeyMap::finish()
 void
 KeyMap::foreachKey(ForeachKeyCallback cb, void* userData)
 {
-    for (KeyIDMap::iterator i = m_keyIDMap.begin();
-                                i != m_keyIDMap.end(); ++i) {
+    for (auto i = m_keyIDMap.begin(); i != m_keyIDMap.end(); ++i) {
         KeyGroupTable& groupTable = i->second;
         for (size_t group = 0; group < groupTable.size(); ++group) {
             KeyEntryList& entryList = groupTable[group];
@@ -340,7 +338,7 @@ const KeyMap::KeyItemList* KeyMap::findCompatibleKey(KeyID id, std::int32_t grou
 {
     assert(group >= 0 && group < getNumGroups());
 
-    KeyIDMap::const_iterator i = m_keyIDMap.find(id);
+    auto i = m_keyIDMap.find(id);
     if (i == m_keyIDMap.end()) {
         return nullptr;
     }
@@ -386,8 +384,7 @@ void
 KeyMap::collectButtons(const ModifierToKeys& mods, ButtonToKeyMap& keys)
 {
     keys.clear();
-    for (ModifierToKeys::const_iterator i = mods.begin();
-                                i != mods.end(); ++i) {
+    for (auto i = mods.begin(); i != mods.end(); ++i) {
         keys.insert(std::make_pair(i->second.m_button, &i->second));
     }
 }
@@ -451,8 +448,7 @@ KeyMap::initModifierKey(KeyItem& item)
 std::int32_t KeyMap::findNumGroups() const
 {
     size_t max = 0;
-    for (KeyIDMap::const_iterator i = m_keyIDMap.begin();
-                                i != m_keyIDMap.end(); ++i) {
+    for (auto i = m_keyIDMap.begin(); i != m_keyIDMap.end(); ++i) {
         if (i->second.size() > max) {
             max = i->second.size();
         }
@@ -465,8 +461,7 @@ KeyMap::setModifierKeys()
 {
     m_modifierKeys.clear();
     m_modifierKeys.resize(kKeyModifierNumBits * getNumGroups());
-    for (KeyIDMap::const_iterator i = m_keyIDMap.begin();
-                                i != m_keyIDMap.end(); ++i) {
+    for (auto i = m_keyIDMap.begin(); i != m_keyIDMap.end(); ++i) {
         const KeyGroupTable& groupTable = i->second;
         for (size_t g = 0; g < groupTable.size(); ++g) {
             const KeyEntryList& entries = groupTable[g];
@@ -503,7 +498,7 @@ const KeyMap::KeyItem* KeyMap::mapCommandKey(Keystrokes& keys, KeyID id, std::in
     static const KeyModifierMask s_overrideModifiers = 0xffffu;
 
     // find KeySym in table
-    KeyIDMap::const_iterator it = m_keyIDMap.find(id);
+    auto it = m_keyIDMap.find(id);
     if (it == m_keyIDMap.end()) {
         // unknown key
         LOG_DEBUG1("key %04x is not on keyboard", id);
@@ -592,7 +587,7 @@ const KeyMap::KeyItem* KeyMap::mapCharacterKey(Keystrokes& keys, KeyID id, std::
                                                KeyModifierMask desiredMask, bool isAutoRepeat) const
 {
     // find KeySym in table
-    KeyIDMap::const_iterator i = m_keyIDMap.find(id);
+    auto i = m_keyIDMap.find(id);
     if (i == m_keyIDMap.end()) {
         // unknown key
         LOG_DEBUG1("key %04x is not on keyboard", id);
@@ -721,8 +716,7 @@ const KeyMap::KeyItem* KeyMap::keyForModifier(KeyButton button, std::int32_t gro
     // must use the other shift button to do the shifting.
     const ModifierKeyItemList& items =
         m_modifierKeys[group * kKeyModifierNumBits + modifierBit];
-    for (ModifierKeyItemList::const_iterator i = items.begin();
-                                i != items.end(); ++i) {
+    for (auto i = items.begin(); i != items.end(); ++i) {
         if ((*i)->m_button != button) {
             return (*i);
         }
@@ -815,8 +809,7 @@ bool KeyMap::keysToRestoreModifiers(const KeyItem& keyItem, std::int32_t,
     collectButtons(desiredModifiers, newKeys);
 
     // release unwanted keys
-    for (ModifierToKeys::const_iterator i = oldModifiers.begin();
-                                i != oldModifiers.end(); ++i) {
+    for (auto i = oldModifiers.begin(); i != oldModifiers.end(); ++i) {
         KeyButton button = i->second.m_button;
         if (button != keyItem.m_button && newKeys.count(button) == 0) {
             EKeystroke type = kKeystrokeRelease;
@@ -829,8 +822,7 @@ bool KeyMap::keysToRestoreModifiers(const KeyItem& keyItem, std::int32_t,
     }
 
     // press wanted keys
-    for (ModifierToKeys::const_iterator i = desiredModifiers.begin();
-                                i != desiredModifiers.end(); ++i) {
+    for (auto i = desiredModifiers.begin(); i != desiredModifiers.end(); ++i) {
         KeyButton button = i->second.m_button;
         if (button != keyItem.m_button && oldKeys.count(button) == 0) {
             EKeystroke type = kKeystrokePress;
@@ -967,11 +959,8 @@ KeyMap::addKeystrokes(EKeystroke type, const KeyItem& keyItem,
         keystrokes.push_back(Keystroke(button, false, false, data));
         if (keyItem.m_generates != 0 && !keyItem.m_lock) {
             // remove key from active modifiers
-            std::pair<ModifierToKeys::iterator,
-                        ModifierToKeys::iterator> range =
-                activeModifiers.equal_range(keyItem.m_generates);
-            for (ModifierToKeys::iterator i = range.first;
-                                i != range.second; ++i) {
+            auto range = activeModifiers.equal_range(keyItem.m_generates);
+            for (auto i = range.first; i != range.second; ++i) {
                 if (i->second.m_button == button) {
                     activeModifiers.erase(i);
                     break;
@@ -1024,11 +1013,8 @@ KeyMap::addKeystrokes(EKeystroke type, const KeyItem& keyItem,
         else {
             // release all the keys that generate the modifier that are
             // currently down
-            std::pair<ModifierToKeys::const_iterator,
-                        ModifierToKeys::const_iterator> range =
-                activeModifiers.equal_range(keyItem.m_generates);
-            for (ModifierToKeys::const_iterator i = range.first;
-                                i != range.second; ++i) {
+            auto range = activeModifiers.equal_range(keyItem.m_generates);
+            for (auto i = range.first; i != range.second; ++i) {
                 keystrokes.push_back(Keystroke(i->second.m_button,
                                 false, false, i->second.m_client));
             }

--- a/src/lib/inputleap/KeyState.cpp
+++ b/src/lib/inputleap/KeyState.cpp
@@ -500,8 +500,7 @@ KeyState::updateKeyState()
     // get the current keyboard state
     KeyButtonSet keysDown;
     pollPressedKeys(keysDown);
-    for (KeyButtonSet::const_iterator i = keysDown.begin();
-                                i != keysDown.end(); ++i) {
+    for (auto i = keysDown.begin(); i != keysDown.end(); ++i) {
         m_keys[*i] = 1;
     }
 
@@ -628,8 +627,7 @@ bool KeyState::fakeKeyRepeat(KeyID id, KeyModifierMask mask, std::int32_t count,
     if (localID != oldLocalID) {
         // replace key up with previous KeyButton but leave key down
         // alone so it uses the new KeyButton.
-        for (Keystrokes::iterator index = keys.begin();
-                                index != keys.end(); ++index) {
+        for (auto index = keys.begin(); index != keys.end(); ++index) {
             if (index->m_type == Keystroke::kButton &&
                 index->m_data.m_button.m_button == localID) {
                 index->m_data.m_button.m_button = oldLocalID;
@@ -673,13 +671,13 @@ KeyState::fakeKeyUp(KeyButton serverID)
     m_serverKeys[serverID] = 0;
 
     // check if this is a modifier
-    ModifierToKeys::iterator i = m_activeModifiers.begin();
+    auto i = m_activeModifiers.begin();
     while (i != m_activeModifiers.end()) {
         if (i->second.m_button == localID && !i->second.m_lock) {
             // modifier is no longer down
             KeyModifierMask mask = i->first;
 
-            ModifierToKeys::iterator tmp = i;
+            auto tmp = i;
             ++i;
             m_activeModifiers.erase(tmp);
 
@@ -841,11 +839,11 @@ void KeyState::fakeKeys(const Keystrokes& keys, std::uint32_t count)
 
     // generate key events
     LOG_DEBUG1("keystrokes:");
-    for (Keystrokes::const_iterator k = keys.begin(); k != keys.end(); ) {
+    for (auto k = keys.begin(); k != keys.end(); ) {
         if (k->m_type == Keystroke::kButton && k->m_data.m_button.m_repeat) {
             // repeat from here up to but not including the next key
             // with m_repeat == false count times.
-            Keystrokes::const_iterator start = k;
+            auto start = k;
             while (count-- > 0) {
                 // send repeating events
                 for (k = start; k != keys.end() &&
@@ -875,12 +873,10 @@ KeyState::updateModifierKeyState(KeyButton button,
 {
     // get the pressed modifier buttons before and after
     inputleap::KeyMap::ButtonToKeyMap oldKeys, newKeys;
-    for (ModifierToKeys::const_iterator i = oldModifiers.begin();
-                                i != oldModifiers.end(); ++i) {
+    for (auto i = oldModifiers.begin(); i != oldModifiers.end(); ++i) {
         oldKeys.insert(std::make_pair(i->second.m_button, &i->second));
     }
-    for (ModifierToKeys::const_iterator i = newModifiers.begin();
-                                i != newModifiers.end(); ++i) {
+    for (auto i = newModifiers.begin(); i != newModifiers.end(); ++i) {
         newKeys.insert(std::make_pair(i->second.m_button, &i->second));
     }
 
@@ -896,15 +892,13 @@ KeyState::updateModifierKeyState(KeyButton button,
                         ButtonToKeyLess());
 
     // update state
-    for (inputleap::KeyMap::ButtonToKeyMap::const_iterator i = released.begin();
-                                i != released.end(); ++i) {
+    for (auto i = released.begin(); i != released.end(); ++i) {
         if (i->first != button) {
             m_keys[i->first]          = 0;
             m_syntheticKeys[i->first] = 0;
         }
     }
-    for (inputleap::KeyMap::ButtonToKeyMap::const_iterator i = pressed.begin();
-                                i != pressed.end(); ++i) {
+    for (auto i = pressed.begin(); i != pressed.end(); ++i) {
         if (i->first != button) {
             m_keys[i->first]          = 1;
             m_syntheticKeys[i->first] = 1;

--- a/src/lib/io/StreamBuffer.cpp
+++ b/src/lib/io/StreamBuffer.cpp
@@ -49,11 +49,11 @@ const void* StreamBuffer::peek(std::uint32_t n)
     }
 
     // reserve space in first chunk
-    ChunkList::iterator head = m_chunks.begin();
+    auto head = m_chunks.begin();
     head->reserve(n + m_headUsed);
 
     // consolidate chunks into the first chunk until it has n bytes
-    ChunkList::iterator scan = head;
+    auto scan = head;
     ++scan;
     while (head->size() - m_headUsed < n && scan != m_chunks.end()) {
         head->insert(head->end(), scan->begin(), scan->end());
@@ -77,7 +77,7 @@ void StreamBuffer::pop(std::uint32_t n)
     m_size -= n;
 
     // discard chunks until more than n bytes would've been discarded
-    ChunkList::iterator scan = m_chunks.begin();
+    auto scan = m_chunks.begin();
     assert(scan != m_chunks.end());
     while (scan->size() - m_headUsed <= n) {
         n -= static_cast<std::uint32_t>(scan->size()) - m_headUsed;
@@ -106,7 +106,7 @@ void StreamBuffer::write(const void* vdata, std::uint32_t n)
     const std::uint8_t* data = static_cast<const std::uint8_t*>(vdata);
 
     // point to last chunk if it has space, otherwise append an empty chunk
-    ChunkList::iterator scan = m_chunks.end();
+    auto scan = m_chunks.end();
     if (scan != m_chunks.begin()) {
         --scan;
         if (scan->size() >= kChunkSize) {

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -101,8 +101,7 @@ MSWindowsClipboard::add(EFormat format, const std::string& data)
     LOG_DEBUG("add %d bytes to clipboard format: %d", data.size(), format);
 
     // convert data to win32 form
-    for (ConverterList::const_iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         IMSWindowsClipboardConverter* converter = *index;
 
         // skip converters for other formats
@@ -151,8 +150,7 @@ MSWindowsClipboard::getTime() const
 bool
 MSWindowsClipboard::has(EFormat format) const
 {
-    for (ConverterList::const_iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         IMSWindowsClipboardConverter* converter = *index;
         if (converter->getFormat() == format) {
             if (IsClipboardFormatAvailable(converter->getWin32Format())) {
@@ -167,8 +165,7 @@ std::string MSWindowsClipboard::get(EFormat format) const
 {
     // find the converter for the first clipboard format we can handle
     IMSWindowsClipboardConverter* converter = nullptr;
-    for (ConverterList::const_iterator index = m_converters.begin();
-        index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
 
         converter = *index;
         if (converter->getFormat() == format) {
@@ -199,8 +196,7 @@ std::string MSWindowsClipboard::get(EFormat format) const
 void
 MSWindowsClipboard::clearConverters()
 {
-    for (ConverterList::iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         delete *index;
     }
     m_converters.clear();

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -745,8 +745,7 @@ MSWindowsDesks::Desk* MSWindowsDesks::addDesk(const std::string& name, HDESK hde
 void
 MSWindowsDesks::removeDesks()
 {
-    for (Desks::iterator index = m_desks.begin();
-                            index != m_desks.end(); ++index) {
+    for (auto index = m_desks.begin(); index != m_desks.end(); ++index) {
         Desk* desk = index->second;
         PostThreadMessage(desk->m_threadID, WM_QUIT, 0, 0);
         desk->m_thread->wait();
@@ -765,7 +764,7 @@ MSWindowsDesks::checkDesk()
     Desk* desk;
     HDESK hdesk  = openInputDesktop();
     std::string name = getDesktopName(hdesk);
-    Desks::const_iterator index = m_desks.find(name);
+    auto index = m_desks.find(name);
     if (index == m_desks.end()) {
         desk = addDesk(name, hdesk);
         // hold on to hdesk until thread exits so the desk can't

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -626,7 +626,7 @@ std::uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 void MSWindowsScreen::unregisterHotKey(std::uint32_t id)
 {
     // look up hotkey
-    HotKeyMap::iterator i = m_hotKeys.find(id);
+    auto i = m_hotKeys.find(id);
     if (i == m_hotKeys.end()) {
         return;
     }
@@ -1103,7 +1103,7 @@ MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
     m_keyState->onKey(button, down, oldState);
 
     if (!down && m_isPrimary && !m_isOnScreen) {
-        PrimaryKeyDownList::iterator find = std::find(m_primaryKeyDownList.begin(), m_primaryKeyDownList.end(), button);
+        auto find = std::find(m_primaryKeyDownList.begin(), m_primaryKeyDownList.end(), button);
         if (find != m_primaryKeyDownList.end()) {
             LOG_DEBUG1("release key button %d on primary", *find);
             m_hook.setMode(kHOOK_WATCH_JUMP_ZONE);
@@ -1218,8 +1218,7 @@ MSWindowsScreen::onHotKey(WPARAM wParam, LPARAM lParam)
     }
 
     // find the hot key id
-    HotKeyToIDMap::const_iterator i =
-        m_hotKeyToIDMap.find(HotKeyItem(virtKey, modifiers));
+    auto i = m_hotKeyToIDMap.find(HotKeyItem(virtKey, modifiers));
     if (i == m_hotKeyToIDMap.end()) {
         return false;
     }

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -96,7 +96,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = nullptr
     }
 
     std::string nameListJoin;
-    for (std::list<std::string>::iterator it = nameList.begin();
+    for (auto it = nameList.begin();
         it != nameList.end(); it++) {
             nameListJoin.append(*it);
             nameListJoin.append(", ");

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -106,8 +106,7 @@ void OSXClipboard::add(EFormat format, const std::string& data)
         LOG_DEBUG(" format of data to be added to clipboard was kHTML");
     }
 
-    for (ConverterList::const_iterator index = m_converters.begin();
-            index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
 
         IOSXClipboardConverter* converter = *index;
 
@@ -165,8 +164,7 @@ OSXClipboard::has(EFormat format) const
     PasteboardItemID item;
     PasteboardGetItemIdentifier(m_pboard, (CFIndex) 1, &item);
 
-    for (ConverterList::const_iterator index = m_converters.begin();
-            index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         IOSXClipboardConverter* converter = *index;
         if (converter->getFormat() == format) {
             PasteboardFlavorFlags flags;
@@ -197,8 +195,7 @@ std::string OSXClipboard::get(EFormat format) const
 
     // find the converter for the first clipboard format we can handle
     IOSXClipboardConverter* converter = nullptr;
-    for (ConverterList::const_iterator index = m_converters.begin();
-            index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         converter = *index;
 
         PasteboardFlavorFlags flags;
@@ -248,8 +245,7 @@ OSXClipboard::clearConverters()
     if (m_pboard == nullptr)
         return;
 
-    for (ConverterList::iterator index = m_converters.begin();
-            index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         delete *index;
     }
     m_converters.clear();

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -242,7 +242,7 @@ OSXKeyState::mapKeyFromEvent(KeyIDs& ids,
     }
 
     // check for special keys
-    VirtualKeyMap::const_iterator i = m_virtualKeyMap.find(vkCode);
+    auto i = m_virtualKeyMap.find(vkCode);
     if (i != m_virtualKeyMap.end()) {
         m_deadKeyState = 0;
         ids.push_back(i->second);
@@ -397,7 +397,7 @@ std::int32_t OSXKeyState::pollActiveGroup() const
     CFDataRef id = (CFDataRef)TISGetInputSourceProperty(
                         keyboardLayout, kTISPropertyInputSourceID);
 
-    GroupMap::const_iterator i = m_groupMap.find(id);
+    auto i = m_groupMap.find(id);
     if (i != m_groupMap.end()) {
         return i->second;
     }
@@ -754,8 +754,7 @@ bool OSXKeyState::getKeyMap(inputleap::KeyMap& keyMap, std::int32_t group,
 
             // now add a key entry for each key/required modifier pair.
             item.m_sensitive = mapModifiersFromOSX(sensitive << 16);
-            for (std::set<std::uint32_t>::iterator k = required.begin();
-                                            k != required.end(); ++k) {
+            for (auto k = required.begin(); k != required.end(); ++k) {
                 item.m_required = mapModifiersFromOSX(*k << 16);
                 keyMap.addKeyEntry(item);
             }
@@ -895,7 +894,7 @@ OSXKeyState::adjustAltGrModifier(const KeyIDs& ids,
                 KeyModifierMask* mask, bool isCommand) const
 {
     if (!isCommand) {
-        for (KeyIDs::const_iterator i = ids.begin(); i != ids.end(); ++i) {
+        for (auto i = ids.begin(); i != ids.end(); ++i) {
             KeyID id = *i;
             if (id != kKeyNone &&
                 ((id < 0xe000u || id > 0xefffu) ||

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -341,7 +341,7 @@ std::uint32_t OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 void OSXScreen::unregisterHotKey(std::uint32_t id)
 {
 	// look up hotkey
-	HotKeyMap::iterator i = m_hotKeys.find(id);
+        auto i = m_hotKeys.find(id);
 	if (i == m_hotKeys.end()) {
 		return;
 	}
@@ -354,8 +354,7 @@ void OSXScreen::unregisterHotKey(std::uint32_t id)
 	else {
 		okay = false;
 		// XXX -- this is inefficient
-		for (ModifierHotKeyMap::iterator j = m_modifierHotKeys.begin();
-								j != m_modifierHotKeys.end(); ++j) {
+                for (auto j = m_modifierHotKeys.begin(); j != m_modifierHotKeys.end(); ++j) {
 			if (j->second == id) {
 				m_modifierHotKeys.erase(j);
 				okay = true;
@@ -1228,7 +1227,7 @@ OSXScreen::onKey(CGEventRef event)
 		return true;
 	}
 
-	HotKeyToIDMap::const_iterator i = m_hotKeyToIDMap.find(HotKeyItem(virtualKey, m_keyState->mapModifiersToCarbon(macMask) & 0xff00u));
+        auto i = m_hotKeyToIDMap.find(HotKeyItem(virtualKey, m_keyState->mapModifiersToCarbon(macMask) & 0xff00u));
 	if (i != m_hotKeyToIDMap.end()) {
 		std::uint32_t id = i->second;
 		// determine event type
@@ -1282,8 +1281,7 @@ OSXScreen::onKey(CGEventRef event)
 	}
 
 	// send key events
-	for (OSXKeyState::KeyIDs::const_iterator i = keys.begin();
-							i != keys.end(); ++i) {
+        for (auto i = keys.begin(); i != keys.end(); ++i) {
         m_keyState->sendKeyEvent(get_event_target(), down, isRepeat,
 							*i, sendMask, 1, button);
 	}

--- a/src/lib/platform/OSXUchrKeyResource.cpp
+++ b/src/lib/platform/OSXUchrKeyResource.cpp
@@ -189,7 +189,7 @@ bool OSXUchrKeyResource::getDeadKey(KeySequence& keys, std::uint16_t index) cons
     }
 
     // convert keys to their dead counterparts
-    for (KeySequence::iterator i = keys.begin(); i != keys.end(); ++i) {
+    for (auto i = keys.begin(); i != keys.end(); ++i) {
         *i = inputleap::KeyMap::getDeadKey(*i);
     }
 

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -227,7 +227,7 @@ bool
 XWindowsClipboard::processRequest(Window requestor,
                 ::Time /*time*/, Atom property)
 {
-    ReplyMap::iterator index = m_replies.find(requestor);
+    auto index = m_replies.find(requestor);
     if (index == m_replies.end()) {
         // unknown requestor window
         return false;
@@ -237,8 +237,7 @@ XWindowsClipboard::processRequest(Window requestor,
     // find the property in the known requests.  it should be the
     // first property but we'll check 'em all if we have to.
     ReplyList& replies = index->second;
-    for (ReplyList::iterator index2 = replies.begin();
-                                index2 != replies.end(); ++index2) {
+    for (auto index2 = replies.begin(); index2 != replies.end(); ++index2) {
         Reply* reply = *index2;
         if (reply->m_replied && reply->m_property == property) {
             // if reply is complete then remove it and start the
@@ -254,7 +253,7 @@ XWindowsClipboard::processRequest(Window requestor,
 bool
 XWindowsClipboard::destroyRequest(Window requestor)
 {
-    ReplyMap::iterator index = m_replies.find(requestor);
+    auto index = m_replies.find(requestor);
     if (index == m_replies.end()) {
         // unknown requestor window
         return false;
@@ -409,8 +408,7 @@ std::string XWindowsClipboard::get(EFormat format) const
 void
 XWindowsClipboard::clearConverters()
 {
-    for (ConverterList::iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         delete *index;
     }
     m_converters.clear();
@@ -420,8 +418,7 @@ IXWindowsClipboardConverter*
 XWindowsClipboard::getConverter(Atom target, bool onlyIfNotAdded) const
 {
     IXWindowsClipboardConverter* converter = nullptr;
-    for (ConverterList::const_iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         converter = *index;
         if (converter->getAtom() == target) {
             break;
@@ -538,8 +535,7 @@ XWindowsClipboard::icccmFillCache()
 
     // try each converter in order (because they're in order of
     // preference).
-    for (ConverterList::const_iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         IXWindowsClipboardConverter* converter = *index;
 
         // skip already handled targets
@@ -797,8 +793,7 @@ XWindowsClipboard::motifFillCache()
 
     // try each converter in order (because they're in order of
     // preference).
-    for (ConverterList::const_iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         IXWindowsClipboardConverter* converter = *index;
 
         // skip already handled targets
@@ -807,8 +802,7 @@ XWindowsClipboard::motifFillCache()
         }
 
         // see if atom is in target list
-        MotifFormatMap::const_iterator index2 =
-                                motifFormats.find(converter->getAtom());
+        auto index2 = motifFormats.find(converter->getAtom());
         if (index2 == motifFormats.end()) {
             continue;
         }
@@ -989,10 +983,9 @@ XWindowsClipboard::pushReplies()
 {
     // send the first reply for each window if that reply hasn't
     // been sent yet.
-    for (ReplyMap::iterator index = m_replies.begin();
-                                index != m_replies.end(); ) {
+    for (auto index = m_replies.begin(); index != m_replies.end(); ) {
         assert(!index->second.empty());
-        ReplyList::iterator listit = index->second.begin();
+        auto listit = index->second.begin();
         while (listit != index->second.end()) {
             if (!(*listit)->m_replied)
                 break;
@@ -1196,8 +1189,7 @@ XWindowsClipboard::sendReply(Reply* reply)
 void
 XWindowsClipboard::clearReplies()
 {
-    for (ReplyMap::iterator index = m_replies.begin();
-                                index != m_replies.end(); ++index) {
+    for (auto index = m_replies.begin(); index != m_replies.end(); ++index) {
         clearReplies(index->second);
     }
     m_replies.clear();
@@ -1207,8 +1199,7 @@ XWindowsClipboard::clearReplies()
 void
 XWindowsClipboard::clearReplies(ReplyList& replies)
 {
-    for (ReplyList::iterator index = replies.begin();
-                                index != replies.end(); ++index) {
+    for (auto index = replies.begin(); index != replies.end(); ++index) {
         delete *index;
     }
     replies.clear();
@@ -1274,8 +1265,7 @@ Atom XWindowsClipboard::getTargetsData(std::string& data, int* format) const
     XWindowsUtil::appendAtomData(data, m_atomTimestamp);
 
     // add targets we can convert to
-    for (ConverterList::const_iterator index = m_converters.begin();
-                                index != m_converters.end(); ++index) {
+    for (auto index = m_converters.begin(); index != m_converters.end(); ++index) {
         IXWindowsClipboardConverter* converter = *index;
 
         // skip formats we don't have

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -136,7 +136,7 @@ XWindowsKeyState::mapModifiersToX(KeyModifierMask mask,
     for (std::int32_t i = 0; i < kKeyModifierNumBits; ++i) {
         KeyModifierMask bit = (1u << i);
         if ((mask & bit) != 0) {
-            KeyModifierToXMask::const_iterator j = m_modifierToX.find(bit);
+            auto j = m_modifierToX.find(bit);
             if (j == m_modifierToX.end()) {
                 return false;
             }
@@ -153,11 +153,8 @@ void
 XWindowsKeyState::mapKeyToKeycodes(KeyID key, KeycodeList& keycodes) const
 {
     keycodes.clear();
-    std::pair<KeyToKeyCodeMap::const_iterator,
-        KeyToKeyCodeMap::const_iterator> range =
-            m_keyCodeFromKey.equal_range(key);
-    for (KeyToKeyCodeMap::const_iterator i = range.first;
-                                i != range.second; ++i) {
+    auto range = m_keyCodeFromKey.equal_range(key);
+    for (auto i = range.first; i != range.second; ++i) {
         keycodes.push_back(i->second);
     }
 }
@@ -671,8 +668,7 @@ XWindowsKeyState::updateKeysymMapXKB(inputleap::KeyMap& keyMap)
 
                 // VMware modifier hack
                 if (useLastGoodModifiers) {
-                    XKBModifierMap::const_iterator k =
-                        m_lastGoodXKBModifiers.find(eGroup * 256 + keycode);
+                    auto k = m_lastGoodXKBModifiers.find(eGroup * 256 + keycode);
                     if (k != m_lastGoodXKBModifiers.end()) {
                         // Use last known good modifier
                         isModifier   = true;

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -664,9 +664,7 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 				toggleModifiers[numToggleModifiers++] = modifier;
 			}
 
-
-			for (XWindowsKeyState::KeycodeList::iterator j = keycodes.begin();
-									j != keycodes.end() && !err; ++j) {
+            for (auto j = keycodes.begin(); j != keycodes.end() && !err; ++j) {
 				for (size_t i = 0; i < (1u << numToggleModifiers); ++i) {
 					// add toggle modifiers for index i
 					unsigned int tmpModifiers = modifiers;
@@ -694,8 +692,7 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 
 	if (err) {
 		// if any failed then unregister any we did get
-		for (HotKeyList::iterator j = hotKeys.begin();
-								j != hotKeys.end(); ++j) {
+        for (auto j = hotKeys.begin(); j != hotKeys.end(); ++j) {
             m_impl->XUngrabKey(m_display, j->first, j->second, m_root);
 			m_hotKeyToIDMap.erase(HotKeyItem(j->first, j->second));
 		}
@@ -713,7 +710,7 @@ std::uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 void XWindowsScreen::unregisterHotKey(std::uint32_t id)
 {
 	// look up hotkey
-	HotKeyMap::iterator i = m_hotKeys.find(id);
+    auto i = m_hotKeys.find(id);
 	if (i == m_hotKeys.end()) {
 		return;
 	}
@@ -723,8 +720,7 @@ void XWindowsScreen::unregisterHotKey(std::uint32_t id)
 	{
 		XWindowsUtil::ErrorLock lock(m_display, &err);
 		HotKeyList& hotKeys = i->second;
-		for (HotKeyList::iterator j = hotKeys.begin();
-								j != hotKeys.end(); ++j) {
+        for (auto j = hotKeys.begin(); j != hotKeys.end(); ++j) {
             m_impl->XUngrabKey(m_display, j->first, j->second, m_root);
 			m_hotKeyToIDMap.erase(HotKeyItem(j->first, j->second));
 		}
@@ -1462,8 +1458,7 @@ bool
 XWindowsScreen::onHotKey(XKeyEvent& xkey, bool isRepeat)
 {
 	// find the hot key id
-	HotKeyToIDMap::const_iterator i =
-		m_hotKeyToIDMap.find(HotKeyItem(xkey.keycode, xkey.state & SCROLL_LOCK_EXCLUDE_MASK));
+    auto i = m_hotKeyToIDMap.find(HotKeyItem(xkey.keycode, xkey.state & SCROLL_LOCK_EXCLUDE_MASK));
 	if (i == m_hotKeyToIDMap.end()) {
 		return false;
 	}

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -436,8 +436,7 @@ XWindowsScreenSaver::clearWatchForXScreenSaver()
 {
     // stop watching all windows
     XWindowsUtil::ErrorLock lock(m_display);
-    for (WatchList::iterator index = m_watchWindows.begin();
-                                index != m_watchWindows.end(); ++index) {
+    for (auto index = m_watchWindows.begin(); index != m_watchWindows.end(); ++index) {
         m_impl->XSelectInput(m_display, index->first, index->second);
     }
     m_watchWindows.clear();

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1591,7 +1591,7 @@ XWindowsUtil::mapKeySymToKeyID(KeySym k)
 
     default: {
         // lookup character in table
-        KeySymMap::const_iterator index = s_keySymToUCS4.find(k);
+        auto index = s_keySymToUCS4.find(k);
         if (index != s_keySymToUCS4.end()) {
             return static_cast<KeyID>(index->second);
         }

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -69,8 +69,7 @@ ClientListener::~ClientListener()
     LOG_DEBUG1("stop listening for clients");
 
     // discard already connected clients
-    for (NewClients::iterator index = m_newClients.begin();
-                                index != m_newClients.end(); ++index) {
+    for (auto index = m_newClients.begin(); index != m_newClients.end(); ++index) {
         ClientProxyUnknown* client = *index;
         m_events->remove_handler(EventType::CLIENT_PROXY_UNKNOWN_SUCCESS, client);
         m_events->remove_handler(EventType::CLIENT_PROXY_UNKNOWN_FAILURE, client);
@@ -192,8 +191,7 @@ void ClientListener::handle_unknown_client(ClientProxyUnknown* unknownClient)
 void ClientListener::handle_client_disconnected(ClientProxy* client)
 {
     // find client in waiting clients queue
-    for (WaitingClients::iterator i = m_waitingClients.begin(),
-                            n = m_waitingClients.end(); i != n; ++i) {
+    for (auto i = m_waitingClients.begin(), n = m_waitingClients.end(); i != n; ++i) {
         if (*i == client) {
             m_waitingClients.erase(i);
             m_events->remove_handler(EventType::CLIENT_PROXY_DISCONNECTED, client);

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -64,7 +64,7 @@ bool Config::renameScreen(const std::string& oldName, const std::string& newName
 {
 	// get canonical name and find cell
     std::string oldCanonical = getCanonicalName(oldName);
-	CellMap::iterator index = m_map.find(oldCanonical);
+    auto index = m_map.find(oldCanonical);
 	if (index == m_map.end()) {
 		return false;
 	}
@@ -93,8 +93,7 @@ bool Config::renameScreen(const std::string& oldName, const std::string& newName
 
 	// update alias targets
 	if (CaselessCmp::equal(oldName, oldCanonical)) {
-		for (NameMap::iterator iter = m_nameToCanonicalName.begin();
-							iter != m_nameToCanonicalName.end(); ++iter) {
+        for (auto iter = m_nameToCanonicalName.begin(); iter != m_nameToCanonicalName.end(); ++iter) {
 			if (CaselessCmp::equal(
 							iter->second, oldCanonical)) {
 				iter->second = newName;
@@ -109,7 +108,7 @@ void Config::removeScreen(const std::string& name)
 {
 	// get canonical name and find cell
     std::string canonical = getCanonicalName(name);
-	CellMap::iterator index = m_map.find(canonical);
+    auto index = m_map.find(canonical);
 	if (index == m_map.end()) {
 		return;
 	}
@@ -124,8 +123,7 @@ void Config::removeScreen(const std::string& name)
 	}
 
 	// remove aliases (and canonical name)
-	for (NameMap::iterator iter = m_nameToCanonicalName.begin();
-								iter != m_nameToCanonicalName.end(); ) {
+    for (auto iter = m_nameToCanonicalName.begin(); iter != m_nameToCanonicalName.end(); ) {
 		if (iter->second == canonical) {
 			m_nameToCanonicalName.erase(iter++);
 		}
@@ -168,7 +166,7 @@ bool Config::removeAlias(const std::string& alias)
 	}
 
 	// find alias
-	NameMap::iterator index = m_nameToCanonicalName.find(alias);
+    auto index = m_nameToCanonicalName.find(alias);
 	if (index == m_nameToCanonicalName.end()) {
 		return false;
 	}
@@ -187,8 +185,7 @@ bool Config::removeAliases(const std::string& canonical)
 	}
 
 	// find and removing matching aliases
-	for (NameMap::iterator index = m_nameToCanonicalName.begin();
-							index != m_nameToCanonicalName.end(); ) {
+    for (auto index = m_nameToCanonicalName.begin(); index != m_nameToCanonicalName.end(); ) {
 		if (index->second == canonical && index->first != canonical) {
 			m_nameToCanonicalName.erase(index++);
 		}
@@ -207,8 +204,7 @@ Config::removeAllAliases()
 	m_nameToCanonicalName.clear();
 
 	// put the canonical names back in
-	for (CellMap::iterator index = m_map.begin();
-								index != m_map.end(); ++index) {
+    for (auto index = m_map.begin(); index != m_map.end(); ++index) {
 		m_nameToCanonicalName.insert(
 								std::make_pair(index->first, index->first));
 	}
@@ -221,7 +217,7 @@ bool Config::connect(const std::string& srcName, EDirection srcSide,
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
 	// find source cell
-	CellMap::iterator index = m_map.find(getCanonicalName(srcName));
+    auto index = m_map.find(getCanonicalName(srcName));
 	if (index == m_map.end()) {
 		return false;
 	}
@@ -237,7 +233,7 @@ bool Config::disconnect(const std::string& srcName, EDirection srcSide)
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
 	// find source cell
-	CellMap::iterator index = m_map.find(srcName);
+    auto index = m_map.find(srcName);
 	if (index == m_map.end()) {
 		return false;
 	}
@@ -253,7 +249,7 @@ bool Config::disconnect(const std::string& srcName, EDirection srcSide, float po
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
 	// find source cell
-	CellMap::iterator index = m_map.find(srcName);
+    auto index = m_map.find(srcName);
 	if (index == m_map.end()) {
 		return false;
 	}
@@ -278,7 +274,7 @@ bool Config::addOption(const std::string& name, OptionID option, OptionValue val
 		options = &m_globalOptions;
 	}
 	else {
-		CellMap::iterator index = m_map.find(name);
+        auto index = m_map.find(name);
 		if (index != m_map.end()) {
 			options = &index->second.m_options;
 		}
@@ -300,7 +296,7 @@ bool Config::removeOption(const std::string& name, OptionID option)
 		options = &m_globalOptions;
 	}
 	else {
-		CellMap::iterator index = m_map.find(name);
+        auto index = m_map.find(name);
 		if (index != m_map.end()) {
 			options = &index->second.m_options;
 		}
@@ -322,7 +318,7 @@ bool Config::removeOptions(const std::string& name)
 		options = &m_globalOptions;
 	}
 	else {
-		CellMap::iterator index = m_map.find(name);
+        auto index = m_map.find(name);
 		if (index != m_map.end()) {
 			options = &index->second.m_options;
 		}
@@ -432,7 +428,7 @@ Config::isCanonicalName(const std::string& name) const
 
 std::string Config::getCanonicalName(const std::string& name) const
 {
-	NameMap::const_iterator index = m_nameToCanonicalName.find(name);
+    auto index = m_nameToCanonicalName.find(name);
 	if (index == m_nameToCanonicalName.end()) {
         return std::string();
 	}
@@ -447,7 +443,7 @@ std::string Config::getNeighbor(const std::string& srcName, EDirection srcSide,
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
 	// find source cell
-	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
+    auto index = m_map.find(getCanonicalName(srcName));
 	if (index == m_map.end()) {
         return std::string();
 	}
@@ -481,7 +477,7 @@ bool Config::hasNeighbor(const std::string& srcName, EDirection srcSide,
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
 	// find source cell
-	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
+    auto index = m_map.find(getCanonicalName(srcName));
 	if (index == m_map.end()) {
 		return false;
 	}
@@ -491,14 +487,14 @@ bool Config::hasNeighbor(const std::string& srcName, EDirection srcSide,
 
 Config::link_const_iterator Config::beginNeighbor(const std::string& srcName) const
 {
-	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
+    auto index = m_map.find(getCanonicalName(srcName));
 	assert(index != m_map.end());
 	return index->second.begin();
 }
 
 Config::link_const_iterator Config::endNeighbor(const std::string& srcName) const
 {
-	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
+    auto index = m_map.find(getCanonicalName(srcName));
 	assert(index != m_map.end());
 	return index->second.end();
 }
@@ -516,7 +512,7 @@ const Config::ScreenOptions* Config::getOptions(const std::string& name) const
 		options = &m_globalOptions;
 	}
 	else {
-		CellMap::const_iterator index = m_map.find(name);
+        auto index = m_map.find(name);
 		if (index != m_map.end()) {
 			options = &index->second.m_options;
 		}
@@ -550,9 +546,8 @@ Config::operator==(const Config& x) const
 		return false;
 	}
 
-	for (CellMap::const_iterator index1 = m_map.begin(),
-								index2 = x.m_map.begin();
-								index1 != m_map.end(); ++index1, ++index2) {
+    for (auto index1 = m_map.begin(), index2 = x.m_map.begin();
+         index1 != m_map.end(); ++index1, ++index2) {
 		// compare names
 		if (!CaselessCmp::equal(index1->first, index2->first)) {
 			return false;
@@ -564,10 +559,8 @@ Config::operator==(const Config& x) const
 		}
 	}
 
-	for (NameMap::const_iterator index1 = m_nameToCanonicalName.begin(),
-								index2 = x.m_nameToCanonicalName.begin();
-								index1 != m_nameToCanonicalName.end();
-								++index1, ++index2) {
+    for (auto index1 = m_nameToCanonicalName.begin(), index2 = x.m_nameToCanonicalName.begin();
+         index1 != m_nameToCanonicalName.end(); ++index1, ++index2) {
 		if (!CaselessCmp::equal(index1->first,  index2->first) ||
 			!CaselessCmp::equal(index1->second, index2->second)) {
 			return false;
@@ -1592,8 +1585,7 @@ Config::Cell::add(const CellEdge& src, const CellEdge& dst)
 void
 Config::Cell::remove(EDirection side)
 {
-	for (EdgeLinks::iterator j = m_neighbors.begin();
-							j != m_neighbors.end(); ) {
+    for (auto j = m_neighbors.begin(); j != m_neighbors.end(); ) {
 		if (j->first.getSide() == side) {
 			m_neighbors.erase(j++);
 		}
@@ -1606,8 +1598,7 @@ Config::Cell::remove(EDirection side)
 void
 Config::Cell::remove(EDirection side, float position)
 {
-	for (EdgeLinks::iterator j = m_neighbors.begin();
-							j != m_neighbors.end(); ++j) {
+    for (auto j = m_neighbors.begin(); j != m_neighbors.end(); ++j) {
 		if (j->first.getSide() == side && j->first.isInside(position)) {
 			m_neighbors.erase(j);
 			break;
@@ -1617,8 +1608,7 @@ Config::Cell::remove(EDirection side, float position)
 void
 Config::Cell::remove(const Name& name)
 {
-	for (EdgeLinks::iterator j = m_neighbors.begin();
-							j != m_neighbors.end(); ) {
+    for (auto j = m_neighbors.begin(); j != m_neighbors.end(); ) {
 		if (name == j->second.getName()) {
 			m_neighbors.erase(j++);
 		}
@@ -1630,8 +1620,7 @@ Config::Cell::remove(const Name& name)
 
 void Config::Cell::rename(const Name& oldName, const std::string& newName)
 {
-	for (EdgeLinks::iterator j = m_neighbors.begin();
-							j != m_neighbors.end(); ++j) {
+    for (auto j = m_neighbors.begin(); j != m_neighbors.end(); ++j) {
 		if (oldName == j->second.getName()) {
 			j->second.setName(newName);
 		}
@@ -1641,14 +1630,14 @@ void Config::Cell::rename(const Name& oldName, const std::string& newName)
 bool
 Config::Cell::hasEdge(const CellEdge& edge) const
 {
-	EdgeLinks::const_iterator i = m_neighbors.find(edge);
+    auto i = m_neighbors.find(edge);
 	return (i != m_neighbors.end() && i->first == edge);
 }
 
 bool
 Config::Cell::overlaps(const CellEdge& edge) const
 {
-	EdgeLinks::const_iterator i = m_neighbors.upper_bound(edge);
+    auto i = m_neighbors.upper_bound(edge);
 	if (i != m_neighbors.end() && i->first.overlaps(edge)) {
 		return true;
 	}
@@ -1663,7 +1652,7 @@ Config::Cell::getLink(EDirection side, float position,
 				const CellEdge*& src, const CellEdge*& dst) const
 {
 	CellEdge edge(side, position);
-	EdgeLinks::const_iterator i = m_neighbors.upper_bound(edge);
+    auto i = m_neighbors.upper_bound(edge);
 	if (i == m_neighbors.begin()) {
 		return false;
 	}
@@ -1688,10 +1677,8 @@ Config::Cell::operator==(const Cell& x) const
 	if (m_neighbors.size() != x.m_neighbors.size()) {
 		return false;
 	}
-	for (EdgeLinks::const_iterator index1 = m_neighbors.begin(),
-								index2 = x.m_neighbors.begin();
-								index1 != m_neighbors.end();
-								++index1, ++index2) {
+    for (auto index1 = m_neighbors.begin(), index2 = x.m_neighbors.begin();
+         index1 != m_neighbors.end(); ++index1, ++index2) {
 		if (index1->first != index2->first) {
 			return false;
 		}
@@ -1745,14 +1732,11 @@ operator<<(std::ostream& s, const Config& config)
 {
 	// screens section
     s << "section: screens\n";
-	for (Config::const_iterator screen = config.begin();
-								screen != config.end(); ++screen) {
+    for (auto screen = config.begin(); screen != config.end(); ++screen) {
         s << "\t" << screen->c_str() << ":\n";
 		const Config::ScreenOptions* options = config.getOptions(*screen);
 		if (options != nullptr && options->size() > 0) {
-			for (Config::ScreenOptions::const_iterator
-								option  = options->begin();
-								option != options->end(); ++option) {
+            for (auto option = options->begin(); option != options->end(); ++option) {
 				const char* name = Config::getOptionName(option->first);
                 std::string value = Config::getOptionValue(option->first, option->second);
 				if (name != nullptr && !value.empty()) {
@@ -1766,13 +1750,11 @@ operator<<(std::ostream& s, const Config& config)
 	// links section
     std::string neighbor;
     s << "section: links\n";
-	for (Config::const_iterator screen = config.begin();
-								screen != config.end(); ++screen) {
+    for (auto screen = config.begin(); screen != config.end(); ++screen) {
         s << "\t" << screen->c_str() << ":\n";
 
-		for (Config::link_const_iterator
-				link = config.beginNeighbor(*screen),
-				nend = config.endNeighbor(*screen); link != nend; ++link) {
+        for (auto link = config.beginNeighbor(*screen), nend = config.endNeighbor(*screen);
+             link != nend; ++link) {
 			s << "\t\t" << Config::dirName(link->first.getSide()) <<
 				Config::formatInterval(link->first.getInterval()) <<
 				" = " << link->second.getName().c_str() <<
@@ -1787,10 +1769,9 @@ operator<<(std::ostream& s, const Config& config)
 		// map canonical to alias
         typedef std::multimap<std::string, std::string, CaselessCmp> CMNameMap;
 		CMNameMap aliases;
-		for (Config::NameMap::const_iterator
-								index = config.m_nameToCanonicalName.begin();
-								index != config.m_nameToCanonicalName.end();
-								++index) {
+        for (auto index = config.m_nameToCanonicalName.begin();
+             index != config.m_nameToCanonicalName.end();
+             ++index) {
 			if (index->first != index->second) {
 				aliases.insert(std::make_pair(index->second, index->first));
 			}
@@ -1799,8 +1780,7 @@ operator<<(std::ostream& s, const Config& config)
 		// dump it
         std::string screen;
         s << "section: aliases\n";
-		for (CMNameMap::const_iterator index = aliases.begin();
-								index != aliases.end(); ++index) {
+        for (auto index = aliases.begin(); index != aliases.end(); ++index) {
 			if (index->first != screen) {
 				screen = index->first;
                 s << "\t" << screen.c_str() << ":\n";

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -648,12 +648,10 @@ void
 InputFilter::Rule::clear()
 {
     delete m_condition;
-    for (ActionList::iterator i = m_activateActions.begin();
-                                i != m_activateActions.end(); ++i) {
+    for (auto i = m_activateActions.begin(); i != m_activateActions.end(); ++i) {
         delete *i;
     }
-    for (ActionList::iterator i = m_deactivateActions.begin();
-                                i != m_deactivateActions.end(); ++i) {
+    for (auto i = m_deactivateActions.begin(); i != m_deactivateActions.end(); ++i) {
         delete *i;
     }
 
@@ -669,12 +667,10 @@ InputFilter::Rule::copy(const Rule& rule)
     if (rule.m_condition != nullptr) {
         m_condition = rule.m_condition->clone();
     }
-    for (ActionList::const_iterator i = rule.m_activateActions.begin();
-                                i != rule.m_activateActions.end(); ++i) {
+    for (auto i = rule.m_activateActions.begin(); i != rule.m_activateActions.end(); ++i) {
         m_activateActions.push_back((*i)->clone());
     }
-    for (ActionList::const_iterator i = rule.m_deactivateActions.begin();
-                                i != rule.m_deactivateActions.end(); ++i) {
+    for (auto i = rule.m_deactivateActions.begin(); i != rule.m_deactivateActions.end(); ++i) {
         m_deactivateActions.push_back((*i)->clone());
     }
 }
@@ -769,8 +765,7 @@ InputFilter::Rule::handleEvent(const Event& event)
     }
 
     // perform actions
-    for (ActionList::const_iterator i = actions->begin();
-                                i != actions->end(); ++i) {
+    for (auto i = actions->begin(); i != actions->end(); ++i) {
         LOG_DEBUG1("hotkey: %s", (*i)->format().c_str());
         (*i)->perform(event);
     }
@@ -787,7 +782,7 @@ std::string InputFilter::Rule::format() const
         s += " = ";
 
         // activate actions
-        ActionList::const_iterator i = m_activateActions.begin();
+        auto i = m_activateActions.begin();
         if (i != m_activateActions.end()) {
             s += (*i)->format();
             while (++i != m_activateActions.end()) {
@@ -908,8 +903,7 @@ InputFilter::setPrimaryClient(PrimaryClient* client)
     }
 
     if (m_primaryClient != nullptr) {
-        for (RuleList::iterator rule  = m_ruleList.begin();
-                                 rule != m_ruleList.end(); ++rule) {
+        for (auto rule  = m_ruleList.begin(); rule != m_ruleList.end(); ++rule) {
             rule->disable(m_primaryClient);
         }
 
@@ -944,8 +938,7 @@ InputFilter::setPrimaryClient(PrimaryClient* client)
         m_events->add_handler(EventType::SERVER_CONNECTED, event_target,
                               [this](const auto& e){ handle_event(e); });
 
-        for (RuleList::iterator rule  = m_ruleList.begin();
-                                 rule != m_ruleList.end(); ++rule) {
+        for (auto rule = m_ruleList.begin(); rule != m_ruleList.end(); ++rule) {
             rule->enable(m_primaryClient);
         }
     }
@@ -954,8 +947,7 @@ InputFilter::setPrimaryClient(PrimaryClient* client)
 std::string InputFilter::format(const std::string& linePrefix) const
 {
     std::string s;
-    for (RuleList::const_iterator i = m_ruleList.begin();
-                                i != m_ruleList.end(); ++i) {
+    for (auto i = m_ruleList.begin(); i != m_ruleList.end(); ++i) {
         s += linePrefix;
         s += i->format();
         s += "\n";
@@ -979,12 +971,10 @@ InputFilter::operator==(const InputFilter& x) const
     // compare rule lists.  the easiest way to do that is to format each
     // rule into a string, sort the strings, then compare the results.
     std::vector<std::string> aList, bList;
-    for (RuleList::const_iterator i = m_ruleList.begin();
-                                i != m_ruleList.end(); ++i) {
+    for (auto i = m_ruleList.begin(); i != m_ruleList.end(); ++i) {
         aList.push_back(i->format());
     }
-    for (RuleList::const_iterator i = x.m_ruleList.begin();
-                                i != x.m_ruleList.end(); ++i) {
+    for (auto i = x.m_ruleList.begin(); i != x.m_ruleList.end(); ++i) {
         bList.push_back(i->format());
     }
     std::partial_sort(aList.begin(), aList.end(), aList.end());
@@ -1005,8 +995,7 @@ void InputFilter::handle_event(const Event& event)
     myEvent.clone_data_from(event);
 
     // let each rule try to match the event until one does
-    for (RuleList::iterator rule  = m_ruleList.begin();
-                             rule != m_ruleList.end(); ++rule) {
+    for (auto rule = m_ruleList.begin(); rule != m_ruleList.end(); ++rule) {
         if (rule->handleEvent(myEvent)) {
             // handled
             return;

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -207,8 +207,7 @@ Server::~Server()
 
 	// force immediate disconnection of secondary clients
 	disconnect();
-	for (OldClients::iterator index = m_oldClients.begin();
-							index != m_oldClients.end(); ++index) {
+    for (auto index = m_oldClients.begin(); index != m_oldClients.end(); ++index) {
 		BaseClientProxy* client = index->first;
 		m_events->deleteTimer(index->second);
         m_events->remove_handler(EventType::TIMER, client);
@@ -257,8 +256,7 @@ Server::setConfig(const Config& config)
 	m_primaryClient->reconfigure(getActivePrimarySides());
 
 	// tell all (connected) clients about current options
-	for (ClientList::const_iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+    for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 		BaseClientProxy* client = index->second;
 		sendOptions(client);
 	}
@@ -327,8 +325,7 @@ void
 Server::getClients(std::vector<std::string>& list) const
 {
 	list.clear();
-	for (ClientList::const_iterator index = m_clients.begin();
-							index != m_clients.end(); ++index) {
+    for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 		list.push_back(index->first);
 	}
 }
@@ -577,7 +574,7 @@ BaseClientProxy* Server::getNeighbor(BaseClientProxy* src, EDirection dir, std::
 
 		// look up neighbor cell.  if the screen is connected and
 		// ready then we can stop.
-		ClientList::const_iterator index = m_clients.find(dstName);
+        auto index = m_clients.find(dstName);
 		if (index != m_clients.end()) {
 			LOG_DEBUG2("\"%s\" is on %s of \"%s\" at %f", dstName.c_str(), Config::dirName(dir), srcName.c_str(), t);
 			mapToPixel(index->second, dir, tTmp, x, y);
@@ -808,8 +805,7 @@ bool Server::isSwitchOkay(BaseClientProxy* newScreen, EDirection dir, std::int32
 	}
 	if (options != nullptr && options->count(kOptionScreenSwitchCorners) > 0) {
 		// get corner mask and size
-		Config::ScreenOptions::const_iterator i =
-			options->find(kOptionScreenSwitchCorners);
+        auto i = options->find(kOptionScreenSwitchCorners);
         std::uint32_t corners = static_cast<std::uint32_t>(i->second);
 		i = options->find(kOptionScreenSwitchCornerSize);
 		std::int32_t size = 0;
@@ -1053,8 +1049,7 @@ Server::sendOptions(BaseClientProxy* client) const
 	if (options != nullptr) {
 		// convert options to a more convenient form for sending
 		optionsList.reserve(2 * options->size());
-		for (Config::ScreenOptions::const_iterator index = options->begin();
-									index != options->end(); ++index) {
+        for (auto index = options->begin(); index != options->end(); ++index) {
 			optionsList.push_back(index->first);
             optionsList.push_back(static_cast<std::uint32_t>(index->second));
 		}
@@ -1065,8 +1060,7 @@ Server::sendOptions(BaseClientProxy* client) const
 	if (options != nullptr) {
 		// convert options to a more convenient form for sending
 		optionsList.reserve(optionsList.size() + 2 * options->size());
-		for (Config::ScreenOptions::const_iterator index = options->begin();
-									index != options->end(); ++index) {
+        for (auto index = options->begin(); index != options->end(); ++index) {
 			optionsList.push_back(index->first);
             optionsList.push_back(static_cast<std::uint32_t>(index->second));
 		}
@@ -1090,8 +1084,7 @@ Server::processOptions()
 	m_switchNeedsAlt = false;		// doesn't work correct.
 
 	bool newRelativeMoves = m_relativeMoves;
-	for (Config::ScreenOptions::const_iterator index = options->begin();
-								index != options->end(); ++index) {
+    for (auto index = options->begin(); index != options->end(); ++index) {
 		const OptionID id       = index->first;
 		const OptionValue value = index->second;
 		if (id == kOptionScreenSwitchDelay) {
@@ -1210,8 +1203,7 @@ void Server::handle_clipboard_grabbed(const Event& event, BaseClientProxy* grabb
 
 	// tell all other screens to take ownership of clipboard.  tell the
 	// grabber that it's clipboard isn't dirty.
-	for (ClientList::iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+    for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 		BaseClientProxy* client = index->second;
 		if (client == grabber) {
             client->setClipboardDirty(info.m_id, false);
@@ -1326,7 +1318,7 @@ void Server::handle_switch_to_screen_event(const Event& event)
 {
     const auto& info = event.get_data_as<SwitchToScreenInfo>();
 
-    ClientList::const_iterator index = m_clients.find(info.m_screen);
+    auto index = m_clients.find(info.m_screen);
 	if (index == m_clients.end()) {
         LOG_DEBUG1("screen \"%s\" not active", info.m_screen.c_str());
 	}
@@ -1341,7 +1333,7 @@ Server::handle_toggle_screen_event(const Event& event)
     (void) event;
 
   std::string current = getName(m_active);
-  ClientList::const_iterator index = m_clients.find(current);
+  auto index = m_clients.find(current);
   if (index == m_clients.end()) {
     LOG_DEBUG1("screen \"%s\" not active", current.c_str());
   }
@@ -1492,8 +1484,7 @@ void Server::onClipboardChanged(BaseClientProxy* sender, ClipboardID id, std::ui
 	clipboard.m_clipboardData = data;
 
 	// tell all clients except the sender that the clipboard is dirty
-	for (ClientList::const_iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+    for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 		BaseClientProxy* client = index->second;
 		client->setClipboardDirty(id, client != sender);
 	}
@@ -1550,8 +1541,7 @@ Server::onScreensaver(bool activated)
 	}
 
 	// send message to all clients
-	for (ClientList::const_iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+    for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 		BaseClientProxy* client = index->second;
 		client->screensaver(activated);
 	}
@@ -1575,8 +1565,7 @@ Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button,
 				screens = "*";
 			}
 		}
-		for (ClientList::const_iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+        for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 			if (IKeyState::KeyInfo::contains(screens, index->first)) {
 				index->second->keyDown(id, mask, button);
 			}
@@ -1602,8 +1591,7 @@ Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button,
 				screens = "*";
 			}
 		}
-		for (ClientList::const_iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+        for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 			if (IKeyState::KeyInfo::contains(screens, index->first)) {
 				index->second->keyUp(id, mask, button);
 			}
@@ -2052,7 +2040,7 @@ bool
 Server::removeClient(BaseClientProxy* client)
 {
 	// return false if not in list
-	ClientSet::iterator i = m_clientSet.find(client);
+    auto i = m_clientSet.find(client);
 	if (i == m_clientSet.end()) {
 		return false;
 	}
@@ -2114,8 +2102,7 @@ Server::closeClients(const Config& config)
 	// from the configuration (or who's canonical name is changing).
 	typedef std::set<BaseClientProxy*> RemovedClients;
 	RemovedClients removed;
-	for (ClientList::iterator index = m_clients.begin();
-								index != m_clients.end(); ++index) {
+    for (auto index = m_clients.begin(); index != m_clients.end(); ++index) {
 		if (!config.isCanonicalName(index->first)) {
 			removed.insert(index->second);
 		}
@@ -2126,8 +2113,7 @@ Server::closeClients(const Config& config)
 
 	// now close them.  we collect the list then close in two steps
 	// because closeClient() modifies the collection we iterate over.
-	for (RemovedClients::iterator index = removed.begin();
-								index != removed.end(); ++index) {
+    for (auto index = removed.begin(); index != removed.end(); ++index) {
 		closeClient(*index, kMsgCClose);
 	}
 }
@@ -2147,7 +2133,7 @@ Server::removeActiveClient(BaseClientProxy* client)
 void
 Server::removeOldClient(BaseClientProxy* client)
 {
-	OldClients::iterator i = m_oldClients.find(client);
+    auto i = m_oldClients.find(client);
 	if (i != m_oldClients.end()) {
         m_events->remove_handler(EventType::CLIENT_PROXY_DISCONNECTED, client);
         m_events->remove_handler(EventType::TIMER, i->second);

--- a/src/server/MSWindowsServerTaskBarReceiver.cpp
+++ b/src/server/MSWindowsServerTaskBarReceiver.cpp
@@ -101,8 +101,7 @@ MSWindowsServerTaskBarReceiver::showStatus()
     SendMessage(child, WM_SETTEXT, 0, (LPARAM)status.c_str());
     child = GetDlgItem(m_window, IDC_TASKBAR_STATUS_CLIENTS);
     SendMessage(child, LB_RESETCONTENT, 0, 0);
-    for (Clients::const_iterator index = clients.begin();
-                            index != clients.end(); ) {
+    for (auto index = clients.begin(); index != clients.end(); ) {
         const char* client = index->c_str();
         if (++index == clients.end()) {
             SendMessage(child, LB_ADDSTRING, 0, (LPARAM)client);
@@ -254,8 +253,7 @@ MSWindowsServerTaskBarReceiver::copyLog() const
     if (m_logBuffer != nullptr) {
         // collect log buffer
         std::string data;
-        for (BufferedLogOutputter::const_iterator index = m_logBuffer->begin();
-                                index != m_logBuffer->end(); ++index) {
+        for (auto index = m_logBuffer->begin(); index != m_logBuffer->end(); ++index) {
             data += *index;
             data += "\n";
         }


### PR DESCRIPTION
There's no reason to spell out full type names when IDE can do so on demand if needed.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
