### PR TITLE
Cleanup configuration handling

### DIFF
--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -807,7 +807,7 @@ ServerApp::runInner(int argc, char** argv, ILogOutputter* outputter, StartupFunc
 {
     // general initialization
     listen_address_ = new NetworkAddress;
-    args().m_config         = new Config(m_events);
+    args().m_config = new Config();
     args().m_exename = ArgParser::parse_exename(argv[0]);
 
     // install caller's output filter

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1808,7 +1808,7 @@ operator<<(std::ostream& s, const Config& config)
 		s << "\taddress = " <<
             config.listen_address_.getHostname().c_str() << "\n";
 	}
-	s << config.m_inputFilter.format("\t");
+    s << format_rules(config.m_inputFilter.get_rules(), "\t");
     s << "end\n";
 
 	return s;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -568,7 +568,7 @@ Config::operator==(const Config& x) const
 	}
 
 	// compare input filters
-	if (m_inputFilter != x.m_inputFilter) {
+    if (!are_rules_equal(m_inputFilter.get_rules(), x.m_inputFilter.get_rules())) {
 		return false;
 	}
 

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1026,7 +1026,7 @@ InputFilter::Condition* Config::parseCondition(ConfigReadContext& s, const std::
 
         IPlatformScreen::KeyInfo keyInfo = s.parseKeystroke(args[0]);
 
-		return new InputFilter::KeystrokeCondition(m_events, keyInfo);
+        return new InputFilter::KeystrokeCondition(keyInfo);
 	}
 
 	if (name == "mousebutton") {
@@ -1034,7 +1034,7 @@ InputFilter::Condition* Config::parseCondition(ConfigReadContext& s, const std::
 			throw XConfigRead(s, "syntax for condition: mousebutton(modifiers+button)");
 		}
 
-        return new InputFilter::MouseButtonCondition(m_events, s.parseMouse(args[0]));
+        return new InputFilter::MouseButtonCondition(s.parseMouse(args[0]));
 	}
 
 	if (name == "connect") {
@@ -1050,7 +1050,7 @@ InputFilter::Condition* Config::parseCondition(ConfigReadContext& s, const std::
 			throw XConfigRead(s, "unknown screen name \"%{1}\" in connect", screen);
 		}
 
-		return new InputFilter::ScreenConnectedCondition(m_events, screen);
+        return new InputFilter::ScreenConnectedCondition(screen);
 	}
 
 	throw XConfigRead(s, "unknown argument \"%{1}\"", name);
@@ -1078,16 +1078,16 @@ void Config::parseAction(ConfigReadContext& s, const std::string& name,
 		}
 
 		if (name == "keystroke") {
-            action = new InputFilter::KeystrokeAction(m_events, keyInfo, true);
+            action = new InputFilter::KeystrokeAction(keyInfo, true);
 			rule.adoptAction(action, true);
-			action   = new InputFilter::KeystrokeAction(m_events, keyInfo, false);
+            action   = new InputFilter::KeystrokeAction(keyInfo, false);
 			activate = false;
 		}
 		else if (name == "keyDown") {
-			action = new InputFilter::KeystrokeAction(m_events, keyInfo, true);
+            action = new InputFilter::KeystrokeAction(keyInfo, true);
 		}
 		else {
-			action = new InputFilter::KeystrokeAction(m_events, keyInfo, false);
+            action = new InputFilter::KeystrokeAction(keyInfo, false);
 		}
 	}
 
@@ -1100,16 +1100,16 @@ void Config::parseAction(ConfigReadContext& s, const std::string& name,
         auto mouseInfo = s.parseMouse(args[0]);
 
 		if (name == "mousebutton") {
-            action = new InputFilter::MouseButtonAction(m_events, mouseInfo, true);
+            action = new InputFilter::MouseButtonAction(mouseInfo, true);
 			rule.adoptAction(action, true);
-			action   = new InputFilter::MouseButtonAction(m_events, mouseInfo, false);
+            action   = new InputFilter::MouseButtonAction(mouseInfo, false);
 			activate = false;
 		}
 		else if (name == "mouseDown") {
-			action = new InputFilter::MouseButtonAction(m_events, mouseInfo, true);
+            action = new InputFilter::MouseButtonAction(mouseInfo, true);
 		}
 		else {
-			action = new InputFilter::MouseButtonAction(m_events, mouseInfo, false);
+            action = new InputFilter::MouseButtonAction(mouseInfo, false);
 		}
 	}
 
@@ -1138,11 +1138,11 @@ void Config::parseAction(ConfigReadContext& s, const std::string& name,
 			throw XConfigRead(s, "unknown screen name in switchToScreen");
 		}
 
