### PR TITLE
input-capture: Fix disabled call

### DIFF
--- a/doc/newsfragments/input-capture_fix_disabled_call.bugfix
+++ b/doc/newsfragments/input-capture_fix_disabled_call.bugfix
@@ -1,0 +1,1 @@
+Fixed input capture Disabled signal, Enable method is now properly called after Disable.

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -261,7 +261,7 @@ void PortalInputCapture::release(double x, double y)
     is_active_ = false;
 }
 
-void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session)
+void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session, GVariant* options)
 {
     LOG_DEBUG("PortalInputCapture::cb_disabled");
 

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -46,7 +46,7 @@ private:
     void cb_init_input_capture_session(GObject* object, GAsyncResult *res);
     void cb_set_pointer_barriers(GObject* object, GAsyncResult *res);
     void cb_session_closed(XdpSession *session);
-    void cb_disabled(XdpInputCaptureSession* session);
+    void cb_disabled(XdpInputCaptureSession* session, GVariant* option);
     void cb_activated(XdpInputCaptureSession* session, std::uint32_t activation_id,
                       GVariant* options);
     void cb_deactivated(XdpInputCaptureSession* session, std::uint32_t activation_id,
@@ -58,9 +58,9 @@ private:
     {
         reinterpret_cast<PortalInputCapture*>(data)->cb_session_closed(session);
     }
-    static void cb_disabled_cb(XdpInputCaptureSession *session, gpointer data)
+    static void cb_disabled_cb(XdpInputCaptureSession *session, GVariant* options, gpointer data)
     {
-        reinterpret_cast<PortalInputCapture*>(data)->cb_disabled(session);
+        reinterpret_cast<PortalInputCapture*>(data)->cb_disabled(session, options);
     }
     static void cb_activated_cb(XdpInputCaptureSession* session, std::uint32_t activation_id,
                                 GVariant* options, gpointer data)


### PR DESCRIPTION
The options argument was missing so the argument data wasn't the right one and the method cb_disabled was actually called on a GVariant* instead on a PortalInputCapture*

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)

