### PR TITLE
ei: reset w h x y when calculating screen size

### DIFF
--- a/doc/newsfragments/fixed_ei_screen_shape.bugfix
+++ b/doc/newsfragments/fixed_ei_screen_shape.bugfix
@@ -1,0 +1,1 @@
+EI screen shape is now properly reset on update, shape x and y are not bound to 0 0 anymore.

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -423,7 +423,10 @@ bool EiScreen::isPrimary() const
 
 void EiScreen::update_shape()
 {
-
+    w_ = 1;
+    h_ = 1;
+    x_ = std::numeric_limits<uint32_t>::max();
+    y_ = std::numeric_limits<uint32_t>::max();
     for (auto it = ei_devices_.begin(); it != ei_devices_.end(); it++) {
         auto idx = 0;
         struct ei_region *r;


### PR DESCRIPTION
These values were not reset each time the screen shape was update, so if the screen shrink the values will be invalid and lead to borders not triggered.
Also x and y need to be initialised at they maximum values or else they will be always 0 since only min are called on them in the calculation processs.

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
