### PR TITLE
gui: Fix usage of deprecated QCheckBox::stateChanged

### DIFF
--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -64,7 +64,13 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     ui_->m_pComboElevate->hide();
 #endif
 
-    connect(ui_->m_pCheckBoxLogToFile, &QCheckBox::stateChanged, this, &SettingsDialog::logToFileChanged);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    connect(ui_->m_pCheckBoxLogToFile, &QCheckBox::checkStateChanged, this,
+            [this](Qt::CheckState state) { logToFileChanged(state == Qt::Checked); });
+#else
+    connect(ui_->m_pCheckBoxLogToFile, &QCheckBox::stateChanged, this,
+            [this](int state) { logToFileChanged(state == 2); });
+#endif
     connect(ui_->m_pButtonBrowseLog, &QPushButton::clicked, this, &SettingsDialog::browseLogClicked);
     connect(ui_->m_pComboLanguage, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::languageChanged);
 }
@@ -120,9 +126,8 @@ void SettingsDialog::changeEvent(QEvent* event)
     }
 }
 
-void SettingsDialog::logToFileChanged(int i)
+void SettingsDialog::logToFileChanged(bool checked)
 {
-    bool checked = i == 2;
 
     ui_->m_pLineEditLogFilename->setEnabled(checked);
     ui_->m_pButtonBrowseLog->setEnabled(checked);

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -47,7 +47,7 @@ class SettingsDialog : public QDialog
 
     private:
         void languageChanged(int index);
-        void logToFileChanged(int i);
+        void logToFileChanged(bool checked);
         void browseLogClicked();
 
         std::unique_ptr<Ui::SettingsDialog> ui_;


### PR DESCRIPTION
## Contributor Checklist:

* [ ] This change affects end users and I have created a file in the `doc/newsfragments` directory (and made sure to read the `README.md` in that directory)
* [x] This change does not affect end users
