### PR TITLE
Add a reload action to the tray icon menu.

### DIFF
--- a/doc/newsfragments/add_reload_action_to_tray_icon.feature
+++ b/doc/newsfragments/add_reload_action_to_tray_icon.feature
@@ -1,0 +1,3 @@
+Add a reload action to the tray icon menu.
+Sometimes the clipboard copy function does not work. In this case, when the input-leap is reloaded, the function works normally again.
+To make reload easier, add a reload action to the tray icon.

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -255,6 +255,7 @@ void MainWindow::createTrayIcon()
     m_pTrayIconMenu->addAction(ui_->m_pActionStartCmdApp);
     m_pTrayIconMenu->addAction(ui_->m_pActionStopCmdApp);
     m_pTrayIconMenu->addAction(ui_->m_pActionShowLog);
+    m_pTrayIconMenu->addAction(ui_->m_pActionReload);
     m_pTrayIconMenu->addSeparator();
 
     m_pTrayIconMenu->addAction(ui_->m_pActionMinimize);
@@ -341,6 +342,7 @@ void MainWindow::initConnections()
     connect(ui_->m_pActionStartCmdApp, &QAction::triggered, this, &MainWindow::start_cmd_app);
     connect(ui_->m_pActionStopCmdApp, &QAction::triggered, this, &MainWindow::stop_cmd_app);
     connect(ui_->m_pActionShowLog, &QAction::triggered, this, &MainWindow::showLogWindow);
+    connect(ui_->m_pActionReload, &QAction::triggered, this, &MainWindow::restart_cmd_app);
     connect(ui_->m_pActionQuit, &QAction::triggered, qApp, &QCoreApplication::quit);
 }
 

--- a/src/gui/src/MainWindow.ui
+++ b/src/gui/src/MainWindow.ui
@@ -469,6 +469,17 @@
     <string notr="true">F2</string>
    </property>
   </action>
+  <action name="m_pActionReload">
+   <property name="text">
+    <string>&amp;Reload</string>
+   </property>
+   <property name="toolTip">
+    <string>Reload app</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../res/InputLeap.qrc"/>


### PR DESCRIPTION
Sometimes the clipboard copy function does not work. In this case, when the input-leap is reloaded, the function works normally again. To make reload easier, add a reload action to the tray icon.

After this patch:

![reload_screen_shot](https://github.com/user-attachments/assets/5300ffba-d176-4a4b-8384-3b3098d7a1ab)

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
