### PR TITLE
Added prevalent known issue to FAQ section on Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,5 +151,6 @@ __Q: Is it possible to use Input Leap on Mac OS X / OS X versions prior to 10.12
 >    - Input Leap currently has limited UTF-8 support; issues have been reported with processing various languages.
 >      - *(see [#860](https://github.com/input-leap/input-leap/issues/860))*
 >    - Clipboard sharing is not currently supported on Linux/Wayland.
+>    - AltGr key combinations when Server is linux and client is Windows don't usually work out of the box. See [#100](https://github.com/input-leap/input-leap/issues/100) for a workaround
 >
 > The complete list of open issues can be found in the ['Issues' tab on GitHub](https://github.com/input-leap/input-leap/issues?q=is%3Aissue+is%3Aopen). Help is always appreciated.


### PR DESCRIPTION
Adds a disclaimer about AltGr key combinations when the server is Linux and the client is Windows, noting that they might not work out of the box. Refers to issue #100 for a workaround.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