-		action = new InputFilter::SwitchToScreenAction(m_events, screen);
+        action = new InputFilter::SwitchToScreenAction(screen);
 	}
 
   else if (name == "toggleScreen") {
-    action = new InputFilter::ToggleScreenAction(m_events);
+    action = new InputFilter::ToggleScreenAction();
   }
 
 	else if (name == "switchInDirection") {
@@ -1167,7 +1167,7 @@ void Config::parseAction(ConfigReadContext& s, const std::string& name,
 			throw XConfigRead(s, "unknown direction \"%{1}\" in switchToScreen", args[0]);
 		}
 
-		action = new InputFilter::SwitchInDirectionAction(m_events, direction);
+        action = new InputFilter::SwitchInDirectionAction(direction);
 	}
 
 	else if (name == "lockCursorToScreen") {
@@ -1196,7 +1196,7 @@ void Config::parseAction(ConfigReadContext& s, const std::string& name,
 			m_hasLockToScreenAction = true;
 		}
 
-		action = new InputFilter::LockCursorToScreenAction(m_events, mode);
+        action = new InputFilter::LockCursorToScreenAction(mode);
 	}
 
 	else if (name == "keyboardBroadcast") {
@@ -1226,7 +1226,7 @@ void Config::parseAction(ConfigReadContext& s, const std::string& name,
 			parseScreens(s, args[1], screens);
 		}
 
-		action = new InputFilter::KeyboardBroadcastAction(m_events, mode, screens);
+        action = new InputFilter::KeyboardBroadcastAction(mode, screens);
 	}
 
 	else {

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -178,12 +178,8 @@ public:
         internal_const_iterator m_i;
     };
 
-    Config(IEventQueue* events);
+    Config();
     virtual ~Config();
-
-#ifdef INPUTLEAP_TEST_ENV
-    Config() : m_inputFilter(nullptr) { }
-#endif
 
     //! @name manipulators
     //@{
@@ -309,12 +305,11 @@ public:
     */
     bool removeOptions(const std::string& name);
 
-    //! Get the hot key input filter
-    /*!
-    Returns the hot key input filter.  Clients can modify hotkeys using
-    that object.
-    */
-    virtual InputFilter* getInputFilter();
+    // Note, that the list of rules may be modified
+    virtual std::vector<InputFilter::Rule>& get_input_filter_rules()
+    {
+        return input_filter_rules_;
+    }
 
     //@}
     //! @name accessors
@@ -466,9 +461,8 @@ private:
     NameMap m_nameToCanonicalName;
     NetworkAddress listen_address_;
     ScreenOptions m_globalOptions;
-    InputFilter m_inputFilter;
+    std::vector<InputFilter::Rule> input_filter_rules_;
     bool m_hasLockToScreenAction;
-    IEventQueue* m_events;
 };
 
 //! Configuration read context

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -53,23 +53,18 @@ InputFilter::Condition::disablePrimary(PrimaryClient*)
     // do nothing
 }
 
-InputFilter::KeystrokeCondition::KeystrokeCondition(IEventQueue* events,
-                                                    const IPlatformScreen::KeyInfo& info) :
+InputFilter::KeystrokeCondition::KeystrokeCondition(const IPlatformScreen::KeyInfo& info) :
     m_id(0),
     m_key(info.m_key),
-    m_mask(info.m_mask),
-    m_events(events)
+    m_mask(info.m_mask)
 {
 }
 
-InputFilter::KeystrokeCondition::KeystrokeCondition(
-        IEventQueue* events, KeyID key, KeyModifierMask mask) :
+InputFilter::KeystrokeCondition::KeystrokeCondition(KeyID key, KeyModifierMask mask) :
     m_id(0),
     m_key(key),
-    m_mask(mask),
-    m_events(events)
+    m_mask(mask)
 {
-    // do nothing
 }
 
 InputFilter::KeystrokeCondition::~KeystrokeCondition()
@@ -92,7 +87,7 @@ InputFilter::KeystrokeCondition::getMask() const
 InputFilter::Condition*
 InputFilter::KeystrokeCondition::clone() const
 {
-    return new KeystrokeCondition(m_events, m_key, m_mask);
+    return new KeystrokeCondition(m_key, m_mask);
 }
 
 std::string InputFilter::KeystrokeCondition::format() const
@@ -139,21 +134,16 @@ InputFilter::KeystrokeCondition::disablePrimary(PrimaryClient* primary)
     m_id = 0;
 }
 
-InputFilter::MouseButtonCondition::MouseButtonCondition(IEventQueue* events,
-                                                        const IPrimaryScreen::ButtonInfo& info) :
+InputFilter::MouseButtonCondition::MouseButtonCondition(const IPrimaryScreen::ButtonInfo& info) :
     m_button(info.m_button),
-    m_mask(info.m_mask),
-    m_events(events)
+    m_mask(info.m_mask)
 {
 }
 
