### PR TITLE
fix: Seg fault on arch linux when configuring server. Error with server config dialog show event.

### DIFF
--- a/doc/newsfragments/arch_bug_when_configuring_server.bugfix
+++ b/doc/newsfragments/arch_bug_when_configuring_server.bugfix
@@ -1,0 +1,1 @@
+Fixed a segmentation fault that would occur when configuring servers on certain platforms. This solution was proposed by sithlord48 and they used it to fix the issue for deskflow.

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -74,19 +74,6 @@ ServerConfigDialog::ServerConfigDialog(QWidget* parent, ServerConfig& config, co
         model().screen(serverConfig().numColumns() / 2, serverConfig().numRows() / 2) = Screen(defaultScreenName);
 }
 
-void ServerConfigDialog::showEvent(QShowEvent* event)
-{
-    (void) event;
-
-    QDialog::show();
-
-    if (!m_Message.isEmpty())
-    {
-        // TODO: ideally this message box should pop up after the dialog is shown
-        QMessageBox::information(this, tr("Configure server"), m_Message);
-    }
-}
-
 void ServerConfigDialog::accept()
 {
     serverConfig().haveHeartbeat(ui_->m_pCheckBoxHeartbeat->isChecked());

--- a/src/gui/src/ServerConfigDialog.h
+++ b/src/gui/src/ServerConfigDialog.h
@@ -39,7 +39,6 @@ class ServerConfigDialog : public QDialog
 
     public slots:
         void accept() override;
-        void showEvent(QShowEvent* event) override;
         void message(const QString& message) { m_Message = message; }
 
     protected slots:


### PR DESCRIPTION
Fixed a segmentation fault that would occur when configuring servers on certain platforms. This solution was proposed by sithlord48 and they used it to fix the issue for deskflow.
This should fix #2067
## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
