### PR TITLE
fix(wayland): release portal input capture when EI_EVENT_DISCONNECT is encountered, refactoring

### DIFF
--- a/doc/newsfragments/fix_server_input_stuck_when_inputcapture_reconnect.bugfix
+++ b/doc/newsfragments/fix_server_input_stuck_when_inputcapture_reconnect.bugfix
@@ -1,0 +1,1 @@
+Fix InputLeap server inputs stuck when EIS reconnect to client after invalid EIS protocol.


### PR DESCRIPTION
See deskflow issue #8005.
Closes #2287

## Contributor Checklist:

* [x] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [ ] This change does not affect end users