-InputFilter::MouseButtonCondition::MouseButtonCondition(
-        IEventQueue* events, ButtonID button, KeyModifierMask mask) :
+InputFilter::MouseButtonCondition::MouseButtonCondition(ButtonID button, KeyModifierMask mask) :
     m_button(button),
-    m_mask(mask),
-    m_events(events)
+    m_mask(mask)
 {
-    // do nothing
 }
 
 InputFilter::MouseButtonCondition::~MouseButtonCondition()
@@ -176,7 +166,7 @@ InputFilter::MouseButtonCondition::getMask() const
 InputFilter::Condition*
 InputFilter::MouseButtonCondition::clone() const
 {
-    return new MouseButtonCondition(m_events, m_button, m_mask);
+    return new MouseButtonCondition(m_button, m_mask);
 }
 
 std::string InputFilter::MouseButtonCondition::format() const
@@ -218,10 +208,8 @@ InputFilter::MouseButtonCondition::match(const Event& event)
     return status;
 }
 
-InputFilter::ScreenConnectedCondition::ScreenConnectedCondition(IEventQueue* events,
-                                                                const std::string& screen) :
-    m_screen(screen),
-    m_events(events)
+InputFilter::ScreenConnectedCondition::ScreenConnectedCondition(const std::string& screen) :
+    m_screen(screen)
 {
     // do nothing
 }
@@ -234,7 +222,7 @@ InputFilter::ScreenConnectedCondition::~ScreenConnectedCondition()
 InputFilter::Condition*
 InputFilter::ScreenConnectedCondition::clone() const
 {
-    return new ScreenConnectedCondition(m_events, m_screen);
+    return new ScreenConnectedCondition(m_screen);
 }
 
 std::string InputFilter::ScreenConnectedCondition::format() const
@@ -268,12 +256,9 @@ InputFilter::Action::~Action()
     // do nothing
 }
 
-InputFilter::LockCursorToScreenAction::LockCursorToScreenAction(
-        IEventQueue* events, Mode mode) :
-    m_mode(mode),
-    m_events(events)
+InputFilter::LockCursorToScreenAction::LockCursorToScreenAction(Mode mode) :
+    m_mode(mode)
 {
-    // do nothing
 }
 
 InputFilter::LockCursorToScreenAction::Mode
@@ -296,7 +281,7 @@ std::string InputFilter::LockCursorToScreenAction::format() const
 }
 
 void
-InputFilter::LockCursorToScreenAction::perform(const Event& event)
+InputFilter::LockCursorToScreenAction::perform(IEventQueue* queue, const Event& event)
 {
     static const Server::LockCursorToScreenInfo::State s_state[] = {
         Server::LockCursorToScreenInfo::kOff,
@@ -306,17 +291,14 @@ InputFilter::LockCursorToScreenAction::perform(const Event& event)
 
     // send event
     Server::LockCursorToScreenInfo info(s_state[m_mode]);
-    m_events->add_event(EventType::SERVER_LOCK_CURSOR_TO_SCREEN, event.getTarget(),
-                        create_event_data<Server::LockCursorToScreenInfo>(info),
-                        Event::kDeliverImmediately);
+    queue->add_event(EventType::SERVER_LOCK_CURSOR_TO_SCREEN, event.getTarget(),
+                     create_event_data<Server::LockCursorToScreenInfo>(info),
+                     Event::kDeliverImmediately);
 }
 
-InputFilter::SwitchToScreenAction::SwitchToScreenAction(IEventQueue* events,
-                                                        const std::string& screen) :
-    m_screen(screen),
-    m_events(events)
+InputFilter::SwitchToScreenAction::SwitchToScreenAction(const std::string& screen) :
+    m_screen(screen)
 {
-    // do nothing
 }
 
 std::string InputFilter::SwitchToScreenAction::getScreen() const
@@ -336,7 +318,7 @@ std::string InputFilter::SwitchToScreenAction::format() const
 }
 
 void
-InputFilter::SwitchToScreenAction::perform(const Event& event)
+InputFilter::SwitchToScreenAction::perform(IEventQueue* queue, const Event& event)
 {
     // pick screen name.  if m_screen is empty then use the screen from
     // event if it has one.
@@ -348,15 +330,9 @@ InputFilter::SwitchToScreenAction::perform(const Event& event)
 
     // send event
     Server::SwitchToScreenInfo info{screen};
-    m_events->add_event(EventType::SERVER_SWITCH_TO_SCREEN, event.getTarget(),
+    queue->add_event(EventType::SERVER_SWITCH_TO_SCREEN, event.getTarget(),
                         create_event_data<Server::SwitchToScreenInfo>(info),
                         Event::kDeliverImmediately);
-}
-
-InputFilter::ToggleScreenAction::ToggleScreenAction(IEventQueue* events) :
-    m_events(events)
-{
-    // do nothing
 }
 
 InputFilter::Action*
@@ -371,18 +347,15 @@ std::string InputFilter::ToggleScreenAction::format() const
 }
 
 void
