### PR TITLE
Fix keymap not correctly loading for the Ei backend

### DIFF
--- a/doc/newsfragments/fixed_keymap_loading_fail_on_wayland.bugfix
+++ b/doc/newsfragments/fixed_keymap_loading_fail_on_wayland.bugfix
@@ -1,0 +1,1 @@
+Fixed missing keymap configs on wayland as the XKB keymap from Ei was not properly loading. The respective keymap file was not seeked to the start on some systems.

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -56,6 +56,7 @@ void EiKeyState::init_default_keymap()
 void EiKeyState::init(int fd, size_t len)
 {
     auto buffer = std::make_unique<char[]>(len + 1);
+    lseek(fd, 0, SEEK_SET);
     auto sz = read(fd, buffer.get(), len);
 
     if ((size_t)sz < len) {


### PR DESCRIPTION
On some systems, the keymap file provided by Ei required to create the XKB context is not properly seeked to the start.
This will cause reading the file to fail (or, more accurately, just cause 0 bytes to be read), causing the keymap to just default to a US-keymap.
This PR fixes this, causing the correct keymap to be loaded.

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
