### PR TITLE
fix(gui): Adjust KeySequence.cpp for Qt > 6.9 change

### DIFF
--- a/src/gui/src/KeySequence.cpp
+++ b/src/gui/src/KeySequence.cpp
@@ -237,8 +237,11 @@ QString KeySequence::keyToString(int key)
 
     // representable in ucs2?
     if (key < 0x10000)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        return QString("\\u%1").arg((uint16_t) QChar(key).toLower().unicode(), 4, 16, QChar('0'));
+#else
         return QString("\\u%1").arg(QChar(key).toLower().unicode(), 4, 16, QChar('0'));
-
+#endif
     // give up, InputLeap probably won't handle this
     return "";
 }


### PR DESCRIPTION
Based off these comments on #2231.

- https://github.com/input-leap/input-leap/pull/2231#issuecomment-2823052026
- https://github.com/input-leap/input-leap/pull/2231#issuecomment-2824062717

And this patch: https://gist.github.com/sid-code/9131300ee943af1ce5958ee40e527b93

Closes: #2231.
Closes: #2221.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
