### PR TITLE
fix: Wrong key mappings in OSX clients

### DIFF
--- a/doc/newsfragments/wrong_key_mappings_in_osx_clients.bugfix
+++ b/doc/newsfragments/wrong_key_mappings_in_osx_clients.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with mapping keys in OSX clients introduced in #1635, where keys like the equals sign "=" or the back tick "`" wouldn't be mapped correctly.

--- a/src/lib/platform/OSXUchrKeyResource.cpp
+++ b/src/lib/platform/OSXUchrKeyResource.cpp
@@ -97,7 +97,7 @@ OSXUchrKeyResource::isValid() const
 
 std::uint32_t OSXUchrKeyResource::getNumModifierCombinations() const
 {
-    return 256;
+    return 32;
 }
 
 std::uint32_t OSXUchrKeyResource::getNumTables() const

--- a/src/lib/platform/OSXUchrKeyResource.cpp
+++ b/src/lib/platform/OSXUchrKeyResource.cpp
@@ -97,6 +97,9 @@ OSXUchrKeyResource::isValid() const
 
 std::uint32_t OSXUchrKeyResource::getNumModifierCombinations() const
 {
+    // (old comment) only 32 (not 256) because the right-handed modifier bits are ignored
+    // (new comment) Since the old comment support for right-handed modifiers was added but this has to stay 32,
+    // otherwise it generates key combinations that break the correct mapping for some keys
     return 32;
 }
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users

Fixed an issue with mapping keys in OSX clients introduced in #1635, where keys like the equals sign "=" or the back tick "`" wouldn't be mapped correctly.

Fixes #1990 
Fixes #2099 
Fixes #2077