### PR TITLE
Fixed UTF-16 surrogate pairs handling.

### DIFF
--- a/doc/newsfragments/fixed_utf-16_surrogate_pairs_handling.bugfix
+++ b/doc/newsfragments/fixed_utf-16_surrogate_pairs_handling.bugfix
@@ -1,0 +1,1 @@
+Fixed a problem with UTF-16 surrogate pairs that caused broken characters (especially emojis) when copying to the clipboard from a Windows machine

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -563,9 +563,9 @@ std::string Unicode::doUTF16ToUTF8(const std::uint8_t* data, std::size_t n, bool
             toUTF8(dst, s_replacement, nullptr);
         }
         else if (c >= 0x0000d800 && c <= 0x0000dbff) {
-            std::uint32_t c2 = decode16(data, byteSwapped);
             data += 2;
             --n;
+            std::uint32_t c2 = decode16(data, byteSwapped);
             if (c2 < 0x0000dc00 || c2 > 0x0000dfff) {
                 // error -- [d800,dbff] not followed by [dc00,dfff]
                 setError(errors);


### PR DESCRIPTION
The data pointer needs to move before decoding the second surrogate, and not after. The first surrogate was begin decoded again, resulting in an invalid codepoint.

This affected clipboard operations originating on Windows machines, where the text is encoded in UTF-16 and copying characters from a high plane (like emojis) was broken.

## Contributor Checklist:

* [X] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
