### PR TITLE
remove win32 snapshot key legacy behavior

### DIFF
--- a/doc/newsfragments/win32_snapshot_key_legacy_behaviour.bugfix
+++ b/doc/newsfragments/win32_snapshot_key_legacy_behaviour.bugfix
@@ -1,0 +1,2 @@
+Remove check requiring the Alt modifier for non-extended VK_SNAPSHOT scancode in Win32.
+Check is irrelevant for modern keyboards, and breaks Print Screen functionality.

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -1186,10 +1186,6 @@ MSWindowsKeyState::getKeyMap(inputleap::KeyMap& keyMap)
 
 					case VK_SNAPSHOT:
 						item.m_sensitive |= KeyModifierAlt;
-						if ((i & 0x100u) == 0) {
-							// non-extended snapshot key requires alt
-							item.m_required |= KeyModifierAlt;
-						}
 						break;
 					}
 					addKeyEntry(keyMap, item);


### PR DESCRIPTION
## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
