### PR TITLE
Address issues with modifiers and dead keys on Windows

### DIFF
--- a/doc/newsfragments/windows_dead_keys.bugfix
+++ b/doc/newsfragments/windows_dead_keys.bugfix
@@ -1,0 +1,1 @@
+Fixed a long standing bug with modifiers and dead keys on Windows because their state was not being reset.

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -1349,8 +1349,20 @@ MSWindowsKeyState::getIDForKey(inputleap::KeyMap::KeyItem& item,
 	KeyID id = static_cast<KeyID>(unicode[0]);
 
 	switch (n) {
-	case -1:
-		return inputleap::KeyMap::getDeadKey(id);
+	case -1: {
+        // dead key. add an space to the keyboard so we exit
+        // the dead key mode and future calls to this function
+        // with different modifiers are not affected.
+
+        BYTE emptyState[256] = { };
+        n = m_ToUnicodeEx(VK_SPACE, 0, emptyState, unicode,
+                          sizeof(unicode) / sizeof(unicode[0]), 0, hkl);
+
+        // as an alternative, we could use the returned
+        // buffer in unicode to look at the dead key character
+        // and not rely on getDeadKey to provide the mapping
+        return inputleap::KeyMap::getDeadKey(id);
+    }
 
 	default:
 	case 0:


### PR DESCRIPTION
After getting a dead key from `ToUnicodeEx`, add an additional `VK_SPACE` to the keyboard state so we reset the dead key flag and subsequent calls with modifiers, like shift, return the right result (-1) instead of 1.

This happened because without reseting the dead key status the new one was attempted to be composed with the old one, which failed and the end result was a single unicode codepoint not marked as a dead key.

This opens the door to potentially use the returned unicode from the second call to `ToUnicodeEx` as the key character instead of maintaining the getDeadKey function.

I submitted this change to Synergy and Barrier (https://github.com/debauchee/barrier/pull/1583), but the Barrier PR was never merged.


## Contributor Checklist:

* [X] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
