### PR TITLE
Fixed MacOS cursor jump, issue 1043

### DIFF
--- a/doc/newsfragments/MacOS_cursor_jump_when_entering_bug.bugfix
+++ b/doc/newsfragments/MacOS_cursor_jump_when_entering_bug.bugfix
@@ -1,0 +1,1 @@
+Fixed cursor jumping to center of primary display when entering macOS screen by moving isOnScreen flag

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -790,6 +790,10 @@ OSXScreen::disable()
 void
 OSXScreen::enter()
 {
+    // Mark as on screen so other events are handled as on screen.
+    // Mitigates https://github.com/input-leap/input-leap/issues/1043 from the bogus movement check
+	m_isOnScreen = true;
+
 	showCursor();
 
 	if (m_isPrimary) {
@@ -816,9 +820,6 @@ OSXScreen::enter()
 
 		avoidSupression();
 	}
-
-	// now on screen
-	m_isOnScreen = true;
 }
 
 bool


### PR DESCRIPTION
This was the easiest and probably best solution to #1043 .

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