-InputFilter::ToggleScreenAction::perform(const Event& event)
+InputFilter::ToggleScreenAction::perform(IEventQueue* queue, const Event& event)
 {
-    m_events->add_event(EventType::SERVER_TOGGLE_SCREEN, event.getTarget(), nullptr,
-                        Event::kDeliverImmediately);
+    queue->add_event(EventType::SERVER_TOGGLE_SCREEN, event.getTarget(), nullptr,
+                     Event::kDeliverImmediately);
 }
 
-InputFilter::SwitchInDirectionAction::SwitchInDirectionAction(
-        IEventQueue* events, EDirection direction) :
-    m_direction(direction),
-    m_events(events)
+InputFilter::SwitchInDirectionAction::SwitchInDirectionAction(EDirection direction) :
+    m_direction(direction)
 {
-    // do nothing
 }
 
 EDirection
@@ -411,29 +384,24 @@ std::string InputFilter::SwitchInDirectionAction::format() const
 }
 
 void
-InputFilter::SwitchInDirectionAction::perform(const Event& event)
+InputFilter::SwitchInDirectionAction::perform(IEventQueue* queue, const Event& event)
 {
     Server::SwitchInDirectionInfo info{m_direction};
-    m_events->add_event(EventType::SERVER_SWITCH_INDIRECTION, event.getTarget(),
-                        create_event_data<Server::SwitchInDirectionInfo>(info),
-                        Event::kDeliverImmediately);
+    queue->add_event(EventType::SERVER_SWITCH_INDIRECTION, event.getTarget(),
+                     create_event_data<Server::SwitchInDirectionInfo>(info),
+                     Event::kDeliverImmediately);
 }
 
-InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(
-        IEventQueue* events, Mode mode) :
-    m_mode(mode),
-    m_events(events)
+InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(Mode mode) :
+    m_mode(mode)
 {
-    // do nothing
 }
 
-InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(IEventQueue* events, Mode mode,
+InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(Mode mode,
                                                               const std::set<std::string>& screens) :
     m_mode(mode),
-    m_screens(IKeyState::KeyInfo::join(screens)),
-    m_events(events)
+    m_screens(IKeyState::KeyInfo::join(screens))
 {
-    // do nothing
 }
 
 InputFilter::KeyboardBroadcastAction::Mode
@@ -471,7 +439,7 @@ std::string InputFilter::KeyboardBroadcastAction::format() const
 }
 
 void
-InputFilter::KeyboardBroadcastAction::perform(const Event& event)
+InputFilter::KeyboardBroadcastAction::perform(IEventQueue* queue, const Event& event)
 {
     static const Server::KeyboardBroadcastInfo::State s_state[] = {
         Server::KeyboardBroadcastInfo::kOff,
@@ -481,17 +449,15 @@ InputFilter::KeyboardBroadcastAction::perform(const Event& event)
 
     // send event
     Server::KeyboardBroadcastInfo info{s_state[m_mode], m_screens};
-    m_events->add_event(EventType::SERVER_KEYBOARD_BROADCAST, event.getTarget(),
-                        create_event_data<Server::KeyboardBroadcastInfo>(info),
-                        Event::kDeliverImmediately);
+    queue->add_event(EventType::SERVER_KEYBOARD_BROADCAST, event.getTarget(),
+                     create_event_data<Server::KeyboardBroadcastInfo>(info),
+                     Event::kDeliverImmediately);
 }
 
-InputFilter::KeystrokeAction::KeystrokeAction(IEventQueue* events, const IKeyState::KeyInfo& info, bool press) :
+InputFilter::KeystrokeAction::KeystrokeAction(const IKeyState::KeyInfo& info, bool press) :
     info_(info),
-    m_press(press),
-    m_events(events)
+    m_press(press)
 {
-    // do nothing
 }
 
 InputFilter::KeystrokeAction::~KeystrokeAction() = default;
@@ -505,7 +471,7 @@ InputFilter::KeystrokeAction::isOnPress() const
 InputFilter::Action*
 InputFilter::KeystrokeAction::clone() const
 {
-    return new KeystrokeAction(m_events, info_, m_press);
+    return new KeystrokeAction(info_, m_press);
 }
 
 std::string InputFilter::KeystrokeAction::format() const
@@ -528,17 +494,17 @@ std::string InputFilter::KeystrokeAction::format() const
 }
 
 void
