### PR TITLE
Fix missing size_t include in XKBUtil.cpp for stricter compilers

### DIFF
--- a/src/lib/platform/XKBUtil.cpp
+++ b/src/lib/platform/XKBUtil.cpp
@@ -20,6 +20,8 @@
 
 #include "inputleap/key_types.h"
 
+#include <cstddef>
+
 #define XK_APL
 #define XK_ARABIC
 #define XK_ARMENIAN


### PR DESCRIPTION
The raspberry pi has a stricter compiler, this is needed in order to build on it. 