### PR TITLE
feat: make appstream data compliant with flathub standards

### DIFF
--- a/res/io.github.input_leap.InputLeap.appdata.xml
+++ b/res/io.github.input_leap.InputLeap.appdata.xml
@@ -5,11 +5,13 @@
 <component type="desktop-application">
   <id>io.github.input_leap.InputLeap</id>
   <metadata_license>FSFAP</metadata_license>
-  <project_license>GPLv2</project_license>
+  <project_license>GPL-2.0</project_license>
   <name>InputLeap</name>
   <summary>Share mouse and keyboard between multiple computers over the network</summary>
-  <developer_name>Input Leap Team</developer_name>
-  <content_rating type="oars-1.0" />
+  <developer id="io.github.input_leap">
+    <name>Input Leap Team</name>
+  </developer>
+  <content_rating type="oars-1.1" />
 
   <description>
     <p>
@@ -25,6 +27,11 @@
 
   <screenshots>
     <screenshot type="default">
+      <caption>Pairing and connections screen</caption>
+      <image>https://github.com/user-attachments/assets/73fb76b6-da03-458c-96b2-38bf642168d8</image>
+    </screenshot>
+    <screenshot>
+      <caption>Settings screen</caption>
       <image>https://github.com/user-attachments/assets/73fb76b6-da03-458c-96b2-38bf642168d8</image>
     </screenshot>
   </screenshots>
@@ -54,13 +61,9 @@
 
 
   <releases>
-    <!-- TODO THIS SECTION MUST HAVE A HISTORY OF ALL OUR STABLE RELEASES -->
-    <release version="3.0.0" date="YYYY-MM-DD" urgency="high">
-      <description>
-        <p> This is the first stable release of Input Leap </p>
-      </description>
-      <url>https://github.com/input-leap/input-leap/releases/tag/v3.0.0</url>
-    </release>
+    <release version="3.0.2" date="2024-10-12"/>
+    <release version="3.0.1" date="2024-10-10"/>
+    <release version="3.0.0" date="2024-10-03"/>
   </releases>
 </component>
 

--- a/res/io.github.input_leap.InputLeap.appdata.xml
+++ b/res/io.github.input_leap.InputLeap.appdata.xml
@@ -28,11 +28,11 @@
   <screenshots>
     <screenshot type="default">
       <caption>Pairing and connections screen</caption>
-      <image>https://github.com/user-attachments/assets/73fb76b6-da03-458c-96b2-38bf642168d8</image>
+      <image>https://github.com/user-attachments/assets/15274a63-94e9-4ef2-a66c-ff85bffddd73</image>
     </screenshot>
     <screenshot>
       <caption>Settings screen</caption>
-      <image>https://github.com/user-attachments/assets/73fb76b6-da03-458c-96b2-38bf642168d8</image>
+      <image>https://github.com/user-attachments/assets/cb7391f7-401e-488c-8661-ac6acaca6432</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
These changes are required so that the flatpak-builder linter doesnt complain about this files. Ill add the screenshots in a bit.