-InputFilter::KeystrokeAction::perform(const Event& event)
+InputFilter::KeystrokeAction::perform(IEventQueue* queue, const Event& event)
 {
     EventType type = m_press ? EventType::KEY_STATE_KEY_DOWN : EventType::KEY_STATE_KEY_UP;
 
-    m_events->add_event(EventType::PRIMARY_SCREEN_FAKE_INPUT_BEGIN, event.getTarget(), nullptr,
-                        Event::kDeliverImmediately);
-    m_events->add_event(type, event.getTarget(),
-                        create_event_data<IPlatformScreen::KeyInfo>(info_),
-                        Event::kDeliverImmediately);
-    m_events->add_event(EventType::PRIMARY_SCREEN_FAKE_INPUT_END, event.getTarget(), nullptr,
-                        Event::kDeliverImmediately);
+    queue->add_event(EventType::PRIMARY_SCREEN_FAKE_INPUT_BEGIN, event.getTarget(), nullptr,
+                     Event::kDeliverImmediately);
+    queue->add_event(type, event.getTarget(),
+                     create_event_data<IPlatformScreen::KeyInfo>(info_),
+                     Event::kDeliverImmediately);
+    queue->add_event(EventType::PRIMARY_SCREEN_FAKE_INPUT_END, event.getTarget(), nullptr,
+                     Event::kDeliverImmediately);
 }
 
 const char*
@@ -547,14 +513,11 @@ InputFilter::KeystrokeAction::formatName() const
     return (m_press ? "keyDown" : "keyUp");
 }
 
-InputFilter::MouseButtonAction::MouseButtonAction(IEventQueue* events,
-                                                  const IPlatformScreen::ButtonInfo& info,
+InputFilter::MouseButtonAction::MouseButtonAction(const IPlatformScreen::ButtonInfo& info,
                                                   bool press) :
     button_info_(info),
-    m_press(press),
-    m_events(events)
+    m_press(press)
 {
-    // do nothing
 }
 
 InputFilter::MouseButtonAction::~MouseButtonAction() = default;
@@ -568,7 +531,7 @@ InputFilter::MouseButtonAction::isOnPress() const
 InputFilter::Action*
 InputFilter::MouseButtonAction::clone() const
 {
-    return new MouseButtonAction(m_events, button_info_, m_press);
+    return new MouseButtonAction(button_info_, m_press);
 }
 
 std::string InputFilter::MouseButtonAction::format() const
@@ -582,24 +545,24 @@ std::string InputFilter::MouseButtonAction::format() const
 }
 
 void
-InputFilter::MouseButtonAction::perform(const Event& event)
+InputFilter::MouseButtonAction::perform(IEventQueue* queue, const Event& event)
 
 {
     // send modifiers
     if (button_info_.m_mask != 0) {
         KeyID key = m_press ? kKeySetModifiers : kKeyClearModifiers;
-        m_events->add_event(EventType::KEY_STATE_KEY_DOWN, event.getTarget(),
-                            create_event_data<IPlatformScreen::KeyInfo>(
+        queue->add_event(EventType::KEY_STATE_KEY_DOWN, event.getTarget(),
+                         create_event_data<IPlatformScreen::KeyInfo>(
                                 IPlatformScreen::KeyInfo{key, button_info_.m_mask, 0, 1}),
-                            Event::kDeliverImmediately);
+                         Event::kDeliverImmediately);
     }
 
     // send button
     EventType type = m_press ? EventType::PRIMARY_SCREEN_BUTTON_DOWN :
                                EventType::PRIMARY_SCREEN_BUTTON_UP;
-    m_events->add_event(type, event.getTarget(),
-                        create_event_data<IPlatformScreen::ButtonInfo>(button_info_),
-                        Event::kDeliverImmediately);
+    queue->add_event(type, event.getTarget(),
+                     create_event_data<IPlatformScreen::ButtonInfo>(button_info_),
+                     Event::kDeliverImmediately);
 }
 
 const char*
@@ -738,8 +701,7 @@ InputFilter::Rule::disable(PrimaryClient* primaryClient)
     }
 }
 
