### PR TITLE
Drop text part from InnoSetup version string

### DIFF
--- a/dist/inno/input-leap.iss.in
+++ b/dist/inno/input-leap.iss.in
@@ -1,5 +1,5 @@
 #define MyAppName "InputLeap"
-#define MyAppVersion "@INPUTLEAP_VERSION_MAJOR@.@INPUTLEAP_VERSION_MINOR@.@INPUTLEAP_VERSION_PATCH@.@INPUTLEAP_VERSION_DESC@"
+#define MyAppVersion "@INPUTLEAP_VERSION_MAJOR@.@INPUTLEAP_VERSION_MINOR@.@INPUTLEAP_VERSION_PATCH@"
 #define MyAppTextVersion "@INPUTLEAP_VERSION@"
 #define MyAppPublisher "InputLeap contributors"
 #define MyAppURL "https://github.com/input-leap/input-leap/wiki"

--- a/doc/newsfragments/fix_win_release_builds.bugfix
+++ b/doc/newsfragments/fix_win_release_builds.bugfix
@@ -1,0 +1,1 @@
+Fix Windows release builds by making installer “product version” numerical only.


### PR DESCRIPTION
Removed text (“git” / “release” / etc) from the inno product version string, as only numbers are supported. Fixes the Windows release builds if you ever want to build some.

## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
