### PR TITLE
Ignore `.cache` dir used by `clangd`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ CMakeLists.txt.user
 /out/build/x64-Debug
 bundle
 compile_commands.json
+# Cache (used by clangd)
+.cache


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