-bool
-InputFilter::Rule::handleEvent(const Event& event)
+bool InputFilter::Rule::handle_event(IEventQueue* queue, const Event& event)
 {
     // nullptr condition never matches
     if (m_condition == nullptr) {
@@ -767,7 +729,7 @@ InputFilter::Rule::handleEvent(const Event& event)
     // perform actions
     for (auto i = actions->begin(); i != actions->end(); ++i) {
         LOG_DEBUG1("hotkey: %s", (*i)->format().c_str());
-        (*i)->perform(event);
+        (*i)->perform(queue, event);
     }
 
     return true;
@@ -996,7 +958,7 @@ void InputFilter::handle_event(const Event& event)
 
     // let each rule try to match the event until one does
     for (auto rule = m_ruleList.begin(); rule != m_ruleList.end(); ++rule) {
-        if (rule->handleEvent(myEvent)) {
+        if (rule->handle_event(m_events, myEvent)) {
             // handled
             return;
         }

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -844,6 +844,13 @@ InputFilter::addFilterRule(const Rule& rule)
     }
 }
 
+void InputFilter::add_rules(const std::vector<Rule>& rules)
+{
+    for (const auto& rule : rules) {
+        addFilterRule(rule);
+    }
+}
+
 void
 InputFilter::setPrimaryClient(PrimaryClient* client)
 {

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -911,34 +911,6 @@ std::uint32_t InputFilter::getNumRules() const
     return static_cast<std::uint32_t>(m_ruleList.size());
 }
 
-bool
-InputFilter::operator==(const InputFilter& x) const
-{
-    // if there are different numbers of rules then we can't be equal
-    if (m_ruleList.size() != x.m_ruleList.size()) {
-        return false;
-    }
-
-    // compare rule lists.  the easiest way to do that is to format each
-    // rule into a string, sort the strings, then compare the results.
-    std::vector<std::string> aList, bList;
-    for (auto i = m_ruleList.begin(); i != m_ruleList.end(); ++i) {
-        aList.push_back(i->format());
-    }
-    for (auto i = x.m_ruleList.begin(); i != x.m_ruleList.end(); ++i) {
-        bList.push_back(i->format());
-    }
-    std::partial_sort(aList.begin(), aList.end(), aList.end());
-    std::partial_sort(bList.begin(), bList.end(), bList.end());
-    return (aList == bList);
-}
-
-bool
-InputFilter::operator!=(const InputFilter& x) const
-{
-    return !operator==(x);
-}
-
 void InputFilter::handle_event(const Event& event)
 {
     // copy event and adjust target
@@ -968,6 +940,28 @@ std::string format_rules(const std::vector<InputFilter::Rule>& rules,
         s += "\n";
     }
     return s;
+}
+
+bool are_rules_equal(const std::vector<InputFilter::Rule>& rules1,
+                     const std::vector<InputFilter::Rule>& rules2)
+{
+    // if there are different numbers of rules then we can't be equal
+    if (rules1.size() != rules2.size()) {
+        return false;
+    }
+
+    // compare rule lists.  the easiest way to do that is to format each
+    // rule into a string, sort the strings, then compare the results.
+    std::vector<std::string> list1, list2;
+    for (const auto& rule : rules1) {
+        list1.push_back(rule.format());
+    }
+    for (const auto& rule : rules2) {
+        list2.push_back(rule.format());
+    }
+    std::partial_sort(list1.begin(), list1.end(), list1.end());
+    std::partial_sort(list2.begin(), list2.end(), list2.end());
+    return list1 == list2;
 }
 
 } // namespace inputleap

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -844,19 +844,6 @@ InputFilter::addFilterRule(const Rule& rule)
     }
 }
 
-void InputFilter::removeFilterRule(std::uint32_t index)
-{
-    if (m_primaryClient != nullptr) {
-        m_ruleList[index].disable(m_primaryClient);
-    }
-    m_ruleList.erase(m_ruleList.begin() + index);
-}
-
-InputFilter::Rule& InputFilter::getRule(std::uint32_t index)
-{
-    return m_ruleList[index];
-}
-
 void
 InputFilter::setPrimaryClient(PrimaryClient* client)
 {
@@ -904,11 +891,6 @@ InputFilter::setPrimaryClient(PrimaryClient* client)
             rule->enable(m_primaryClient);
         }
     }
-}
-
-std::uint32_t InputFilter::getNumRules() const
-{
-    return static_cast<std::uint32_t>(m_ruleList.size());
 }
 
 void InputFilter::handle_event(const Event& event)

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -906,17 +906,6 @@ InputFilter::setPrimaryClient(PrimaryClient* client)
     }
 }
 
-std::string InputFilter::format(const std::string& linePrefix) const
-{
-    std::string s;
-    for (auto i = m_ruleList.begin(); i != m_ruleList.end(); ++i) {
-        s += linePrefix;
-        s += i->format();
-        s += "\n";
-    }
-    return s;
-}
-
 std::uint32_t InputFilter::getNumRules() const
 {
     return static_cast<std::uint32_t>(m_ruleList.size());
@@ -966,6 +955,19 @@ void InputFilter::handle_event(const Event& event)
 
     // not handled so pass through
     m_events->add_event(std::move(myEvent));
+}
+
+
+std::string format_rules(const std::vector<InputFilter::Rule>& rules,
+                         const std::string& line_prefix)
+{
+    std::string s;
+    for (const auto& rule : rules) {
+        s += line_prefix;
+        s += rule.format();
+        s += "\n";
+    }
+    return s;
 }
 
 } // namespace inputleap

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -335,8 +335,7 @@ public:
     // if client is nullptr.
     virtual void setPrimaryClient(PrimaryClient* client);
 
