### PR TITLE
MacOS: Add NSSupportsSuddenTermination = false to application plist

### DIFF
--- a/src/gui/res/mac/Info.plist
+++ b/src/gui/res/mac/Info.plist
@@ -25,5 +25,7 @@
     <string>1.8.8</string>
     <key>NSHumanReadableCopyright</key>
     <string>© 2012-2016, Symless Ltd</string>
+    <key>NSSupportsSuddenTermination</key>
+    <false/>
   </dict>
 </plist>


### PR DESCRIPTION
Possibly stops application from being terminated early due to memory pressure, which is usually undesired for an app providing mouse/keyboard access.


I tried to create an Issue for this 5 times, but consistently got a 500 back from github.  No idea why.

My InputLeap (and Barrier before it) is sometimes restarting many times in a row on MacOS. I was hoping the upgrade to InputLeap would fix it, but sadly, no.

Logging, even with debug1, only gave me "The process exited normally."

Attaching lldb and breaking on exit, however, gave me this:

```
(lldb) thread backtrace
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.5
  * frame #0: 0x0000000182f3e730 libsystem_c.dylib`exit
    frame #1: 0x0000000186eb4e34 AppKit`-[NSApplication terminate:] + 2084
    frame #2: 0x0000000186eb4540 AppKit`-[NSApplication _terminateOnMemoryPressure:] + 484
    frame #3: 0x00000001871eaa48 AppKit`__79-[NSApplication(NSAppssassination) _tryTransformingToBackgroundTypeForAutoQuit]_block_invoke.2175 + 132
    frame #4: 0x00000001871e9c04 AppKit`-[NSApplication _callMemoryPressureHandlers] + 176
    frame #5: 0x00000001871ec868 AppKit`___NSMainRunLoopPerformBlockInModes_block_invoke + 44
    frame #6: 0x0000000183169fa0 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 28
    frame #7: 0x0000000183169eb0 CoreFoundation`__CFRunLoopDoBlocks + 356
    frame #8: 0x0000000183169330 CoreFoundation`__CFRunLoopRun + 2432
    frame #9: 0x0000000183168334 CoreFoundation`CFRunLoopRunSpecific + 572
    frame #10: 0x000000018e5a10cc HIToolbox`RunCurrentEventLoopInMode + 292
    frame #11: 0x000000018e5a6ebc HIToolbox`ReceiveNextEventCommon + 636
    frame #12: 0x000000018e5a7020 HIToolbox`_BlockUntilNextEventMatchingListInModeWithFilter + 76
    frame #13: 0x0000000186caca70 AppKit`_DPSNextEvent + 660
    frame #14: 0x00000001875d27b8 AppKit`-[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 688
    frame #15: 0x0000000186c9fb7c AppKit`-[NSApplication run] + 480
    frame #16: 0x00000001045707b4 input-leapc`inputleap::runCocoaApp() + 224
    frame #17: 0x00000001045bf030 input-leapc`inputleap::ClientApp::mainLoop() + 244
    frame #18: 0x00000001045bf3d4 input-leapc`inputleap::ClientApp::runInner(int, char**, inputleap::ILogOutputter*, int (*)(int, char**)) + 160
    frame #19: 0x00000001045ba388 input-leapc`inputleap::App::run(int, char**) + 108
    frame #20: 0x000000010453d070 input-leapc`inputleap::client_main(int, char**) + 112
    frame #21: 0x0000000182d00274 dyld`start + 2840
```

My mac's memory wasn't particularly pressured, which led me to asking ChatGPT, which gave me a workaround:

```defaults write input-leap NSSupportsSuddenTermination -bool NO```

Which seems to correspond to this plist entry.


I haven't seen the behavior since.   Feel free to ignore the PR and treat this as an issue!  

Thanks!