-    // convert rules to a string
-    std::string format(const std::string& linePrefix) const;
+    const std::vector<Rule>& get_rules() const { return m_ruleList; }
 
     // get number of rules
     std::uint32_t getNumRules() const;
@@ -355,5 +354,8 @@ private:
     PrimaryClient* m_primaryClient;
     IEventQueue* m_events;
 };
+
+std::string format_rules(const std::vector<InputFilter::Rule>& rules,
+                         const std::string& line_prefix);
 
 } // namespace inputleap

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -324,6 +324,7 @@ public:
 
     // add rule, adopting the condition and the actions
     void addFilterRule(const Rule& rule);
+    void add_rules(const std::vector<Rule>& rules);
 
     // enable event filtering using the given primary client.  disable
     // if client is nullptr.

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -340,11 +340,6 @@ public:
     // get number of rules
     std::uint32_t getNumRules() const;
 
-    //! Compare filters
-    bool                operator==(const InputFilter&) const;
-    //! Compare filters
-    bool                operator!=(const InputFilter&) const;
-
 private:
     // event handling
     void handle_event(const Event&);
@@ -357,5 +352,8 @@ private:
 
 std::string format_rules(const std::vector<InputFilter::Rule>& rules,
                          const std::string& line_prefix);
+
+bool are_rules_equal(const std::vector<InputFilter::Rule>& rules1,
+                     const std::vector<InputFilter::Rule>& rules2);
 
 } // namespace inputleap

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -60,8 +60,8 @@ public:
     // KeystrokeCondition
     class KeystrokeCondition : public Condition {
     public:
-        KeystrokeCondition(IEventQueue* events, const IPlatformScreen::KeyInfo& info);
-        KeystrokeCondition(IEventQueue* events, KeyID key, KeyModifierMask mask);
+        KeystrokeCondition(const IPlatformScreen::KeyInfo& info);
+        KeystrokeCondition(KeyID key, KeyModifierMask mask);
         ~KeystrokeCondition() override;
 
         KeyID getKey() const;
@@ -78,14 +78,13 @@ public:
         std::uint32_t m_id;
         KeyID m_key;
         KeyModifierMask m_mask;
-        IEventQueue* m_events;
     };
 
     // MouseButtonCondition
     class MouseButtonCondition : public Condition {
     public:
-        MouseButtonCondition(IEventQueue* events, const IPlatformScreen::ButtonInfo& info);
-        MouseButtonCondition(IEventQueue* events, ButtonID, KeyModifierMask mask);
+        MouseButtonCondition(const IPlatformScreen::ButtonInfo& info);
+        MouseButtonCondition(ButtonID, KeyModifierMask mask);
         ~MouseButtonCondition() override;
 
         ButtonID getButton() const;
@@ -99,13 +98,12 @@ public:
     private:
         ButtonID m_button;
         KeyModifierMask m_mask;
-        IEventQueue* m_events;
     };
 
     // ScreenConnectedCondition
     class ScreenConnectedCondition : public Condition {
     public:
-        ScreenConnectedCondition(IEventQueue* events, const std::string& screen);
+        ScreenConnectedCondition(const std::string& screen);
         ~ScreenConnectedCondition() override;
 
         // Condition overrides
@@ -115,7 +113,6 @@ public:
 
     private:
         std::string m_screen;
-        IEventQueue* m_events;
     };
 
     // -------------------------------------------------------------------------
@@ -130,7 +127,7 @@ public:
         virtual Action* clone() const = 0;
         virtual std::string format() const = 0;
 
-        virtual void perform(const Event&) = 0;
+        virtual void perform(IEventQueue* queue, const Event& event) = 0;
     };
 
     // LockCursorToScreenAction
@@ -138,66 +135,58 @@ public:
     public:
         enum Mode { kOff, kOn, kToggle };
 
-        LockCursorToScreenAction(IEventQueue* events, Mode = kToggle);
+        LockCursorToScreenAction(Mode = kToggle);
 
         Mode getMode() const;
 
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
+        void perform(IEventQueue* queue, const Event& event) override;
 
     private:
         Mode m_mode;
-        IEventQueue* m_events;
     };
 
     // SwitchToScreenAction
     class SwitchToScreenAction : public Action {
     public:
-        SwitchToScreenAction(IEventQueue* events, const std::string& screen);
+        SwitchToScreenAction(const std::string& screen);
 
         std::string getScreen() const;
 
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
+        void perform(IEventQueue* queue, const Event& event) override;
 
     private:
         std::string m_screen;
-        IEventQueue* m_events;
     };
 
     // ToggleScreenAction
     class ToggleScreenAction : public Action {
     public:
-        ToggleScreenAction(IEventQueue* events);
-
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
-
-    private:
-        IEventQueue* m_events;
+        void perform(IEventQueue* queue, const Event&) override;
     };
 
     // SwitchInDirectionAction
     class SwitchInDirectionAction : public Action {
     public:
-        SwitchInDirectionAction(IEventQueue* events, EDirection);
+        SwitchInDirectionAction(EDirection);
 
         EDirection getDirection() const;
 
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
+        void perform(IEventQueue* queue, const Event&) override;
 
     private:
         EDirection m_direction;
-        IEventQueue* m_events;
     };
 
     // KeyboardBroadcastAction
@@ -205,8 +194,8 @@ public:
     public:
         enum Mode { kOff, kOn, kToggle };
 
-        KeyboardBroadcastAction(IEventQueue* events, Mode = kToggle);
-        KeyboardBroadcastAction(IEventQueue* events, Mode, const std::set<std::string>& screens);
+        KeyboardBroadcastAction(Mode = kToggle);
+        KeyboardBroadcastAction(Mode, const std::set<std::string>& screens);
 
         Mode getMode() const;
         std::set<std::string> getScreens() const;
@@ -214,18 +203,17 @@ public:
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
+        void perform(IEventQueue* queue, const Event&) override;
 
     private:
         Mode m_mode;
         std::string m_screens;
-        IEventQueue* m_events;
     };
 
     // KeystrokeAction
     class KeystrokeAction : public Action {
     public:
-        KeystrokeAction(IEventQueue* events, const IPlatformScreen::KeyInfo& info, bool press);
+        KeystrokeAction(const IPlatformScreen::KeyInfo& info, bool press);
         ~KeystrokeAction();
 
         void set_info(const IPlatformScreen::KeyInfo& info) { info_ = info; }
@@ -235,7 +223,7 @@ public:
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
+        void perform(IEventQueue* queue, const Event& event) override;
 
     protected:
         virtual const char* formatName() const;
@@ -243,13 +231,12 @@ public:
     private:
         IPlatformScreen::KeyInfo info_;
         bool m_press;
-        IEventQueue* m_events;
     };
 
     // MouseButtonAction -- modifier combinations not implemented yet
     class MouseButtonAction : public Action {
     public:
-        MouseButtonAction(IEventQueue* events, const IPlatformScreen::ButtonInfo& info, bool press);
+        MouseButtonAction(const IPlatformScreen::ButtonInfo& info, bool press);
         ~MouseButtonAction();
 
         const IPlatformScreen::ButtonInfo& getInfo() const { return button_info_; }
@@ -258,7 +245,7 @@ public:
         // Action overrides
         Action* clone() const override;
         std::string format() const override;
-        void perform(const Event&) override;
+        void perform(IEventQueue* queue, const Event& event) override;
 
     protected:
         virtual const char* formatName() const;
@@ -266,7 +253,6 @@ public:
     private:
         IPlatformScreen::ButtonInfo button_info_;
         bool m_press;
-        IEventQueue* m_events;
     };
 
     class Rule {
@@ -295,7 +281,7 @@ public:
         void disable(PrimaryClient*);
 
         // event handling
-        bool handleEvent(const Event&);
+        bool handle_event(IEventQueue* queue, const Event&);
 
         // convert rule to a string
         std::string format() const;

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -325,20 +325,11 @@ public:
     // add rule, adopting the condition and the actions
     void addFilterRule(const Rule& rule);
 
-    // remove a rule
-    void removeFilterRule(std::uint32_t index);
-
-    // get rule by index
-    Rule& getRule(std::uint32_t index);
-
     // enable event filtering using the given primary client.  disable
     // if client is nullptr.
     virtual void setPrimaryClient(PrimaryClient* client);
 
     const std::vector<Rule>& get_rules() const { return m_ruleList; }
-
-    // get number of rules
-    std::uint32_t getNumRules() const;
 
 private:
     // event handling

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -247,8 +247,8 @@ Server::setConfig(const Config& config)
 	// ScrollLock as a hotkey.
 	if (!m_config->hasLockToScreenAction()) {
         IPlatformScreen::KeyInfo key{kKeyScrollLock, 0, 0, 0};
-		InputFilter::Rule rule(new InputFilter::KeystrokeCondition(m_events, key));
-		rule.adoptAction(new InputFilter::LockCursorToScreenAction(m_events), true);
+        InputFilter::Rule rule(new InputFilter::KeystrokeCondition(key));
+        rule.adoptAction(new InputFilter::LockCursorToScreenAction(), true);
 		m_inputFilter->addFilterRule(rule);
 	}
 

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -419,7 +419,7 @@ private:
     Config* m_config;
 
     // input filter (from m_config);
-    InputFilter* m_inputFilter;
+    InputFilter input_filter_;
 
     // clipboard cache
     ClipboardInfo m_clipboards[kClipboardEnd];


### PR DESCRIPTION
Classes that store data should do only that exclusively instead of coupling with the rest of application.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
